### PR TITLE
updated the bandit secrets reporting logic to mask secret values

### DIFF
--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -77,6 +77,22 @@ global_settings:
     - rule_id: "python.lang.compatibility.python36.python36-compatibility-Popen2"
       path: automated_security_helper/utils/subprocess_utils.py
       reason: "False positive - ASH requires Python 3.10+, compatibility with Python3.6 and less is not required"
+    - rule_id: SECRET-SECRET-KEYWORD
+      path: automated_security_helper/utils/secret_masking.py
+      reason: "False positive - Secret found message string"
+      line_start: 37
+      line_end: 37
+    - rule_id: SECRET-SECRET-KEYWORD
+      path: automated_security_helper/utils/secret_masking.py
+      reason: "False positive - Secret found message string"
+      line_start: 46
+      line_end: 46
+    - rule_id: SECRET-SECRET-KEYWORD
+      path: tests/unit/utils/test_secret_masking.py
+      reason: "False positive - Multiple ocurrences of the keyword due to the nature of the test suite"
+    - rule_id: SECRET-BASE64-HIGH-ENTROPY-STRING
+      path: tests/unit/utils/test_secret_masking.py
+      reason: "False positive - Multiple ocurrences of the keyword due to the nature of the test suite"
   ignore_paths:
     - path: "**/.venv/**"
       reason: Virtual environment, not committed, only 3p content

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 curl -sSfL https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 ```
 
 ```powershell
@@ -99,7 +99,7 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3 $args }
 ```
 
 ### Other Installation Methods
@@ -120,13 +120,13 @@ ash --help
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.2
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.3
 cd automated-security-helper
 pip install .
 ```

--- a/automated_security_helper/models/asharp_model.py
+++ b/automated_security_helper/models/asharp_model.py
@@ -21,6 +21,7 @@ from automated_security_helper.schemas.sarif_schema_model import (
 )
 from automated_security_helper.utils.get_ash_version import get_ash_version
 from automated_security_helper.utils.log import ASH_LOGGER
+from automated_security_helper.utils.secret_masking import mask_secret_in_text
 
 if TYPE_CHECKING:
     from automated_security_helper.config.ash_config import AshConfig
@@ -386,6 +387,10 @@ class AshAggregatedResults(BaseModel):
                             result.message.root, "text"
                         ):
                             description = result.message.root.text
+                    
+                    # Mask secrets in the description based on rule ID
+                    if description and result.ruleId:
+                        description = mask_secret_in_text(description, result.ruleId)
 
                     # Extract location information
                     file_path = None

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
@@ -28,6 +28,7 @@ from automated_security_helper.schemas.sarif_schema_model import (
 )
 from automated_security_helper.utils.get_shortest_name import get_shortest_name
 from automated_security_helper.utils.log import ASH_LOGGER
+from automated_security_helper.utils.sarif_utils import mask_secrets_in_sarif
 
 
 class BanditScannerConfigOptions(ScannerOptionsBase):
@@ -398,6 +399,10 @@ class BanditScanner(ScannerPluginBase[BanditScannerConfig]):
                     ),
                 )
             ]
+            
+            # Mask secrets in the SARIF report before returning
+            sarif_report = mask_secrets_in_sarif(sarif_report)
+            
         except Exception as e:
             ASH_LOGGER.warning(f"Failed to parse Bandit results as SARIF: {str(e)}")
             sarif_report = bandit_results

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -21199,7 +21199,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.0.2"
+                "version": "3.0.3"
               },
               "extensions": [],
               "properties": null

