### PR TITLE
Fix/gitlab sast suppressions

### DIFF
--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
@@ -17,10 +17,22 @@ from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
 from automated_security_helper.utils.get_ash_version import get_ash_version
 from automated_security_helper.utils.log import ASH_LOGGER
+from pydantic import Field
+from typing import Annotated
 
 
 class GitLabSASTReporterConfigOptions(ReporterOptionsBase):
-    pass
+    exclude_suppressed: Annotated[
+        bool,
+        Field(
+            description=(
+                "When true, suppressed findings are excluded entirely from the "
+                "GitLab SAST report. When false (default), suppressed findings "
+                "are included with Info severity and the suppression reason in "
+                "the solution field."
+            ),
+        ),
+    ] = False
 
 
 class GitLabSASTReporterConfig(ReporterPluginConfigBase):
@@ -47,6 +59,24 @@ class GitLabSASTReporter(ReporterPluginBase[GitLabSASTReporterConfig]):
             if model.sarif and model.sarif.runs and model.sarif.runs[0].results:
                 ASH_LOGGER.trace("Creating rule dict")
                 for result in model.sarif.runs[0].results:
+                    # Check if finding is suppressed
+                    is_suppressed = (
+                        hasattr(result, "suppressions")
+                        and result.suppressions
+                        and len(result.suppressions) > 0
+                    )
+
+                    # Optionally exclude suppressed findings entirely
+                    if (
+                        is_suppressed
+                        and self.config
+                        and self.config.options.exclude_suppressed
+                    ):
+                        ASH_LOGGER.trace(
+                            f"Skipping suppressed finding: {result.ruleId}"
+                        )
+                        continue
+
                     ASH_LOGGER.trace(f"Processing result: {result.ruleId}")
 
                     # Determine severity
@@ -60,7 +90,20 @@ class GitLabSASTReporter(ReporterPluginBase[GitLabSASTReporterConfig]):
                         elif level_str == "note":
                             severity = "Low"
                         elif level_str == "none":
-                            severity = None  # Don't include severity for info level
+                            severity = None
+
+                    # Suppressed findings: downgrade to Info with solution
+                    suppression_solution = None
+                    if is_suppressed:
+                        severity = "Info"
+                        justification = (
+                            result.suppressions[0].justification or "No reason provided"
+                        )
+                        suppression_solution = (
+                            f"This finding was suppressed by ASH: {justification}. "
+                            "You can dismiss this vulnerability in the "
+                            "GitLab Security Dashboard."
+                        )
 
                     # Get location information
                     file_path = None
@@ -247,9 +290,13 @@ class GitLabSASTReporter(ReporterPluginBase[GitLabSASTReporterConfig]):
                         "details": details,
                     }
 
-                    # Only add severity if it's not None (info level findings don't have severity)
+                    # Only add severity if it's not None
                     if severity:
                         vuln["severity"] = severity
+
+                    # Add solution for suppressed findings
+                    if suppression_solution:
+                        vuln["solution"] = suppression_solution
 
                     vulnerabilities.append(vuln)
 

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1392,7 +1392,9 @@
               "enabled": true,
               "extension": "gl-sast-report.json",
               "name": "gitlab-sast",
-              "options": {}
+              "options": {
+                "exclude_suppressed": false
+              }
             },
             "html": {
               "enabled": true,
@@ -7416,7 +7418,9 @@
         },
         "options": {
           "$ref": "#/$defs/GitLabSASTReporterConfigOptions",
-          "default": {}
+          "default": {
+            "exclude_suppressed": false
+          }
         }
       },
       "title": "GitLabSASTReporterConfig",
@@ -7424,7 +7428,14 @@
     },
     "GitLabSASTReporterConfigOptions": {
       "additionalProperties": true,
-      "properties": {},
+      "properties": {
+        "exclude_suppressed": {
+          "default": false,
+          "description": "When true, suppressed findings are excluded entirely from the GitLab SAST report. When false (default), suppressed findings are included with Info severity and the suppression reason in the solution field.",
+          "title": "Exclude Suppressed",
+          "type": "boolean"
+        }
+      },
       "title": "GitLabSASTReporterConfigOptions",
       "type": "object"
     },
@@ -13228,7 +13239,9 @@
             "enabled": true,
             "extension": "gl-sast-report.json",
             "name": "gitlab-sast",
