### PR TITLE
fix(#33): revert npm install on multi-container-arch to resolve cd issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,8 +121,8 @@ COPY . /ash/
 # Install CDK Nag stub dependencies
 #
 # Update NPM to latest
-RUN npm install -g npm
-RUN cd /ash/utils/cdk-nag-scan && \
+RUN npm install -g npm && \
+    cd /ash/utils/cdk-nag-scan && \
     npm install --quiet
 
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,8 +120,10 @@ COPY . /ash/
 #
 # Install CDK Nag stub dependencies
 #
+# Update NPM to latest
+RUN npm install -g npm
 RUN cd /ash/utils/cdk-nag-scan && \
-    npm install
+    npm install --quiet
 
 #
 # Flag ASH as local execution mode since we are running in a container already

--- a/helper_dockerfiles/Dockerfile-cdk
+++ b/helper_dockerfiles/Dockerfile-cdk
@@ -15,9 +15,6 @@ RUN mkdir -p /src && \
     mkdir -p /run/scan/src \
     mkdir -p /ash
 
-RUN cd /utils/cdk-nag-scan && \
-    npm install
-
 WORKDIR /src
 
 CMD bash -C /utils/cdk-docker-execute.sh

--- a/utils/cdk-docker-execute.sh
+++ b/utils/cdk-docker-execute.sh
@@ -117,7 +117,7 @@ cd ${CDK_WORK_DIR}
 
 # # Install the CDK application's required packages
 
-# npm install --quiet
+npm install --silent
 
 #
 # Now, for each file, run a cdk synth to subject the file to CDK-NAG scanning


### PR DESCRIPTION
*Issue #, if available:* #33

*Description of changes:*

- Restored `npm install` on `utils/cdk-docker-execute.sh`, also swapped `--quiet` for `--silent`
- Removed `npm install` from `helper_dockerfiles/Dockerfile-cdk` as it runs before utils are mounted in multi-container architecture
- Added `npm install -g npm` to root `Dockerfile` to ensure `npm` is update to latest during single-container build


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
