### PR TITLE
fix: mkdocs deployment issue

### DIFF
--- a/.github/workflows/docs-build-and-deploy.yml
+++ b/.github/workflows/docs-build-and-deploy.yml
@@ -52,4 +52,4 @@ jobs:
         run: pip install -r requirements.txt
 
       - name: Deploy documentation
-        run: mkdocs gh-deploy --clean
+        run: mkdocs gh-deploy --clean --force


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/mkdocs/mkdocs/issues/2370

*Description of changes:*

- Fixed mkdocs commit sync issue by forcing the push to the `gh-pages` branch. Does not affect any code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
