### PR TITLE
feat: adopt commitizen for unified release management

### DIFF
--- a/.github/workflows/ash-create-release.yml
+++ b/.github/workflows/ash-create-release.yml
@@ -34,6 +34,11 @@ jobs:
       - name: Install dependencies
         run: uv sync
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Determine bump and create release artifacts
         id: bump
         env:
@@ -66,8 +71,6 @@ jobs:
           ACTOR: ${{ github.actor }}
         run: |
           BRANCH="release/v${NEW_VERSION}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -b "$BRANCH"
           git add -A
           git commit -m "chore(release): ${OLD_VERSION} -> ${NEW_VERSION}" \


### PR DESCRIPTION
## Summary

Replace the fragmented version bump system with commitizen-driven releases. This unifies version bumping, changelog generation, tagging, and GitHub Release creation into a single automated flow.

## What changed

### Deleted
- `ash-version-check.yml` — per-PR version bump enforcement
- `ash-version-bump-{patch,minor,major}.yml` — dispatch bump workflows

### Added
- **Commitizen** as dev dependency + config in `pyproject.toml` (with `legacy_tag_formats` for old tag patterns)
- **Pre-commit hook** (`commitizen`) — validates local commit messages follow conventional commits
- **`ash-pr-title-check.yml`** — required check for conventional commit PR titles
- **`ash-create-release.yml`** — dispatch workflow: `cz bump --changelog`, regenerate docs, create release PR
- **`ash-tag-on-merge.yml`** — auto: creates tag + GitHub Release + moves `v3` when release PR merges
- **`.github/release.yml`** — label-to-section mapping for auto-generated release notes

### Ruleset updated
- Removed "Verify version bump" required check
- Added "Validate PR title" required check

## Release flow

```
PRs merged (conventional commit titles)
    → maintainer runs "Create Release" dispatch
    → commitizen determines bump type from commit history
    → version bump + changelog + doc regeneration → release PR
    → maintainer merges release PR
    → tag + GitHub Release + v3 update created automatically
```

## Post-merge actions

1. Create baseline tag `v3.3.7` on main so commitizen has a starting point
2. Move `v3` floating tag to current main
3. Remove "Validate PR title" from required checks temporarily (chicken-and-egg), re-add after merge

## Test plan

- [ ] Merge this PR (admin force-merge past the PR title check)
- [ ] Create baseline tag: `gh api repos/awslabs/automated-security-helper/git/refs -X POST --field ref=refs/tags/v3.3.7 --field sha=$(git rev-parse origin/main)`
- [ ] Run "ASH - Create Release" dispatch → verify release PR is created
- [ ] Merge release PR → verify tag + GitHub Release are created and `v3` is moved