### PR TITLE
fix(suppressions): handle ** as recursive glob in path matching

### DIFF
--- a/automated_security_helper/utils/suppression_matcher.py
+++ b/automated_security_helper/utils/suppression_matcher.py
@@ -54,17 +54,132 @@ def _rule_id_matches(finding_rule_id: Optional[str], suppression_rule_id: str) -
 def _file_path_matches(
     finding_file_path: Optional[str], suppression_file_path: str
 ) -> bool:
-    """Check if the finding's file path matches the suppression file path pattern."""
+    """Check if the finding's file path matches the suppression file path pattern.
+
+    Supports ``**`` as a recursive glob that matches zero or more directories,
+    e.g. ``tests/**/*.py`` matches both ``tests/test_foo.py`` and
+    ``tests/sub/test_bar.py``.
+    """
     if finding_file_path is None:
         return False
 
-    # Use glob pattern matching for file paths
     if finding_file_path == suppression_file_path:
-        # If it's an exact match, return True instead of wasting cycles on
-        # pattern matching
         return True
 
+    # When the pattern contains "**", we need special handling because
+    # fnmatch treats "*" as "anything except /" and has no concept of
+    # recursive directory matching.  We split on "**" and check that
+    # each segment matches in order, allowing any number of path
+    # components (including zero) in place of each "**".
+    if "**" in suppression_file_path:
+        return _recursive_glob_match(finding_file_path, suppression_file_path)
+
     return fnmatch.fnmatch(finding_file_path, suppression_file_path)
+
+
+def _recursive_glob_match(path: str, pattern: str) -> bool:
+    """Match *path* against *pattern* treating ``**`` as zero-or-more directories.
+
+    The algorithm splits the pattern on ``**`` separators, then verifies that
+    each resulting segment appears in the correct order inside *path* using
+    ``fnmatch`` for each segment.
+    """
+    # Normalise separators
+    path = path.replace("\\", "/")
+    pattern = pattern.replace("\\", "/")
+
+    # Split pattern on "**" (possibly surrounded by slashes)
+    import re
+
+    segments = re.split(r"/?\*\*/?", pattern)
+
+    # Handle trailing ** (e.g. "tests/**") — means match anything under prefix
+    has_trailing_star = pattern.rstrip("/").endswith("**")
+    # Handle leading ** (e.g. "**/*.py") — means match from any depth
+    has_leading_star = pattern.lstrip("/").startswith("**")
+
+    # Remove empty segments but track their positions
+    segments = [s for s in segments if s]
+
+    # Pattern is just "**" — matches everything
+    if not segments:
+        return True
+
+    # Single segment with both leading and trailing ** — match anywhere in path
+    if len(segments) == 1 and has_leading_star and has_trailing_star:
+        middle = segments[0]
+        parts = path.split("/")
+        seg_parts = middle.split("/")
+        seg_len = len(seg_parts)
+        for j in range(len(parts) - seg_len + 1):
+            candidate = "/".join(parts[j : j + seg_len])
+            if fnmatch.fnmatch(candidate, middle):
+                return True
+        return False
+
+    # Single segment with trailing ** — prefix match
+    if len(segments) == 1 and has_trailing_star and not has_leading_star:
+        prefix = segments[0]
+        parts = path.split("/")
+        seg_parts = prefix.split("/")
+        seg_len = len(seg_parts)
+        if len(parts) < seg_len:
+            return False
+        candidate = "/".join(parts[:seg_len])
+        return fnmatch.fnmatch(candidate, prefix)
+
+    # Single segment with leading ** — suffix match
+    if len(segments) == 1 and has_leading_star and not has_trailing_star:
+        suffix = segments[0]
+        parts = path.split("/")
+        seg_parts = suffix.split("/")
+        seg_len = len(seg_parts)
+        if len(parts) < seg_len:
+            return fnmatch.fnmatch(path, suffix)
+        candidate = "/".join(parts[-seg_len:])
+        return fnmatch.fnmatch(candidate, suffix)
+
+    # Multiple segments — match in order
+    remaining = path
+    for i, segment in enumerate(segments):
+        if not segment:
+            continue
+
+        is_first = i == 0
+        is_last = i == len(segments) - 1
+
+        if is_first and is_last:
+            return fnmatch.fnmatch(remaining, segment)
+
+        if is_first:
+            parts = remaining.split("/")
+            seg_parts = segment.split("/")
+            seg_len = len(seg_parts)
+            prefix = "/".join(parts[:seg_len])
+            if not fnmatch.fnmatch(prefix, segment):
+                return False
+            remaining = "/".join(parts[seg_len:])
+        elif is_last:
+            parts = remaining.split("/")
+            seg_parts = segment.split("/")
+            seg_len = len(seg_parts)
+            suffix = "/".join(parts[-seg_len:]) if seg_len <= len(parts) else remaining
+            return fnmatch.fnmatch(suffix, segment)
+        else:
+            parts = remaining.split("/")
+            seg_parts = segment.split("/")
+            seg_len = len(seg_parts)
+            found = False
+            for j in range(len(parts) - seg_len + 1):
+                candidate = "/".join(parts[j : j + seg_len])
+                if fnmatch.fnmatch(candidate, segment):
+                    remaining = "/".join(parts[j + seg_len :])
+                    found = True
+                    break
+            if not found:
+                return False
+
+    return True
 
 
 def _line_range_matches(

--- a/tests/unit/utils/test_suppression_glob.py
+++ b/tests/unit/utils/test_suppression_glob.py
@@ -1,0 +1,34 @@
+"""Test that suppression glob patterns with ** match correctly."""
+
+import pytest
+
+from automated_security_helper.utils.suppression_matcher import _file_path_matches
+
+
+@pytest.mark.parametrize(
+    "pattern,path,expected",
+    [
+        # ** matches zero or more directories
+        ("tests/**/*.py", "tests/test_example.py", True),
+        ("tests/**/*.py", "tests/sub/test_foo.py", True),
+        ("tests/**/*.py", "tests/a/b/test.py", True),
+        # trailing ** matches everything under prefix
+        ("tests/**", "tests/test_example.py", True),
+        ("tests/**", "tests/sub/test.py", True),
+        # leading ** matches from any depth
+        ("**/*.py", "any/path/file.py", True),
+        ("**/*.py", "file.py", True),
+        # ** on both sides matches anywhere
+        ("**/.venv/**", ".venv/lib/foo.py", True),
+        ("**/.venv/**", "src/.venv/lib/foo.py", True),
+        # simple glob still works
+        ("src/*.py", "src/app.py", True),
+        ("src/app.py", "src/app.py", True),
+        # non-matches
+        ("tests/**/*.py", "src/app.py", False),
+        ("tests/**/*.py", "tests/test.txt", False),
+        ("tests/**", "src/test.py", False),
+    ],
+)
+def test_file_path_matches(pattern, path, expected):
+    assert _file_path_matches(path, pattern) == expected


### PR DESCRIPTION



*Issue #, if available:*
Closes #265
*Description of changes:*
fnmatch treats ** the same as * (matches one path segment only), so patterns like tests/**/*.py failed to match tests/test_example.py (zero intermediate directories).

Replace fnmatch with a custom recursive glob matcher that splits on ** and matches each segment in order, allowing zero or more directory components in place of each **.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
