### PR TITLE
fix(docs): #comment updated docs triggers

### DIFF
--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -2,17 +2,11 @@ name: Build and Deploy Documentation
 
 on:
   pull_request:
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "requirements.txt"
+    branches:
+      - main
   push:
     branches:
-      - "*"
-    paths:
-      - "docs/**"
-      - "mkdocs.yml"
-      - "requirements.txt"
+      - main
 
 env:
   PYTHON_VERSION: "3.12"


### PR DESCRIPTION
This PR updated the pipeline triggers for the MkDocs docsite to ensure it is published on merge/push to `main`