### PR TITLE
fix: config file discovery broken since v3.2.7

### DIFF
--- a/.ash.yaml
+++ b/.ash.yaml
@@ -2,7 +2,8 @@ global_settings:
   # Ignore test data that intentionally contains insecure patterns
   # (these are scanner test fixtures, not production code)
   ignore_paths:
-    - "tests/test_data/**"
+    - path: "tests/test_data/**"
+      reason: "Scanner test fixtures with intentional insecure patterns"
 
   suppressions:
     # Test files for secret masking contain intentional fake passwords

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 curl -sSfL https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 ```
 
 ```powershell
@@ -99,10 +99,10 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7 $args }
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.6` to stay up to date automatically. Pin a specific version (e.g., `@v3.3.6`) when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.7` to stay up to date automatically. Pin a specific version (e.g., `@v3.3.7`) when you need reproducible builds.
 
 ### Other Installation Methods
 
@@ -122,13 +122,13 @@ ash --help
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.6
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.7
 cd automated-security-helper
 pip install .
 ```

--- a/automated_security_helper/core/orchestrator.py
+++ b/automated_security_helper/core/orchestrator.py
@@ -160,6 +160,7 @@ class ASHScanOrchestrator(BaseModel):
 
         self.config = resolve_config(
             config_path=self.config_path,
+            source_dir=self.source_dir,
             config_overrides=self.config_overrides
             if hasattr(self, "config_overrides")
             else [],

--- a/docs/content/docs/advanced-usage.md
+++ b/docs/content/docs/advanced-usage.md
@@ -216,7 +216,7 @@ print(f"Found {results.summary_stats.total_findings} findings")
 
 ## CI/CD Integration
 
-> **Tip**: The examples below use pinned versions (`@v3.3.6`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
+> **Tip**: The examples below use pinned versions (`@v3.3.7`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
 
 ### GitHub Actions
 
@@ -239,7 +239,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -255,7 +255,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
     - ash --mode local
   artifacts:
     paths:

--- a/docs/content/docs/installation-guide.md
+++ b/docs/content/docs/installation-guide.md
@@ -33,7 +33,7 @@ ASH v3 uses UV's tool isolation system to automatically manage most scanner depe
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 
 # Use as normal
 ash --help
@@ -45,14 +45,14 @@ ash --help
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7 $args }
 
 # Use as normal
 ash --help
 ```
 
 !!! tip "Floating tag `v3`"
-    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.6`) when you need reproducible builds, such as in CI/CD pipelines.
+    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.7`) when you need reproducible builds, such as in CI/CD pipelines.
 
 #### 2. Using `pipx`
 
@@ -60,7 +60,7 @@ ash --help
 
 ```bash
 # Works on Windows, macOS, and Linux
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Use as normal
 ash --help
@@ -72,7 +72,7 @@ Standard Python package installation:
 
 ```bash
 # Works on Windows, macOS, and Linux
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Use as normal
 ash --help
@@ -84,7 +84,7 @@ For development or if you want to modify ASH:
 
 ```bash
 # Works on Windows, macOS, and Linux
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.6
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.7
 cd automated-security-helper
 pip install .
 
@@ -134,7 +134,7 @@ To upgrade ASH to the latest version:
 ### If installed with `uvx`
 ```bash
 # Your alias will use the latest version when specified
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 ```
 
 ### If installed with `pipx`
@@ -144,7 +144,7 @@ pipx upgrade automated-security-helper
 
 ### If installed with `pip`
 ```bash
-pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ### If installed from repository

--- a/docs/content/docs/migration-guide.md
+++ b/docs/content/docs/migration-guide.md
@@ -48,13 +48,13 @@ export PATH="${PATH}:/path/to/automated-security-helper"
 
 ```bash
 # Option 1: Using uvx (recommended) -- add to shell profile
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 
 # Option 2: Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Option 3: Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 > **Tip**: You can also use the `v3` floating tag (`@v3`) instead of a specific version to always get the latest stable v3.x release. Pin a specific version for CI/CD or reproducible environments.

--- a/docs/content/docs/quick-start-guide.md
+++ b/docs/content/docs/quick-start-guide.md
@@ -25,7 +25,7 @@ Prerequisites: Python 3.10+, [uv](https://docs.astral.sh/uv/getting-started/inst
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 ```
 
 #### Windows PowerShell
@@ -34,17 +34,17 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7 $args }
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.6`) when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.3.7`) when you need reproducible builds.
 
 ### Option 2: Using pipx
 
 Prerequisites: Python 3.10+, [pipx](https://pipx.pypa.io/stable/installation/)
 
 ```bash
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ### Option 3: Using pip
@@ -52,7 +52,7 @@ pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
 Prerequisites: Python 3.10+
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ## Basic Usage

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -23,25 +23,25 @@ No. ASH is designed to help identify common security issues early in the develop
 You have several options:
 ```bash
 # Using uvx (recommended)
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 
 # Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ### What are the prerequisites for ASH v3?
 
 ### What is the `v3` floating tag?
-We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.3.6`:
+We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.3.7`:
 
 ```bash
 alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3"
 ```
 
-This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.3.6`).
+This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.3.7`).
 
 ### What are the prerequisites for ASH v3?
 - For local mode: Python 3.10 or later, UV package manager

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -55,13 +55,13 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 
 ```bash
 # Install with pipx (isolated environment)
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Use as normal
 ash --help
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.6` to stay up to date automatically. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.3.7` to stay up to date automatically. Pin a specific version when you need reproducible builds.
 
 ### Other Installation Methods
 
@@ -73,23 +73,23 @@ ash --help
 ```bash
 # Linux/macOS
 curl -sSf https://astral.sh/uv/install.sh | sh
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 
 # Windows PowerShell
 irm https://astral.sh/uv/install.ps1 | iex
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7 $args }
 ```
 
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 #### Clone the Repository
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.6
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.7
 cd automated-security-helper
 pip install .
 ```