-            "options": {}
+            "options": {
+              "exclude_suppressed": false
+            }
           },
           "description": "Configure the options for the GitLab SAST reporter"
         },

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -154,7 +154,9 @@
               "enabled": true,
               "extension": "gl-sast-report.json",
               "name": "gitlab-sast",
-              "options": {}
+              "options": {
+                "exclude_suppressed": false
+              }
             },
             "html": {
               "enabled": true,
@@ -1516,7 +1518,9 @@
         },
         "options": {
           "$ref": "#/$defs/GitLabSASTReporterConfigOptions",
-          "default": {}
+          "default": {
+            "exclude_suppressed": false
+          }
         }
       },
       "title": "GitLabSASTReporterConfig",
@@ -1524,7 +1528,14 @@
     },
     "GitLabSASTReporterConfigOptions": {
       "additionalProperties": true,
-      "properties": {},
+      "properties": {
+        "exclude_suppressed": {
+          "default": false,
+          "description": "When true, suppressed findings are excluded entirely from the GitLab SAST report. When false (default), suppressed findings are included with Info severity and the suppression reason in the solution field.",
+          "title": "Exclude Suppressed",
+          "type": "boolean"
+        }
+      },
       "title": "GitLabSASTReporterConfigOptions",
       "type": "object"
     },
@@ -2326,7 +2337,9 @@
             "enabled": true,
             "extension": "gl-sast-report.json",
             "name": "gitlab-sast",
-            "options": {}
+            "options": {
+              "exclude_suppressed": false
+            }
           },
           "description": "Configure the options for the GitLab SAST reporter"
         },

