### PR TITLE
feat: #comment removed build/deploy interdependency for doc pipeline

### DIFF
--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -14,6 +14,7 @@ env:
 jobs:
   build:
     name: Build documentation
+    needs: []
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
 
@@ -34,7 +35,7 @@ jobs:
 
   deploy:
     name: Deploy documentation
-    needs: build
+    needs: []
     runs-on: ubuntu-latest
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
 


### PR DESCRIPTION
Removes dependency between build and deploy jobs in doc pipeline (build is only running during non-main-branch builds, deploy only runs on main-branch builds)