### PR TITLE
fix/codebuild shared bindmount issue

### DIFF
--- a/ash
+++ b/ash
@@ -116,8 +116,8 @@ else
         -e ACTUAL_SOURCE_DIR=${SOURCE_DIR} \
         -e ACTUAL_OUTPUT_DIR=${OUTPUT_DIR} \
         -e ASH_DEBUG=${DEBUG} \
-        --mount type=bind,source="${SOURCE_DIR}",destination=/src,readonly,bind-propagation=shared \
-        --mount type=bind,source="${OUTPUT_DIR}",destination=/out,bind-propagation=shared \
+        --mount type=bind,source="${SOURCE_DIR}",destination=/src,readonly \
+        --mount type=bind,source="${OUTPUT_DIR}",destination=/out \
         --tmpfs /run/scan/src:rw,noexec,nosuid ${ASH_IMAGE_NAME} \
           ash \
             --source-dir /src  \

--- a/ash-multi
+++ b/ash-multi
@@ -283,7 +283,7 @@ run_security_check() {
 
 set -e
 START_TIME=$(date +%s)
-VERSION=("1.2.3-e-15Mar2024")
+VERSION=("1.2.4-e-26Mar2024")
 OCI_RUNNER="docker"
 
 # Overrides default OCI Runner used by ASH


### PR DESCRIPTION
- removed shared bindmount in response to regressions reported impacting CodeBuild runs of ASH
- removed shared bindmount in response to regressions reported impacting CodeBuild runs of ASH