--- a/docs/content/docs/suppressions.md
+++ b/docs/content/docs/suppressions.md
@@ -243,3 +243,51 @@ if [ "$UNUSED_COUNT" -gt 0 ]; then
   # exit 1
 fi
 ```
+
+## Suppressions in GitLab Security Dashboard
+
+When using the GitLab SAST reporter, ASH handles suppressed findings in a way that integrates with GitLab's Security Dashboard:
+
+### Default Behavior
+
+By default, suppressed findings are **included** in the GitLab SAST report (`ash.gl-sast-report.json`) with two modifications:
+
+- **Severity is downgraded to `Info`** — suppressed findings won't trigger alerts or block pipelines
+- **The suppression reason is added to the `solution` field** — GitLab admins can see why the finding was suppressed
+
+This approach provides an audit trail: security teams can see that a finding was detected and deliberately suppressed, and use GitLab's built-in vulnerability dismissal workflow to close it.
+
+### Dismissing Suppressed Findings in GitLab
+
+Once suppressed findings appear in the GitLab Security Dashboard as Info-level vulnerabilities:
+
+1. Navigate to **Security & Compliance > Vulnerability Report**
+2. Filter by severity **Info** to find suppressed findings
+3. Select the finding and click **Dismiss**
+4. Choose a reason: "Acceptable risk", "False positive", or "Used in tests"
+5. Paste the ASH suppression reason from the solution field as the dismissal comment
+
+Once dismissed, GitLab tracks the dismissal across future scans — the finding won't reappear as active even if ASH reports it again.
+
+For automation, GitLab's REST API supports programmatic dismissal:
+
+```bash
+curl --request POST \
+  --header "PRIVATE-TOKEN: <your_access_token>" \
+  "https://gitlab.example.com/api/v4/projects/:id/vulnerabilities/:vulnerability_id/dismiss" \
+  --data "comment=Suppressed by ASH: <reason>"
+```
+
+### Excluding Suppressed Findings
+
+If you prefer suppressed findings to not appear in the GitLab Security Dashboard at all, set `exclude_suppressed: true` in your ASH configuration:
+
+```yaml
+reporters:
+  gitlab-sast:
+    enabled: true
+    options:
+      exclude_suppressed: true
+```
+
+With this option, suppressed findings are omitted entirely from the GitLab SAST report. This results in a cleaner dashboard but removes the audit trail from GitLab.

--- a/tests/unit/reporters/test_gitlab_sast_suppressions.py
+++ b/tests/unit/reporters/test_gitlab_sast_suppressions.py
@@ -1,0 +1,117 @@
+"""Test that GitLab SAST reporter handles suppressed findings correctly."""
+
+import json
+import pytest
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_sast_reporter import (
+    GitLabSASTReporter,
+    GitLabSASTReporterConfig,
+    GitLabSASTReporterConfigOptions,
+)
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.schemas.sarif_schema_model import (
+    Result,
+    Suppression,
+)
+
+
+def _make_result(rule_id, level, text, suppressed=False, justification=None):
+    r = Result(ruleId=rule_id, level=level, message={"text": text})
+    if suppressed:
+        r.suppressions = [
+            Suppression(
+                kind="inSource",
+                justification=justification or "Suppressed by test",
+            )
+        ]
+    return r
+
+
+@pytest.fixture
+def plugin_context(tmp_path):
+    return PluginContext(
+        source_dir=tmp_path / "source",
+        output_dir=tmp_path / "output",
+        work_dir=tmp_path / "work",
+        config=AshConfig(),
+    )
+
+
+@pytest.fixture
+def model_with_suppressed_finding():
+    model = AshAggregatedResults()
+    model.sarif.runs[0].results = [
+        _make_result(
+            "B101",
+            "warning",
+            "Assert used",
+            suppressed=True,
+            justification="Assertions used for pytest",
+        ),
+        _make_result("B201", "error", "Flask debug", suppressed=False),
+    ]
+    return model
+
+
+class TestGitLabSASTSuppressions:
+    def test_suppressed_findings_downgraded_to_info(
+        self, plugin_context, model_with_suppressed_finding
+    ):
+        """Suppressed findings should appear with Info severity."""
+        reporter = GitLabSASTReporter(context=plugin_context)
+        report = json.loads(reporter.report(model_with_suppressed_finding))
+
+        vulns = {v["name"]: v for v in report["vulnerabilities"]}
+        assert vulns["B101"]["severity"] == "Info"
+        assert vulns["B201"]["severity"] == "High"
+
+    def test_suppressed_findings_have_solution(
+        self, plugin_context, model_with_suppressed_finding
+    ):
+        """Suppressed findings should include the suppression reason in solution."""
+        reporter = GitLabSASTReporter(context=plugin_context)
+        report = json.loads(reporter.report(model_with_suppressed_finding))
+
+        vulns = {v["name"]: v for v in report["vulnerabilities"]}
+        assert "solution" in vulns["B101"]
+        assert "Assertions used for pytest" in vulns["B101"]["solution"]
+        assert "solution" not in vulns["B201"]
+
+    def test_all_findings_included_by_default(
+        self, plugin_context, model_with_suppressed_finding
+    ):
+        """Both suppressed and active findings should be in the report."""
+        reporter = GitLabSASTReporter(context=plugin_context)
+        report = json.loads(reporter.report(model_with_suppressed_finding))
+        assert len(report["vulnerabilities"]) == 2
+
+    def test_exclude_suppressed_when_configured(
+        self, plugin_context, model_with_suppressed_finding
+    ):
+        """When exclude_suppressed=True, suppressed findings are excluded."""
+        config = GitLabSASTReporterConfig(
+            options=GitLabSASTReporterConfigOptions(exclude_suppressed=True),
+        )
+        reporter = GitLabSASTReporter(context=plugin_context, config=config)
+        report = json.loads(reporter.report(model_with_suppressed_finding))
+
+        rule_ids = [v["name"] for v in report["vulnerabilities"]]
+        assert "B201" in rule_ids
+        assert "B101" not in rule_ids
+
+    def test_exclude_all_suppressed(self, plugin_context):
+        """When all findings are suppressed and exclusion is on, report is empty."""
+        model = AshAggregatedResults()
+        model.sarif.runs[0].results = [
+            _make_result("B101", "warning", "Assert", suppressed=True),
+        ]
+        config = GitLabSASTReporterConfig(
+            options=GitLabSASTReporterConfigOptions(exclude_suppressed=True),
+        )
+        reporter = GitLabSASTReporter(context=plugin_context, config=config)
+        report = json.loads(reporter.report(model))
+
+        assert len(report["vulnerabilities"]) == 0
+        assert report["scan"]["status"] == "success"


### PR DESCRIPTION
*Issue #, if available:*
#266 
*Description of changes:*
- Modified gitlab-sast-report to change the vulnerability level to info and include the suppression message for tracking in Gitlab Security Dashboard

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
