### PR TITLE
fix: scan error result

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -71,7 +71,40 @@
       "name": "Debug Tests",
       "request": "launch",
       "type": "debugpy"
-    }
+    },
+    {
+      "args": [
+        "--verbose",
+        "--scanners",
+        "snyk-code,bandit",
+        "--config-overrides",
+        "ash_plugin_modules+=[\"automated_security_helper.plugin_modules.ash_snyk_plugins\"]"
+      ],
+      "console": "internalConsole",
+      "env": {
+        "PATH": "${workspaceFolder}/.venv/bin:/opt/homebrew/bin:~/.local/share/mise/installs/node/20.19.0/bin:${env.PATH}",
+        "COLUMNS": "160",
+      },
+      "name": "ASH: Test Snyk",
+      "program": "./automated_security_helper/cli/main.py",
+      "request": "launch",
+      "type": "debugpy"
+    },
+    {
+      "args": [
+        "--debug",
+        "--mode=precommit",
+      ],
+      "console": "internalConsole",
+      "env": {
+        "PATH": "${workspaceFolder}/.venv/bin:/opt/homebrew/bin:~/.local/share/mise/installs/node/20.19.0/bin:${env.PATH}",
+        "COLUMNS": "160",
+      },
+      "name": "ASH: Test pre-commit",
+      "program": "./automated_security_helper/cli/main.py",
+      "request": "launch",
+      "type": "debugpy"
+    },     
   ],
   "version": "0.2.0"
 }

