### PR TITLE
added get-scan-set.py to utils scripts to return a list of non-ignored files for processing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN python3 -m pip install --no-cache-dir \
 # YAML (Checkov, cfn-nag)
 #
 RUN echo "gem: --no-document" >> /etc/gemrc && \
-    python3 -m pip install checkov && \
+    python3 -m pip install checkov pathspec && \
     gem install cfn-nag
 
 #
@@ -120,7 +120,8 @@ RUN mkdir -p /src && \
 # Install CDK Nag stub dependencies
 #
 # Update NPM to latest
-COPY ./utils /ash/utils/
+RUN mkdir -p /ash/utils
+COPY ./utils/cdk-nag-scan /ash/utils/cdk-nag-scan/
 RUN npm install -g npm && \
     cd /ash/utils/cdk-nag-scan && \
     npm install --quiet
@@ -128,6 +129,8 @@ RUN npm install -g npm && \
 #
 # COPY ASH source to /ash instead of / to isolate
 #
+COPY ./utils/cfn-to-cdk /ash/utils/cfn-to-cdk/
+COPY ./utils/*.* /ash/utils/
 COPY ./appsec_cfn_rules /ash/appsec_cfn_rules/
 COPY ./ash-multi /ash/ash
 

--- a/ash
+++ b/ash
@@ -8,7 +8,6 @@ export ASH_IMAGE_NAME=${ASH_IMAGE_NAME:-"automated-security-helper:local"}
 # Set local variables
 SOURCE_DIR=""
 OUTPUT_DIR=""
-OCI_RUNNER=""
 DOCKER_EXTRA_ARGS=""
 ASH_ARGS=""
 NO_BUILD="NO"

--- a/ash-multi
+++ b/ash-multi
@@ -292,7 +292,7 @@ run_security_check() {
 
 set -e
 START_TIME=$(date +%s)
-VERSION=("1.2.0-e-06Mar2024")
+VERSION=("1.2.1-e-13Mar2024")
 OCI_RUNNER="docker"
 
 # Overrides default OCI Runner used by ASH
@@ -303,8 +303,8 @@ GIT_EXTENSIONS=("git")
 PY_EXTENSIONS=("py" "pyc" "ipynb")
 INFRA_EXTENSIONS=("yaml" "yml" "tf" "json" "dockerfile")
 CFN_EXTENSIONS=("yaml" "yml" "json" "template")
-JS_EXTENSIONS=("js")
-GRYPE_EXTENSIONS=("js" "py" "java" "go" "cs" "sh")
+JS_EXTENSIONS=("js" "jsx" "ts" "tsx")
+GRYPE_EXTENSIONS=("js" "jsx" "ts" "tsx" "py" "java" "go" "cs" "sh")
 
 DOCKERFILE_LOCATION="$(dirname "${BASH_SOURCE[0]}")"/"helper_dockerfiles"
 UTILS_LOCATION="$(dirname "${BASH_SOURCE[0]}")"/"utils"
@@ -446,11 +446,22 @@ echo -e "\n${LPURPLE}ASH version ${GREEN}$VERSION${NC}\n"
 
 # nosemgrep
 IFS=$'\n' # Support directories with spaces, make the loop iterate over newline instead of space
+zip_files_to_extract=$(python "${_ASH_UTILS_LOCATION}/get-scan-set.py" ${SOURCE_DIR} | grep '\.zip$')
 # Extract all zip files to temp dir *within $OUTPUT_DIR* before scanning
-for zipfile in $(find "${SOURCE_DIR}" -iname "*.zip");
-do
-  unzip ${QUIET_OUTPUT} -d "${OUTPUT_DIR}"/work/$(basename "${zipfile%.*}") $zipfile
+echo "Extracting zip files to temporary work dir before scanning..."
+echo "${zip_files_to_extract}"
+echo ""
+for zipfile in $zip_files_to_extract; do
+  [[ "${zipfile}" == "/"* ]] && zipfile="${zipfile:1}"
+  tgt_extract_dir="${OUTPUT_DIR}"/work/${zipfile%.*}
+  mkdir -p "${tgt_extract_dir}"
+  echo "Unzipping: '/${zipfile}' to '${tgt_extract_dir}'"
+  unzip ${QUIET_OUTPUT} -o -d "${tgt_extract_dir}" "/${zipfile%.*}"
 done
+# for zipfile in $(find "${SOURCE_DIR}" -iname "*.zip");
+# do
+#   unzip ${QUIET_OUTPUT} -d "${OUTPUT_DIR}"/work/$(basename "${zipfile%.*}") $zipfile
+# done
 
 unset IFS
 
@@ -603,7 +614,9 @@ then
   done
 
   # Cleanup work directory containing all temp files
-  rm -rf "${OUTPUT_DIR}"/work
+  if [ -d "${OUTPUT_DIR}/work" ]; then
+    rm -rf "${OUTPUT_DIR}/work"
+  fi
 
   RESOLVED_OUTPUT_DIR=${ACTUAL_OUTPUT_DIR:-${OUTPUT_DIR}}
   echo -e "${GREEN}\nYour final report can be found here:${NC} ${RESOLVED_OUTPUT_DIR}/${AGGREGATED_RESULTS_REPORT_FILENAME}"

--- a/ash-multi
+++ b/ash-multi
@@ -596,7 +596,9 @@ for pid in "${JOBS[@]}"; do
 done
 
 # Cleanup any previous file
-rm -f "${OUTPUT_DIR}"/"${AGGREGATED_RESULTS_REPORT_FILENAME}"
+if [[ -n "${AGGREGATED_RESULTS_REPORT_FILENAME}" && -n "${OUTPUT_DIR}" ]]
+  rm -f "${OUTPUT_DIR}"/"${AGGREGATED_RESULTS_REPORT_FILENAME}"
+fi
 
 # if an extension was not found, no report file will be in place, so skip the final report
 if [[ $(find "${OUTPUT_DIR}/work" -iname "*_report_result.txt" | wc -l | awk '{print $1}') -gt 0 ]];
@@ -614,7 +616,7 @@ then
   done
 
   # Cleanup work directory containing all temp files
-  if [ -d "${OUTPUT_DIR}/work" ]; then
+  if [[ -n "${OUTPUT_DIR}" && -d "${OUTPUT_DIR}/work" ]]; then
     rm -rf "${OUTPUT_DIR}/work"
   fi
 

--- a/utils/cdk-docker-execute.sh
+++ b/utils/cdk-docker-execute.sh
@@ -161,7 +161,9 @@ unset IFS
 #
 # Clean up the CDK application temporary working folder
 #
-rm -rf ${CDK_WORK_DIR}
+if [ -d "${CDK_WORK_DIR}" ]; then
+  rm -rf "${CDK_WORK_DIR}"
+fi
 
 # cd back to the original folder in case path changed during scan
 cd ${_CURRENT_DIR}

--- a/utils/cdk-docker-execute.sh
+++ b/utils/cdk-docker-execute.sh
@@ -79,7 +79,7 @@ cd ${_ASH_OUTPUT_DIR}
 #
 DIRECTORY="ash_cf2cdk_output"
 # Check if this directory already exist from previous ASH run
-if [ -d "${_ASH_OUTPUT_DIR}/$DIRECTORY" ]; then
+if [[ -n "${_ASH_OUTPUT_DIR}" && -n "${DIRECTORY}" && -d "${_ASH_OUTPUT_DIR}/$DIRECTORY" ]]; then
   # Delete this directory and its files and recreate it.
   rm -rf "${_ASH_OUTPUT_DIR}/$DIRECTORY"
 fi
@@ -161,7 +161,7 @@ unset IFS
 #
 # Clean up the CDK application temporary working folder
 #
-if [ -d "${CDK_WORK_DIR}" ]; then
+if [ -n "${CDK_WORK_DIR}" && -d "${CDK_WORK_DIR}" ]; then
   rm -rf "${CDK_WORK_DIR}"
 fi
 

--- a/utils/get-scan-set.py
+++ b/utils/get-scan-set.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import sys
+from typing import List
+from pathspec import PathSpec
+import argparse
+import os
+
+def get_files_not_matching_gitignore(
+    path,
+    ignorefiles: List[str] = []
+):
+    # collect all lines from f"{path}/.gitignore" and any extra ignorefiles passed in
+    # function call
+    all_ignores = list(set([
+        f"{path}/.gitignore",
+        *[
+            f"{path}/{file}"
+            for file in ignorefiles
+        ]
+    ]))
+    lines = ['.git']
+    full = []
+    included = []
+    for ignorefile in all_ignores:
+        with open(ignorefile) as f:
+            lines.extend(f.readlines())
+    lines = [ line.strip() for line in lines ]
+    spec = PathSpec.from_lines('gitwildmatch', lines)
+    for item in os.walk(path):
+        for file in item[2]:
+            full.append(os.path.join(item[0], file))
+            if not spec.match_file(os.path.join(item[0], file)):
+                inc_full = os.path.join(item[0], file)
+                # print(f"Including: {inc_full}", file=sys.stderr)
+                included.append(inc_full)
+    included = sorted(set(included))
+    return included
+
+if __name__ == "__main__":
+    # set up argparse
+    parser = argparse.ArgumentParser(description="Get list of files not matching .gitignore underneath SourceDir arg path")
+    parser.add_argument("path", help="path to scan", default=os.getcwd(), type=str, nargs='?')
+    parser.add_argument("--ignorefile", help="ignore file to use", default=[], type=str, nargs='*')
+    args = parser.parse_args()
+
+    files = get_files_not_matching_gitignore(args.path, args.ignorefile)
+    for file in files:
+        # print(f"Returning: {file}", file=sys.stderr)
+        print(file, file=sys.stdout)


### PR DESCRIPTION
*Issue #, if available:*
- #44 
- #46 
- #36

*Description of changes:*
- #44 - Adds new `get-scan-set.py` python script that allows extensible ignore lists to be provided (vs just using .gitignore). Does not require Git installed, uses Pathspec only in Python. **Uses this script to gather the list of non-ignored files to determine which zip files should be extracted.**
- #46 - Adds the additional extensions under JS_EXTENSIONS and GRYPE_EXTENSIONS known extension lists
- #36 - Guards `rm` calls with path evaluation 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