--- a/automated_security_helper/utils/secret_masking.py
+++ b/automated_security_helper/utils/secret_masking.py
@@ -1,0 +1,87 @@
+"""Utility functions for masking secrets in security findings."""
+
+import re
+from typing import Optional
+
+
+def mask_secret_in_text(text: str, rule_id: Optional[str] = None) -> str:
+    """
+    Mask secrets in text based on the rule ID and content patterns.
+    
+    Args:
+        text: The text that may contain secrets
+        rule_id: The rule ID that triggered the finding (e.g., 'B105')
+        
+    Returns:
+        The text with secrets masked
+    """
+    if not text or not rule_id:
+        return text
+    
+    # Handle Bandit B105 (hardcoded password) findings
+    if rule_id == "B105":
+        return _mask_bandit_b105_secret(text)
+    
+    # Add other rule-specific masking as needed
+    # elif rule_id == "B106":  # hardcoded password funcarg
+    #     return _mask_bandit_b106_secret(text)
+    
+    return text
+
+
+def _mask_bandit_b105_secret(text: str) -> str:
+    """
+    Mask secrets in Bandit B105 findings.
+    
+    B105 findings typically have messages like:
+    "Possible hardcoded password: 'actual_secret_value'"
+    
+    Args:
+        text: The finding description text
+        
+    Returns:
+        The text with the secret value masked
+    """
+    # Pattern to match Bandit B105 messages with quoted secrets
+    # Matches: "Possible hardcoded password: 'secret'" or "Possible hardcoded password: \"secret\""
+    pattern = r"(Possible hardcoded password:\s*['\"])([^'\"]+)(['\"])"
+    
+    def mask_replacement(match):
+        prefix = match.group(1)  # "Possible hardcoded password: '"
+        secret = match.group(2)   # The actual secret
+        suffix = match.group(3)   # "'"
+        
+        # Mask the secret while preserving some structure for analysis
+        masked_secret = _mask_secret_value(secret)
+        return f"{prefix}{masked_secret}{suffix}"
+    
+    return re.sub(pattern, mask_replacement, text)
+
+
+def _mask_secret_value(secret: str) -> str:
+    """
+    Mask a secret value while preserving some structure for analysis.
+    
+    Args:
+        secret: The secret value to mask
+        
+    Returns:
+        The masked secret value
+    """
+    if not secret:
+        return secret
+    
+    # For very short secrets (< 4 chars), mask completely
+    if len(secret) < 4:
+        return "*" * len(secret)
+    
+    # For 4-character secrets, show first and last character
+    if len(secret) == 4:
+        return secret[0] + "**" + secret[-1]
+    
+    # For longer secrets, show first 2 and last 2 characters
+    if len(secret) <= 8:
+        return secret[:2] + "*" * (len(secret) - 4) + secret[-2:]
+    
+    # For very long secrets, show first 3 and last 3 characters
+    return secret[:3] + "*" * (len(secret) - 6) + secret[-3:]

--- a/docs/content/docs/advanced-usage.md
+++ b/docs/content/docs/advanced-usage.md
@@ -237,7 +237,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -253,7 +253,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
     - ash --mode local
   artifacts:
     paths:

--- a/docs/content/docs/installation-guide.md
+++ b/docs/content/docs/installation-guide.md
@@ -33,7 +33,7 @@ ASH v3 uses UV's tool isolation system to automatically manage most scanner depe
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 
 # Use as normal
 ash --help
@@ -45,7 +45,7 @@ ash --help
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3 $args }
 
 # Use as normal
 ash --help
@@ -57,7 +57,7 @@ ash --help
 
 ```bash
 # Works on Windows, macOS, and Linux
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Use as normal
 ash --help
@@ -69,7 +69,7 @@ Standard Python package installation:
 
 ```bash
 # Works on Windows, macOS, and Linux
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Use as normal
 ash --help
@@ -81,7 +81,7 @@ For development or if you want to modify ASH:
 
 ```bash
 # Works on Windows, macOS, and Linux
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.2
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.3
 cd automated-security-helper
 pip install .
 
@@ -131,7 +131,7 @@ To upgrade ASH to the latest version:
 ### If installed with `uvx`
 ```bash
 # Your alias will use the latest version when specified
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 ```
 
 ### If installed with `pipx`
@@ -141,7 +141,7 @@ pipx upgrade automated-security-helper
 
 ### If installed with `pip`
 ```bash
-pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ### If installed from repository

--- a/docs/content/docs/migration-guide.md
+++ b/docs/content/docs/migration-guide.md
@@ -48,13 +48,13 @@ export PATH="${PATH}:/path/to/automated-security-helper"
 
 ```bash
 # Option 1: Using uvx (recommended) -- add to shell profile
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 
 # Option 2: Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Option 3: Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ## Tool Management Changes

--- a/docs/content/docs/quick-start-guide.md
+++ b/docs/content/docs/quick-start-guide.md
@@ -25,7 +25,7 @@ Prerequisites: Python 3.10+, [uv](https://docs.astral.sh/uv/getting-started/inst
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 ```
 
 #### Windows PowerShell
