### PR TITLE
feat: add UV tool package name support for command/package mismatches

### DIFF
--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -15806,6 +15806,18 @@
           },
           "title": "Uv Tool Install Commands",
           "type": "array"
+        },
+        "uv_tool_package_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uv Tool Package Name"
         }
       },
       "title": "ScannerPluginBase",

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -2967,6 +2967,18 @@
           },
           "title": "Uv Tool Install Commands",
           "type": "array"
+        },
+        "uv_tool_package_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uv Tool Package Name"
         }
       },
       "title": "ScannerPluginBase",


### PR DESCRIPTION
*Issue #, if available:*
#183 
*Description of changes:*
- Enhanced UV tool management with support for package names that differ from command names. 
- Added uv_tool_package_name field to plugin base class to handle cases where the UV package name differs from the executable command name. 
- Updated Jupyter converter to use proper package naming (nbconvert package providing jupyter-nbconvert command).
- Modified UV tool runner to support package-specific operations including version detection, installation validation, and command execution. 
- Updated JSON schemas to reflect the new configuration option.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
