### PR TITLE
fix error in reflecting return code in ash script

### DIFF
--- a/ash
+++ b/ash
@@ -109,6 +109,7 @@ else
     fi
 
     # Run the image if the --no-run flag is not set
+    RC=0
     if [ "${NO_RUN}" = "NO" ]; then
       echo "Running ASH scan using built image..."
       ${RESOLVED_OCI_RUNNER} run \
@@ -123,8 +124,10 @@ else
             --source-dir /src  \
             --output-dir /out  \
             $ASH_ARGS
+      RC=$?
     fi
     if [[ "${DEBUG}" = "YES" ]]; then
       set +x
     fi
+    exit ${RC}
 fi


### PR DESCRIPTION
Separately submitted report - no issue number

*Description of changes:*
- updated `ash` script to catch and return the return code from invoking the container.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
