### PR TITLE
fix(ash): set execute permission on ash script in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,6 +135,11 @@ COPY ./ash-multi /ash/ash
 COPY ./__version__ /ash/__version__
 
 #
+# Make sure the ash script is executable
+#
+RUN chmod +x /ash/ash
+
+#
 # Flag ASH as local execution mode since we are running in a container already
 #
 ENV _ASH_EXEC_MODE="local"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Updated the `Dockerfile` to set the permissions on the `ash` script that is copied into the container image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