--- a/automated_security_helper/core/metrics_alignment.py
+++ b/automated_security_helper/core/metrics_alignment.py
@@ -165,6 +165,8 @@ def _populate_scanner_results_from_unified_metrics(
             status = ScannerStatus.SKIPPED
         elif metrics.status == "MISSING":
             status = ScannerStatus.MISSING
+        elif metrics.status == "ERROR":
+            status = ScannerStatus.ERROR
         else:
             status = ScannerStatus.PASSED  # Default fallback
 

--- a/automated_security_helper/core/metrics_table.py
+++ b/automated_security_helper/core/metrics_table.py
@@ -106,6 +106,8 @@ def generate_metrics_table_from_unified_data(
                 status_text = Text("PASSED", style="green bold")
             elif metrics.status == "FAILED":
                 status_text = Text("FAILED", style="red bold")
+            elif metrics.status == "ERROR":
+                status_text = Text("ERROR", style="red bold")
             elif metrics.status == "SKIPPED":
                 status_text = Text("SKIPPED", style="blue bold")
             elif metrics.status == "MISSING":
@@ -118,6 +120,8 @@ def generate_metrics_table_from_unified_data(
                 status_text = "[bold green]PASSED[/bold green]"
             elif metrics.status == "FAILED":
                 status_text = "[bold red]FAILED[/bold red]"
+            elif metrics.status == "ERROR":
+                status_text = "[bold red]ERROR[/bold red]"
             elif metrics.status == "SKIPPED":
                 status_text = "[bold blue]SKIPPED[/bold blue]"
             elif metrics.status == "MISSING":
@@ -211,6 +215,7 @@ def display_metrics_table(
             "  - [bold red]FAILED[/bold red] = Findings at or above threshold\n"
             "  - [bold yellow]MISSING[/bold yellow] = Required dependencies not available\n"
             "  - [bold blue]SKIPPED[/bold blue] = Scanner explicitly disabled\n"
+            "  - [bold red]ERROR[/bold red] = Scanner execution errorn"
             "- [bold]*Threshold (Thresh)*[/bold]: The minimum severity level that will cause a scanner to fail\n"
             "  - Thresholds: ALL, LOW, MEDIUM, HIGH, CRITICAL\n"
             "  - Source: (g)lobal, (c)onfig, (s)canner\n"

--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -652,8 +652,25 @@ class ScannerStatisticsCalculator:
             elif hasattr(scanner_status_info, "dependencies_missing"):
                 # New ScannerMetrics structure
                 dependencies_missing = scanner_status_info.dependencies_missing
+        elif (
+            scanner_name in asharp_model.additional_reports
+            and "source" in asharp_model.additional_reports[scanner_name]
+            and asharp_model.additional_reports[scanner_name]["source"]["scanner_name"]
+            and asharp_model.additional_reports[scanner_name]["source"]["status"]
+        ):
+            # If the scanner is not found in the dictionary, check for errors
+            status = asharp_model.additional_reports[scanner_name]["source"]["status"]
+            if status == "SKIPPED":
+                excluded = True
+            elif status == "MISSING":
+                dependencies_missing = True
+            elif status == "ERROR":
+                error = True
+            elif status != "PASSED":
+                # For any other status, treat as excluded for backward compatibility
+                excluded = True
         else:
-            # If the scanner is not found in the dictionary, return (True, True)
+            # If the scanner is not found in the dictionary, check for errors
             error = True
 
         return excluded, dependencies_missing, error

--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -152,7 +152,7 @@ class ScannerStatisticsCalculator:
                 )
             )
 
-            excluded, dependencies_missing, _ = (
+            excluded, dependencies_missing, error = (
                 ScannerStatisticsCalculator.get_scanner_status_info(
                     asharp_model, scanner_name
                 )
@@ -244,6 +244,7 @@ class ScannerStatisticsCalculator:
                 "threshold_source": threshold_source,
                 "excluded": excluded,
                 "dependencies_missing": dependencies_missing,
+                "error": error,
             }
 
         return scanner_stats
@@ -618,11 +619,11 @@ class ScannerStatisticsCalculator:
             Tuple of (excluded, dependencies_missing), where:
             - excluded: True if the scanner was explicitly excluded from the scan
             - dependencies_missing: True if the scanner has missing dependencies
-            - failed: True if the scanner failed to generate results or failed
+            - error: True if the scanner failed to run or generate results
         """
         excluded = False
         dependencies_missing = False
-        failed = False
+        error = False
         if (
             scanner_name in asharp_model.additional_reports
             and "None" in asharp_model.additional_reports[scanner_name]
@@ -655,9 +656,9 @@ class ScannerStatisticsCalculator:
                 dependencies_missing = scanner_status_info.dependencies_missing
         else:
             # If the scanner is not found in the dictionary, return (True, True)
-            failed = True
+            error = True
 
-        return excluded, dependencies_missing, failed
+        return excluded, dependencies_missing, error
 
     @staticmethod
     def get_scanner_status(
@@ -684,13 +685,13 @@ class ScannerStatisticsCalculator:
         Returns:
             Status string: "PASSED", "FAILED", "SKIPPED", or "MISSING"
         """
-        excluded, dependencies_missing, failed = (
+        excluded, dependencies_missing, error = (
             ScannerStatisticsCalculator.get_scanner_status_info(
                 asharp_model, scanner_name
             )
         )
 
-        if failed:
+        if error:
             return "ERROR"
 
         if excluded:

--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -630,17 +630,15 @@ class ScannerStatisticsCalculator:
             and asharp_model.additional_reports[scanner_name]["None"]["scanner_name"]
             == scanner_name
         ):
-            if (
-                asharp_model.additional_reports[scanner_name]["None"]["status"]
-                == "SKIPPED"
-            ):
+            status = asharp_model.additional_reports[scanner_name]["None"]["status"]
+            if status == "SKIPPED":
                 excluded = True
-            elif (
-                asharp_model.additional_reports[scanner_name]["None"]["status"]
-                == "MISSING"
-            ):
+            elif status == "MISSING":
                 dependencies_missing = True
+            elif status == "ERROR":
+                error = True
             else:
+                # For any other status, treat as excluded for backward compatibility
                 excluded = True
         elif scanner_name in asharp_model.scanner_results:
             scanner_status_info = asharp_model.scanner_results[scanner_name]

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -34,7 +34,6 @@ from pydantic import BaseModel
 
 from automated_security_helper.models.asharp_model import (
     AshAggregatedResults,
-    ScannerTargetStatusInfo,
 )
 from automated_security_helper.core.scanner_statistics_calculator import (
     ScannerStatisticsCalculator,
@@ -170,20 +169,9 @@ def get_unified_scanner_metrics(
     # Convert the statistics to ScannerMetrics objects
     for scanner_name, stats in scanner_stats.items():
         # Determine status text (same as status for now)
-        if stats["excluded"]:
-            status = "SKIPPED"
-        elif stats["dependencies_missing"]:
-            status = "MISSING"
-        elif stats["actionable"] > 0:
-            status = "FAILED"
-        else:
-            scan_result: ScannerTargetStatusInfo | None = (
-                asharp_model.scanner_results.get(scanner_name, None)
-            )
-            status = (
-                scan_result.status if scan_result and scan_result.status else "PASSED"
-            )
-        status_text = status
+        status = ScannerStatisticsCalculator.get_scanner_status(
+            asharp_model=asharp_model, scanner_name=scanner_name
+        )
 
         # Determine if the scanner passed
         passed = status in ["PASSED", "SKIPPED", "MISSING"]
@@ -201,7 +189,7 @@ def get_unified_scanner_metrics(
             actionable=stats["actionable"],
             duration=stats["duration"],
             status=status,
-            status_text=status_text,
+            status_text=status,  # Same as the status for now
             threshold=stats["threshold"],
             threshold_source=stats["threshold_source"],
             excluded=stats["excluded"],

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -34,6 +34,7 @@ from pydantic import BaseModel
 
 from automated_security_helper.models.asharp_model import (
     AshAggregatedResults,
+    ScannerTargetStatusInfo,
 )
 from automated_security_helper.core.scanner_statistics_calculator import (
     ScannerStatisticsCalculator,
@@ -169,9 +170,22 @@ def get_unified_scanner_metrics(
     # Convert the statistics to ScannerMetrics objects
     for scanner_name, stats in scanner_stats.items():
         # Determine status text (same as status for now)
-        status = ScannerStatisticsCalculator.get_scanner_status(
-            asharp_model=asharp_model, scanner_name=scanner_name
-        )
+        if stats["excluded"]:
+            status = "SKIPPED"
+        elif stats["dependencies_missing"]:
+            status = "MISSING"
+        elif stats["error"]:
+            status = "ERROR"
+        elif stats["actionable"] > 0:
+            status = "FAILED"
+        else:
+            scan_result: ScannerTargetStatusInfo | None = (
+                asharp_model.scanner_results.get(scanner_name, None)
+            )
+            status = (
+                scan_result.status if scan_result and scan_result.status else "PASSED"
+            )
+        status_text = status
 
         # Determine if the scanner passed
         passed = status in ["PASSED", "SKIPPED", "MISSING"]
@@ -189,7 +203,7 @@ def get_unified_scanner_metrics(
             actionable=stats["actionable"],
             duration=stats["duration"],
             status=status,
-            status_text=status,  # Same as the status for now
+            status_text=status_text,  # Same as the status for now
             threshold=stats["threshold"],
             threshold_source=stats["threshold_source"],
             excluded=stats["excluded"],

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
@@ -106,6 +106,7 @@ class HtmlReporter(ReporterPluginBase[HTMLReporterConfig]):
         .severity-none {{ color: #28a745; }}
         .status-passed {{ color: #28a745; font-weight: bold; }}
         .status-failed {{ color: #dc3545; font-weight: bold; }}
+        .status-error {{ color: #dc3545; font-weight: bold; }}
         .status-skipped {{ color: #6c757d; font-weight: bold; }}
         .status-missing {{ color: #fd7e14; font-weight: bold; }}
         table {{
@@ -181,6 +182,7 @@ class HtmlReporter(ReporterPluginBase[HTMLReporterConfig]):
                         <li class="status-failed">FAILED = Findings at or above threshold</li>
                         <li class="status-missing">MISSING = Required dependencies not available</li>
                         <li class="status-skipped">SKIPPED = Scanner explicitly disabled</li>
+                        <li class="status-error">ERROR = Scanner execution error</li>
                     </ul>
                 </li>
                 <li><strong>Threshold:</strong> The minimum severity level that will cause a scanner to fail</li>

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -125,6 +125,7 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
             md_parts.append("  - **FAILED** = Findings at or above threshold")
             md_parts.append("  - **MISSING** = Required dependencies not available")
             md_parts.append("  - **SKIPPED** = Scanner explicitly disabled")
+            md_parts.append("  - **ERROR** = Scanner execution error")
             md_parts.append(
                 "- **Threshold**: The minimum severity level that will cause a scanner to fail"
             )
@@ -172,6 +173,8 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
                     status_text = "MISSING"
                 elif status == "SKIPPED":
                     status_text = "SKIPPED"
+                elif status == "ERROR":
+                    status_text = "ERROR"
                 else:
                     status_text = status
 

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/text_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/text_reporter.py
@@ -114,6 +114,7 @@ class TextReporter(ReporterPluginBase[TextReporterConfig]):
             text_parts.append("  - FAILED = Findings at or above threshold")
             text_parts.append("  - MISSING = Required dependencies not available")
             text_parts.append("  - SKIPPED = Scanner explicitly disabled")
+            text_parts.append("  - ERROR = Scanner execution error")
             text_parts.append(
                 "- Note: All statistics are calculated from the final aggregated SARIF report"
             )


### PR DESCRIPTION
*Issue #, if available:*
When scanner execution fails, it's reported as PASSED since the number of actionable findings is equal to 0.

*Description of changes:*
Added code to handle Scanner results as error in the reports and internal functions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
