### PR TITLE
fix: version bump workflows create PRs instead of pushing to main

### DIFF
--- a/.github/workflows/ash-version-bump-major.yml
+++ b/.github/workflows/ash-version-bump-major.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: version-bump
@@ -19,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -53,8 +53,9 @@ jobs:
           VERSION=$(uv run python scripts/version_bump.py current | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Create version bump PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OLD_VERSION: ${{ steps.current-version.outputs.version }}
           NEW_VERSION: ${{ steps.new-version.outputs.version }}
           ACTOR: ${{ github.actor }}
@@ -63,10 +64,19 @@ jobs:
             echo "No version changes detected, skipping"
             exit 0
           fi
+
+          BRANCH="chore/bump-version-${NEW_VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add -A
-          git commit \
-            -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
-            -m "Triggered-by: @${ACTOR} (major via workflow_dispatch)"
-          git push
+          git commit -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+                     -m "Triggered-by: @${ACTOR} (major via workflow_dispatch)"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+            --body "Automated major version bump triggered by @${ACTOR} via workflow_dispatch." \
+            --label "no-version-bump" \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/ash-version-bump-minor.yml
+++ b/.github/workflows/ash-version-bump-minor.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: version-bump
@@ -19,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -53,8 +53,9 @@ jobs:
           VERSION=$(uv run python scripts/version_bump.py current | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Create version bump PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OLD_VERSION: ${{ steps.current-version.outputs.version }}
           NEW_VERSION: ${{ steps.new-version.outputs.version }}
           ACTOR: ${{ github.actor }}
@@ -63,10 +64,19 @@ jobs:
             echo "No version changes detected, skipping"
             exit 0
           fi
+
+          BRANCH="chore/bump-version-${NEW_VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add -A
-          git commit \
-            -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
-            -m "Triggered-by: @${ACTOR} (minor via workflow_dispatch)"
-          git push
+          git commit -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+                     -m "Triggered-by: @${ACTOR} (minor via workflow_dispatch)"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+            --body "Automated minor version bump triggered by @${ACTOR} via workflow_dispatch." \
+            --label "no-version-bump" \
+            --base main \
+            --head "$BRANCH"

--- a/.github/workflows/ash-version-bump-patch.yml
+++ b/.github/workflows/ash-version-bump-patch.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: version-bump
@@ -19,7 +20,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
@@ -53,8 +53,9 @@ jobs:
           VERSION=$(uv run python scripts/version_bump.py current | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push
+      - name: Create version bump PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OLD_VERSION: ${{ steps.current-version.outputs.version }}
           NEW_VERSION: ${{ steps.new-version.outputs.version }}
           ACTOR: ${{ github.actor }}
@@ -63,10 +64,19 @@ jobs:
             echo "No version changes detected, skipping"
             exit 0
           fi
+
+          BRANCH="chore/bump-version-${NEW_VERSION}"
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
           git add -A
-          git commit \
-            -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
-            -m "Triggered-by: @${ACTOR} (patch via workflow_dispatch)"
-          git push
+          git commit -m "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+                     -m "Triggered-by: @${ACTOR} (patch via workflow_dispatch)"
+          git push -u origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: bump version ${OLD_VERSION} -> ${NEW_VERSION}" \
+            --body "Automated patch version bump triggered by @${ACTOR} via workflow_dispatch." \
+            --label "no-version-bump" \
+            --base main \
+            --head "$BRANCH"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -198,7 +198,7 @@ uv run python scripts/version_bump.py bump patch   # or minor / major
 
 Add the `no-version-bump` label to skip the check for docs-only or CI-only changes.
 
-Maintainers can also bump versions directly via **Actions > Version Bump: Patch / Minor / Major > Run workflow**. These push directly to `main` via a GitHub Actions bypass in the repository ruleset.
+Maintainers can also bump versions via **Actions > Version Bump: Patch / Minor / Major > Run workflow**. These create a PR with the version bump and the `no-version-bump` label applied.
 
 ### Manual Version Bumping
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 curl -sSfL https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 ```
 
 ```powershell
@@ -99,10 +99,10 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4 $args }
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.3` to stay up to date automatically. Pin a specific version (e.g., `@v3.3.3`) when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.4` to stay up to date automatically. Pin a specific version (e.g., `@v3.3.4`) when you need reproducible builds.
 
 ### Other Installation Methods
 
@@ -122,13 +122,13 @@ ash --help
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.3
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.4
 cd automated-security-helper
 pip install .
 ```

--- a/docs/VERSION_MANAGEMENT.md
+++ b/docs/VERSION_MANAGEMENT.md
@@ -148,7 +148,7 @@ uv run python scripts/version_bump.py bump patch   # or minor / major
 
 Add the `no-version-bump` label to skip the check for docs-only or CI-only changes.
 
-Maintainers can also bump versions directly via **Actions > Version Bump: Patch / Minor / Major > Run workflow**. These push directly to `main` via a GitHub Actions bypass in the repository ruleset.
+Maintainers can also bump versions via **Actions > Version Bump: Patch / Minor / Major > Run workflow**. These create a PR with the version bump and the `no-version-bump` label applied.
 
 ### Manual Version Bumping (Local)
 

--- a/docs/content/docs/advanced-usage.md
+++ b/docs/content/docs/advanced-usage.md
@@ -216,7 +216,7 @@ print(f"Found {results.summary_stats.total_findings} findings")
 
 ## CI/CD Integration
 
-> **Tip**: The examples below use pinned versions (`@v3.3.3`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
+> **Tip**: The examples below use pinned versions (`@v3.3.4`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
 
 ### GitHub Actions
 
@@ -239,7 +239,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -255,7 +255,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
     - ash --mode local
   artifacts:
     paths:

--- a/docs/content/docs/installation-guide.md
+++ b/docs/content/docs/installation-guide.md
@@ -33,7 +33,7 @@ ASH v3 uses UV's tool isolation system to automatically manage most scanner depe
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 
 # Use as normal
 ash --help
@@ -45,14 +45,14 @@ ash --help
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4 $args }
 
 # Use as normal
 ash --help
 ```
 
 !!! tip "Floating tag `v3`"
-    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.3`) when you need reproducible builds, such as in CI/CD pipelines.
+    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.4`) when you need reproducible builds, such as in CI/CD pipelines.
 
 #### 2. Using `pipx`
 
@@ -60,7 +60,7 @@ ash --help
 
 ```bash
 # Works on Windows, macOS, and Linux
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Use as normal
 ash --help
@@ -72,7 +72,7 @@ Standard Python package installation:
 
 ```bash
 # Works on Windows, macOS, and Linux
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Use as normal
 ash --help
@@ -84,7 +84,7 @@ For development or if you want to modify ASH:
 
 ```bash
 # Works on Windows, macOS, and Linux
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.3
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.4
 cd automated-security-helper
 pip install .
 
@@ -134,7 +134,7 @@ To upgrade ASH to the latest version:
 ### If installed with `uvx`
 ```bash
 # Your alias will use the latest version when specified
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 ```
 
 ### If installed with `pipx`
@@ -144,7 +144,7 @@ pipx upgrade automated-security-helper
 
 ### If installed with `pip`
 ```bash
-pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ### If installed from repository

--- a/docs/content/docs/migration-guide.md
+++ b/docs/content/docs/migration-guide.md
@@ -48,13 +48,13 @@ export PATH="${PATH}:/path/to/automated-security-helper"
 
 ```bash
 # Option 1: Using uvx (recommended) -- add to shell profile
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 
 # Option 2: Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Option 3: Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 > **Tip**: You can also use the `v3` floating tag (`@v3`) instead of a specific version to always get the latest stable v3.x release. Pin a specific version for CI/CD or reproducible environments.

--- a/docs/content/docs/quick-start-guide.md
+++ b/docs/content/docs/quick-start-guide.md
@@ -25,7 +25,7 @@ Prerequisites: Python 3.10+, [uv](https://docs.astral.sh/uv/getting-started/inst
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 ```
 
 #### Windows PowerShell
@@ -34,17 +34,17 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4 $args }
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.3`) when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.4`) when you need reproducible builds.
 
 ### Option 2: Using pipx
 
 Prerequisites: Python 3.10+, [pipx](https://pipx.pypa.io/stable/installation/)
 
 ```bash
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ### Option 3: Using pip
@@ -52,7 +52,7 @@ pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
 Prerequisites: Python 3.10+
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ## Basic Usage

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -23,25 +23,25 @@ No. ASH is designed to help identify common security issues early in the develop
 You have several options:
 ```bash
 # Using uvx (recommended)
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 
 # Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ### What are the prerequisites for ASH v3?
 
 ### What is the `v3` floating tag?
-We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.3.3`:
+We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.3.4`:
 
 ```bash
 alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3"
 ```
 
-This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.3.3`).
+This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.3.4`).
 
 ### What are the prerequisites for ASH v3?
 - For local mode: Python 3.10 or later, UV package manager

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -55,13 +55,13 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 
 ```bash
 # Install with pipx (isolated environment)
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Use as normal
 ash --help
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.3` to stay up to date automatically. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.4` to stay up to date automatically. Pin a specific version when you need reproducible builds.
 
 ### Other Installation Methods
 
@@ -73,23 +73,23 @@ ash --help
 ```bash
 # Linux/macOS
 curl -sSf https://astral.sh/uv/install.sh | sh
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 
 # Windows PowerShell
 irm https://astral.sh/uv/install.ps1 | iex
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4 $args }
 ```
 
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.3
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.4
 cd automated-security-helper
 pip install .
 ```