--- a/docs/content/tutorials/running-ash-in-ci.md
+++ b/docs/content/tutorials/running-ash-in-ci.md
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - name: Run ASH scan
         run: ash --mode container
       - name: Upload scan results
@@ -99,7 +99,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - name: Run ASH scan
         run: ash --mode local
       - name: Add PR comment
@@ -132,7 +132,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
     - ash --mode local
   artifacts:
     paths:
@@ -150,7 +150,7 @@ ash-scan-container:
     DOCKER_TLS_CERTDIR: "/certs"
   script:
     - apk add --no-cache python3 py3-pip git
-    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
     - ash --mode container
   artifacts:
     paths:
@@ -174,7 +174,7 @@ Example using local mode:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
     - ash --mode local --no-fail-on-findings
   artifacts:
     paths:
@@ -193,7 +193,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
   build:
     commands:
@@ -214,7 +214,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
   pre_build:
     commands:
@@ -244,7 +244,7 @@ pipeline {
     stages {
         stage('Install ASH') {
             steps {
-                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6'
+                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7'
             }
         }
         stage('Run ASH Scan') {
@@ -275,7 +275,7 @@ pipeline {
         stage('Install ASH') {
             steps {
                 sh 'apk add --no-cache python3 py3-pip git'
-                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6'
+                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7'
             }
         }
         stage('Run ASH Scan') {
@@ -306,7 +306,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - run:
           name: Run ASH scan
           command: ash --mode local
@@ -333,7 +333,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
       - run:
           name: Run ASH scan
           command: ash --mode container
@@ -350,7 +350,7 @@ workflows:
 
 ## Best Practices for CI Integration
 
-> **Tip**: The CI examples in this guide use pinned versions (`@v3.3.6`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
+> **Tip**: The CI examples in this guide use pinned versions (`@v3.3.7`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
 
 1. **Fail builds on critical findings**:
    ```bash

--- a/docs/content/tutorials/running-ash-locally.md
+++ b/docs/content/tutorials/running-ash-locally.md
@@ -13,12 +13,12 @@ ASH v3 can run in multiple modes: `local`, `container`, or `precommit`. This gui
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7"
 
 # Add this alias to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 ```
 
-> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.3.6` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.3.7` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
 
 ### Option 2: Using `pipx`
 
@@ -28,13 +28,13 @@ python -m pip install --user pipx
 python -m pipx ensurepath
 
 # Install ASH
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ### Option 3: Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 ```
 
 ### Option 4: Clone the Repository (Legacy Method)
@@ -103,7 +103,7 @@ ASH v3 runs natively on Windows with Python 3.10+:
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.6 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.3.7 $args }
 
 # Use as normal
 ash --help

--- a/examples/streamlit_ui/README.md
+++ b/examples/streamlit_ui/README.md
@@ -21,7 +21,7 @@ Install the required dependencies:
 
 ```bash
 # ASH
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.6
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.3.7
 
 # Streamlit
 pip install streamlit
@@ -42,7 +42,7 @@ streamlit run https://raw.githubusercontent.com/awslabs/automated-security-helpe
 #### ...or clone and run from local
 
 ```bash
-git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.6
+git clone https://github.com/awslabs/automated-security-helper.git --branch v3.3.7
 streamlit run ./automated-security-helper/examples/streamlit_ui/ash_ui.py
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "automated-security-helper"
-version = "3.3.6"
+version = "3.3.7"
 description = "Automated Security Helper for GitHub Actions"
 requires-python = ">=3.10,<4"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -40,7 +40,7 @@ wheels = [
 
 [[package]]
 name = "automated-security-helper"
-version = "3.3.5"
+version = "3.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "attrs" },


### PR DESCRIPTION
## Summary

Two bugs introduced in PR #274 that broke `.ash.yaml` config file discovery:

1. **`resolve_config()` skips file search when `source_dir` is `None`** — PR #274 changed the `source_dir` default from `Path.cwd()` to `None` and added an early return at line 172. The orchestrator never passes `source_dir`, so config discovery was completely bypassed.

2. **`.ash.yaml` has invalid `ignore_paths` format** — entries were bare strings (`"tests/test_data/**"`) but the `IgnorePathWithReason` model requires `{path: ..., reason: ...}` objects. Config validation failed silently and fell back to defaults.

## Fix

- Pass `self.source_dir` from the orchestrator to `resolve_config()`
- Fix `.ash.yaml` to use the correct `{path, reason}` format

## Test plan

- [ ] `uv run python -c "from automated_security_helper.config.resolve_config import resolve_config; from pathlib import Path; c = resolve_config(source_dir=Path('.')); print(c.global_settings.ignore_paths)"` shows the ignore path
- [ ] Run ASH scan on the repo — confirm suppressions are applied