@@ -34,7 +34,7 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3 $args }
 ```
 
 ### Option 2: Using pipx
@@ -42,7 +42,7 @@ function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@
 Prerequisites: Python 3.10+, [pipx](https://pipx.pypa.io/stable/installation/)
 
 ```bash
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ### Option 3: Using pip
@@ -50,7 +50,7 @@ pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
 Prerequisites: Python 3.10+
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ## Basic Usage

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -23,13 +23,13 @@ No. ASH is designed to help identify common security issues early in the develop
 You have several options:
 ```bash
 # Using uvx (recommended)
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 
 # Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ### What are the prerequisites for ASH v3?

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -55,7 +55,7 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 
 ```bash
 # Install with pipx (isolated environment)
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Use as normal
 ash --help
@@ -71,23 +71,23 @@ ash --help
 ```bash
 # Linux/macOS
 curl -sSf https://astral.sh/uv/install.sh | sh
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 
 # Windows PowerShell
 irm https://astral.sh/uv/install.ps1 | iex
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3 $args }
 ```
 
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.2
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.3
 cd automated-security-helper
 pip install .
 ```

--- a/docs/content/tutorials/running-ash-in-ci.md
+++ b/docs/content/tutorials/running-ash-in-ci.md
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - name: Run ASH scan
         run: ash --mode container
       - name: Upload scan results
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - name: Run ASH scan
         run: ash --mode local
       - name: Add PR comment
@@ -132,7 +132,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
     - ash --mode local
   artifacts:
     paths:
@@ -150,7 +150,7 @@ ash-scan-container:
     DOCKER_TLS_CERTDIR: "/certs"
   script:
     - apk add --no-cache python3 py3-pip git
-    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
     - ash --mode container
   artifacts:
     paths:
@@ -169,7 +169,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
   build:
     commands:
@@ -190,7 +190,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
   pre_build:
     commands:
@@ -220,7 +220,7 @@ pipeline {
     stages {
         stage('Install ASH') {
             steps {
-                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2'
+                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3'
             }
         }
         stage('Run ASH Scan') {
@@ -251,7 +251,7 @@ pipeline {
         stage('Install ASH') {
             steps {
                 sh 'apk add --no-cache python3 py3-pip git'
-                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2'
+                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3'
             }
         }
         stage('Run ASH Scan') {
@@ -282,7 +282,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - run:
           name: Run ASH scan
           command: ash --mode local
@@ -309,7 +309,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
       - run:
           name: Run ASH scan
           command: ash --mode container

--- a/docs/content/tutorials/running-ash-locally.md
+++ b/docs/content/tutorials/running-ash-locally.md
@@ -13,7 +13,7 @@ ASH v3 can run in multiple modes: `local`, `container`, or `precommit`. This gui
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3"
 
 # Add this alias to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 ```
@@ -26,13 +26,13 @@ python -m pip install --user pipx
 python -m pipx ensurepath
 
 # Install ASH
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ### Option 3: Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 ```
 
 ### Option 4: Clone the Repository (Legacy Method)
@@ -101,7 +101,7 @@ ASH v3 runs natively on Windows with Python 3.10+:
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.2 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.0.3 $args }
 
 # Use as normal
 ash --help