--- a/docs/content/tutorials/running-ash-in-ci.md
+++ b/docs/content/tutorials/running-ash-in-ci.md
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - name: Run ASH scan
         run: ash --mode container
       - name: Upload scan results
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - name: Run ASH scan
         run: ash --mode local
       - name: Add PR comment
@@ -132,7 +132,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
     - ash --mode local
   artifacts:
     paths:
@@ -150,7 +150,7 @@ ash-scan-container:
     DOCKER_TLS_CERTDIR: "/certs"
   script:
     - apk add --no-cache python3 py3-pip git
-    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
     - ash --mode container
   artifacts:
     paths:
@@ -174,7 +174,7 @@ Example using local mode:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
     - ash --mode local --no-fail-on-findings
   artifacts:
     paths:
@@ -193,7 +193,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
   build:
     commands:
@@ -214,7 +214,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
   pre_build:
     commands:
@@ -244,7 +244,7 @@ pipeline {
     stages {
         stage('Install ASH') {
             steps {
-                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3'
+                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4'
             }
         }
         stage('Run ASH Scan') {
@@ -275,7 +275,7 @@ pipeline {
         stage('Install ASH') {
             steps {
                 sh 'apk add --no-cache python3 py3-pip git'
-                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3'
+                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4'
             }
         }
         stage('Run ASH Scan') {
@@ -306,7 +306,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - run:
           name: Run ASH scan
           command: ash --mode local
@@ -333,7 +333,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
       - run:
           name: Run ASH scan
           command: ash --mode container
@@ -350,7 +350,7 @@ workflows:
 
 ## Best Practices for CI Integration
 
-> **Tip**: The CI examples in this guide use pinned versions (`@v3.3.3`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
+> **Tip**: The CI examples in this guide use pinned versions (`@v3.3.4`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
 
 1. **Fail builds on critical findings**:
    ```bash

--- a/docs/content/tutorials/running-ash-locally.md
+++ b/docs/content/tutorials/running-ash-locally.md
@@ -13,12 +13,12 @@ ASH v3 can run in multiple modes: `local`, `container`, or `precommit`. This gui
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4"
 
 # Add this alias to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 ```
 
-> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.3.3` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.3.4` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
 
 ### Option 2: Using `pipx`
 
@@ -28,13 +28,13 @@ python -m pip install --user pipx
 python -m pipx ensurepath
 
 # Install ASH
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ### Option 3: Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 ```
 
 ### Option 4: Clone the Repository (Legacy Method)
@@ -103,7 +103,7 @@ ASH v3 runs natively on Windows with Python 3.10+:
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.3 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.4 $args }
 
 # Use as normal
 ash --help

--- a/examples/streamlit_ui/README.md
+++ b/examples/streamlit_ui/README.md
@@ -21,7 +21,7 @@ Install the required dependencies:
 
 ```bash
 # ASH
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.3
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.4
 
 # Streamlit
 pip install streamlit
@@ -42,7 +42,7 @@ streamlit run https://raw.githubusercontent.com/awslabs/automated-security-helpe
 #### ...or clone and run from local
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.3
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.4
 streamlit run ./automated-security-helper/examples/streamlit_ui/ash_ui.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-security-helper"
-version = "3.3.3"
+version = "3.3.4"
 description = "Automated Security Helper for GitHub Actions"
 requires-python = ">=3.10,<4"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "automated-security-helper"
-version = "3.3.2"
+version = "3.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

- Rewrite the three `workflow_dispatch` version bump workflows (patch/minor/major) to create PRs instead of pushing directly to `main`
- Each PR gets the `no-version-bump` label so it doesn't fail the version check
- Removed the GitHub Actions bypass actor from the ruleset (no longer needed)
- Updated docs in DEVELOPMENT.md and VERSION_MANAGEMENT.md

## Context

The ruleset bypass for `RepositoryRole` ID 5 doesn't work for `GITHUB_TOKEN` pushes — rulesets enforce against Actions pushes regardless. Creating PRs sidesteps this entirely.

## Test plan

- [ ] Run **Actions > Version Bump: Patch > Run workflow** — confirm it creates a PR with the bump and `no-version-bump` label
- [ ] Merge the created PR — confirm it lands on `main`