### PR TITLE
fix(cdk-nag-scan): copy output files to separate folders

### DIFF
--- a/utils/cdk-docker-execute.sh
+++ b/utils/cdk-docker-execute.sh
@@ -147,11 +147,12 @@ if [ "${#cfn_files[@]}" -gt 0 ]; then
     #
 
     RC=$(bumprc $RC $CRC)
+    
+    cp ${CDK_WORK_DIR}/cdk.out/*.template.json ${_ASH_OUTPUT_DIR}/${DIRECTORY}/${cfn_filename}_cdk_nag_results/
+    rm ${CDK_WORK_DIR}/cdk.out/*.template.json
+    cp ${CDK_WORK_DIR}/cdk.out/AwsSolutions-*-NagReport.csv ${_ASH_OUTPUT_DIR}/${DIRECTORY}/${cfn_filename}_cdk_nag_results/
+    rm ${CDK_WORK_DIR}/cdk.out/AwsSolutions-*-NagReport.csv
   done
-  cp ${CDK_WORK_DIR}/cdk.out/*.template.json ${_ASH_OUTPUT_DIR}/${DIRECTORY}/${cfn_filename}_cdk_nag_results/
-  rm ${CDK_WORK_DIR}/cdk.out/*.template.json
-  cp ${CDK_WORK_DIR}/cdk.out/AwsSolutions-*-NagReport.csv ${_ASH_OUTPUT_DIR}/${DIRECTORY}/${cfn_filename}_cdk_nag_results/
-  rm ${CDK_WORK_DIR}/cdk.out/AwsSolutions-*-NagReport.csv
 else
   echo "found ${#cfn_files[@]} files to scan.  Skipping scans." >> ${REPORT_PATH}
 fi


### PR DESCRIPTION
*Issue #, if available:* 68

*Description of changes:* Updated `cdk-docker-execute.sh` to copy template/nag files on every iteration through the loop, copying to separate folders for each file scanned.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