--- a/examples/streamlit_ui/README.md
+++ b/examples/streamlit_ui/README.md
@@ -21,7 +21,7 @@ Install the required dependencies:
 
 ```bash
 # ASH
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.2
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.0.3
 
 # Streamlit
 pip install streamlit
@@ -40,7 +40,7 @@ streamlit run https://raw.githubusercontent.com/awslabs/automated-security-helpe
 #### ...or clone and run from local
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.2
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.0.3
 streamlit run ./automated-security-helper/examples/streamlit_ui/ash_ui.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-security-helper"
-version = "3.0.2"
+version = "3.0.3"
 description = "Automated Security Helper for GitHub Actions"
 requires-python = ">=3.10,<4"
 readme = "README.md"

--- a/tests/unit/utils/test_secret_masking.py
+++ b/tests/unit/utils/test_secret_masking.py
@@ -1,0 +1,101 @@
+"""Tests for secret masking utilities."""
+
+import pytest
+from automated_security_helper.utils.secret_masking import (
+    mask_secret_in_text,
+    _mask_bandit_b105_secret,
+    _mask_secret_value,
+)
+
+
+class TestSecretMasking:
+    """Test cases for secret masking functionality."""
+
+    def test_mask_secret_value_short(self):
+        """Test masking of short secrets."""
+        assert _mask_secret_value("abc") == "***"
+        assert _mask_secret_value("ab") == "**"
+        assert _mask_secret_value("a") == "*"
+        assert _mask_secret_value("") == ""
+
+    def test_mask_secret_value_medium(self):
+        """Test masking of medium-length secrets."""
+        assert _mask_secret_value("test1234") == "te****34"
+        assert _mask_secret_value("secret") == "se**et"
+        assert _mask_secret_value("pass") == "p**s"
+
+    def test_mask_secret_value_long(self):
+        """Test masking of long secrets."""
+        long_secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        masked = _mask_secret_value(long_secret)
+        assert masked.startswith("wJa")
+        assert masked.endswith("KEY")
+        assert "*" in masked
+        assert len(masked) == len(long_secret)
+
+    def test_mask_bandit_b105_single_quote(self):
+        """Test masking of B105 findings with single quotes."""
+        text = "Possible hardcoded password: 'super_secret_password_123'"
+        expected = "Possible hardcoded password: 'sup*******************123'"
+        result = _mask_bandit_b105_secret(text)
+        assert result == expected
+
+    def test_mask_bandit_b105_double_quote(self):
+        """Test masking of B105 findings with double quotes."""
+        text = 'Possible hardcoded password: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"'
+        expected = 'Possible hardcoded password: "wJa**********************************KEY"'
+        result = _mask_bandit_b105_secret(text)
+        assert result == expected
+
+    def test_mask_bandit_b105_no_match(self):
+        """Test that non-matching text is not modified."""
+        text = "Some other security finding"
+        result = _mask_bandit_b105_secret(text)
+        assert result == text
+
+    def test_mask_secret_in_text_b105(self):
+        """Test the main masking function with B105 rule."""
+        text = "Possible hardcoded password: 'test_secret'"
+        expected = "Possible hardcoded password: 'tes*****ret'"
+        result = mask_secret_in_text(text, "B105")
+        assert result == expected
+
+    def test_mask_secret_in_text_other_rule(self):
+        """Test that other rules are not affected."""
+        text = "Some other finding with 'secret' in it"
+        result = mask_secret_in_text(text, "B101")
+        assert result == text
+
+    def test_mask_secret_in_text_no_rule(self):
+        """Test that text without rule ID is not modified."""
+        text = "Possible hardcoded password: 'secret'"
+        result = mask_secret_in_text(text, None)
+        assert result == text
+
+    def test_mask_secret_in_text_empty_text(self):
+        """Test that empty text is handled correctly."""
+        result = mask_secret_in_text("", "B105")
+        assert result == ""
+
+    def test_mask_secret_in_text_none_text(self):
+        """Test that None text is handled correctly."""
+        result = mask_secret_in_text(None, "B105")
+        assert result is None
+
+    def test_real_world_examples(self):
+        """Test with real-world examples from the issue description."""
+        # Example 1: AWS Secret Key
+        text1 = "Possible hardcoded password: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'"
+        result1 = mask_secret_in_text(text1, "B105")
+        assert "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" not in result1
+        assert "Possible hardcoded password:" in result1
+        assert result1.startswith("Possible hardcoded password: 'wJa")
+        assert result1.endswith("KEY'")
+
+        # Example 2: Database Password
+        text2 = "Possible hardcoded password: 'super_secret_password_123'"
+        result2 = mask_secret_in_text(text2, "B105")
+        assert "super_secret_password_123" not in result2
+        assert "Possible hardcoded password:" in result2
+        assert result2.startswith("Possible hardcoded password: 'sup")
+        assert result2.endswith("123'")

--- a/uv.lock
+++ b/uv.lock
@@ -42,7 +42,7 @@ wheels = [
 
 [[package]]
 name = "automated-security-helper"
-version = "3.0.2"
+version = "3.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
fixed the bandit reporting so when B105 rule related secrets are detected, they are not written to ash sarif, json or csv reports.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
