### PR TITLE
docs: fix pip install command to use versioned git URL

### DIFF
--- a/docs/content/docs/plugins/community/trivy-plugin.md
+++ b/docs/content/docs/plugins/community/trivy-plugin.md
@@ -1386,7 +1386,7 @@ jobs:
       - uses: actions/checkout@v3
       
       - name: Install ASH
-        run: pip install automated-security-helper
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.1.2
       
       - name: Run Trivy Security Scan
         run: |
@@ -1406,7 +1406,7 @@ security-scan:
   stage: test
   image: python:3.10
   script:
-    - pip install automated-security-helper
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.1.2
     - ash --scanners trivy-repo --reporters sarif,markdown
   artifacts:
     reports:


### PR DESCRIPTION
Replace pip install automated-security-helper with explicit git URL pointing to v3.1.2 release for reliable installation in CI/CD examples.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
