### PR TITLE
feat(reporters): add gitlab-cyclonedx reporter for GitLab Dependency List

### DIFF
--- a/automated_security_helper/config/ash_config.py
+++ b/automated_security_helper/config/ash_config.py
@@ -33,6 +33,9 @@ from automated_security_helper.plugin_modules.ash_builtin.reporters.csv_reporter
 from automated_security_helper.plugin_modules.ash_builtin.reporters.cyclonedx_reporter import (
     CycloneDXReporterConfig,
 )
+from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_cyclonedx_reporter import (
+    GitLabCycloneDXReporterConfig,
+)
 from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_sast_reporter import (
     GitLabSASTReporterConfig,
 )
@@ -208,6 +211,13 @@ class ReporterConfigSegment(BaseModel):
         CycloneDXReporterConfig,
         Field(description="Configure the options for the CycloneDX reporter"),
     ] = CycloneDXReporterConfig()
+    gitlab_cyclonedx: Annotated[
+        GitLabCycloneDXReporterConfig,
+        Field(
+            description="Configure the options for the GitLab CycloneDX dependency scanning reporter",
+            alias="gitlab-cyclonedx",
+        ),
+    ] = GitLabCycloneDXReporterConfig()
     # Do the same for html, json, junitxml, ocsf, sarif, spdx, text, and yaml
     html: Annotated[
         HTMLReporterConfig,

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/__init__.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/__init__.py
@@ -10,6 +10,9 @@ from automated_security_helper.plugin_modules.ash_builtin.reporters.cyclonedx_re
 from automated_security_helper.plugin_modules.ash_builtin.reporters.github_ghas_reporter import (
     GHASReporter,
 )
+from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_cyclonedx_reporter import (
+    GitLabCycloneDXReporter,
+)
 from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_sast_reporter import (
     GitLabSASTReporter,
 )
@@ -51,6 +54,7 @@ __all__ = [
     "CsvReporter",
     "CycloneDXReporter",
     "GHASReporter",
+    "GitLabCycloneDXReporter",
     "GitLabSASTReporter",
     "HtmlReporter",
     "FlatJsonReporter",

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
@@ -1,0 +1,360 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GitLab CycloneDX reporter.
+
+Enriches the Syft-produced CycloneDX SBOM with GitLab's property taxonomy
+so that GitLab's Dependency List can ingest it without the
+"Required GitLab CycloneDX properties are missing" error.
+
+This reporter does NOT modify the existing ``cyclonedx`` reporter — it produces
+a separate artifact (``gl-dependency-scanning-report.cdx.json``) intended to be
+uploaded as ``artifacts:reports:cyclonedx`` in GitLab CI.
+
+Reference:
+  https://docs.gitlab.com/ee/development/sec/cyclonedx_property_taxonomy.html
+"""
+
+import json
+from typing import Literal, Optional, TYPE_CHECKING
+
+from pydantic import Field
+from typing import Annotated
+
+if TYPE_CHECKING:
+    from automated_security_helper.models.asharp_model import AshAggregatedResults
+
+from automated_security_helper.base.options import ReporterOptionsBase
+from automated_security_helper.base.reporter_plugin import (
+    ReporterPluginBase,
+    ReporterPluginConfigBase,
+)
+from automated_security_helper.plugins.decorators import ash_reporter_plugin
+from automated_security_helper.utils.log import ASH_LOGGER
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GITLAB_SCHEMA_VERSION = "1"
+"""The only supported schema version as of GitLab 17.x (May 2026)."""
+
+# Mapping from Syft's ``syft:package:type`` values to GitLab's expected
+# (package_manager, language) pair.
+SYFT_TYPE_TO_GITLAB: dict[str, tuple[str, str]] = {
+    "npm": ("npm", "JavaScript"),
+    "python": ("pip", "Python"),
+    "gem": ("bundler", "Ruby"),
+    "go-module": ("go", "Go"),
+    "java-archive": ("maven", "Java"),
+    "maven": ("maven", "Java"),
+    "gradle": ("gradle", "Java"),
+    "cargo": ("cargo", "Rust"),
+    "composer": ("composer", "PHP"),
+    "nuget": ("nuget", "C#"),
+    "pub": ("pub", "Dart"),
+    "cocoapods": ("cocoapods", "Swift"),
+    "hex": ("mix", "Elixir"),
+    "hackage": ("cabal", "Haskell"),
+    "apk": ("apk", ""),
+    "deb": ("apt", ""),
+    "rpm": ("yum", ""),
+}
+
+# Fallback mapping from PURL type prefix to GitLab values.
+# Used when ``syft:package:type`` is absent (e.g. non-Syft CycloneDX sources).
+PURL_TYPE_TO_GITLAB: dict[str, tuple[str, str]] = {
+    "npm": ("npm", "JavaScript"),
+    "pypi": ("pip", "Python"),
+    "gem": ("bundler", "Ruby"),
+    "golang": ("go", "Go"),
+    "maven": ("maven", "Java"),
+    "cargo": ("cargo", "Rust"),
+    "composer": ("composer", "PHP"),
+    "nuget": ("nuget", "C#"),
+    "pub": ("pub", "Dart"),
+    "cocoapods": ("cocoapods", "Swift"),
+    "hex": ("mix", "Elixir"),
+    "hackage": ("cabal", "Haskell"),
+    "apk": ("apk", ""),
+    "deb": ("apt", ""),
+    "rpm": ("yum", ""),
+}
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+class GitLabCycloneDXReporterConfigOptions(ReporterOptionsBase):
+    """Options for the gitlab-cyclonedx reporter."""
+
+    category: Annotated[
+        str,
+        Field(
+            description=(
+                "Default dependency category injected as "
+                "gitlab:dependency_scanning:category. "
+                "Typically 'production' or 'development'."
+            ),
+        ),
+    ] = "production"
+
+    package_manager_override: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "If set, overrides the auto-detected package manager name "
+                "for ALL components. Useful for single-ecosystem repos."
+            ),
+        ),
+    ] = None
+
+    language_override: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "If set, overrides the auto-detected language name for ALL components."
+            ),
+        ),
+    ] = None
+
+    input_file_path_override: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "If set, overrides the auto-detected input file path "
+                "for ALL components. Useful when Syft reports absolute "
+                "container paths that don't match the repo layout."
+            ),
+        ),
+    ] = None
+
+
+class GitLabCycloneDXReporterConfig(ReporterPluginConfigBase):
+    name: Literal["gitlab-cyclonedx"] = "gitlab-cyclonedx"
+    extension: str = "gl-dependency-scanning-report.cdx.json"
+    enabled: bool = True
+    options: GitLabCycloneDXReporterConfigOptions = (
+        GitLabCycloneDXReporterConfigOptions()
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_component_property(component_dict: dict, property_name: str) -> str | None:
+    """Extract a named property value from a component's properties list."""
+    for prop in component_dict.get("properties") or []:
+        if prop.get("name") == property_name:
+            return prop.get("value")
+    return None
+
+
+def _extract_purl_type(purl: str | None) -> str | None:
+    """Extract the type segment from a PURL string.
+
+    Example: ``pkg:npm/%40antfu/install-pkg@1.0.0`` → ``npm``
+    """
+    if not purl or not purl.startswith("pkg:"):
+        return None
+    remainder = purl[4:]  # strip "pkg:"
+    slash_idx = remainder.find("/")
+    if slash_idx == -1:
+        return remainder or None
+    return remainder[:slash_idx] or None
+
+
+def _normalize_input_file_path(raw_path: str | None) -> str | None:
+    """Attempt to make a Syft location path repo-relative.
+
+    Syft often reports absolute paths from inside containers
+    (e.g. ``/.venv/lib/python3.12/.../yarn.lock``). We try to extract
+    just the manifest filename which is what GitLab displays.
+
+    Returns None if we can't produce something useful.
+    """
+    if not raw_path:
+        return None
+
+    # Strip leading slash
+    path = raw_path.lstrip("/")
+
+    # If the path contains common virtual-env or site-packages segments,
+    # extract just the filename (the lockfile/manifest).
+    # This is a heuristic — better than showing a container-internal path.
+    segments_to_skip = (
+        ".venv/",
+        "venv/",
+        "site-packages/",
+        "node_modules/",
+        "vendor/",
+    )
+    for segment in segments_to_skip:
+        idx = path.find(segment)
+        if idx != -1:
+            # Find the last path component that looks like a manifest
+            # e.g. "yarn.lock", "package-lock.json", "go.sum", "requirements.txt"
+            parts = path.split("/")
+            # Return the last component (the actual file)
+            return parts[-1] if parts else None
+
+    return path
+
+
+def _resolve_package_manager_and_language(
+    component_dict: dict,
+    options: GitLabCycloneDXReporterConfigOptions,
+) -> tuple[str | None, str | None]:
+    """Resolve (package_manager, language) for a component.
+
+    Resolution order:
+    1. Config overrides (if set)
+    2. ``syft:package:type`` property → SYFT_TYPE_TO_GITLAB mapping
+    3. PURL type → PURL_TYPE_TO_GITLAB mapping
+    4. None (omit the property)
+    """
+    # Config overrides win unconditionally
+    if options.package_manager_override and options.language_override:
+        return options.package_manager_override, options.language_override
+
+    # Try syft:package:type first
+    syft_type = _get_component_property(component_dict, "syft:package:type")
+    if syft_type and syft_type in SYFT_TYPE_TO_GITLAB:
+        pm, lang = SYFT_TYPE_TO_GITLAB[syft_type]
+        return (
+            options.package_manager_override or pm,
+            options.language_override or lang,
+        )
+
+    # Fallback to PURL type
+    purl_type = _extract_purl_type(component_dict.get("purl"))
+    if purl_type and purl_type in PURL_TYPE_TO_GITLAB:
+        pm, lang = PURL_TYPE_TO_GITLAB[purl_type]
+        return (
+            options.package_manager_override or pm,
+            options.language_override or lang,
+        )
+
+    return options.package_manager_override, options.language_override
+
+
+def _resolve_input_file_path(
+    component_dict: dict,
+    options: GitLabCycloneDXReporterConfigOptions,
+) -> str | None:
+    """Resolve the input file path for a component.
+
+    Resolution order:
+    1. Config override (if set)
+    2. ``syft:location:0:path`` property (normalized)
+    3. None (omit the property)
+    """
+    if options.input_file_path_override:
+        return options.input_file_path_override
+
+    raw_path = _get_component_property(component_dict, "syft:location:0:path")
+    return _normalize_input_file_path(raw_path)
+
+
+def _build_gitlab_properties_for_component(
+    component_dict: dict,
+    options: GitLabCycloneDXReporterConfigOptions,
+) -> list[dict[str, str]]:
+    """Build the list of GitLab taxonomy properties to inject on a component."""
+    props: list[dict[str, str]] = []
+
+    # Category (always injected)
+    props.append(
+        {"name": "gitlab:dependency_scanning:category", "value": options.category}
+    )
+
+    # Package manager and language
+    pm, lang = _resolve_package_manager_and_language(component_dict, options)
+    if pm:
+        props.append(
+            {"name": "gitlab:dependency_scanning:package_manager:name", "value": pm}
+        )
+    if lang:
+        props.append(
+            {"name": "gitlab:dependency_scanning:language:name", "value": lang}
+        )
+
+    # Input file path
+    input_file = _resolve_input_file_path(component_dict, options)
+    if input_file:
+        props.append(
+            {"name": "gitlab:dependency_scanning:input_file:path", "value": input_file}
+        )
+
+    return props
+
+
+# ---------------------------------------------------------------------------
+# Reporter
+# ---------------------------------------------------------------------------
+
+
+@ash_reporter_plugin
+class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig]):
+    """Enriches CycloneDX SBOM with GitLab dependency scanning properties.
+
+    Produces ``gl-dependency-scanning-report.cdx.json`` suitable for upload as
+    ``artifacts:reports:cyclonedx`` in GitLab CI pipelines.
+    """
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = GitLabCycloneDXReporterConfig()
+        return super().model_post_init(context)
+
+    def report(self, model: "AshAggregatedResults") -> str | None:
+        """Enrich CycloneDX with GitLab properties and serialize."""
+
+        # Guard: nothing to enrich if there's no CycloneDX data
+        if not model.cyclonedx:
+            ASH_LOGGER.debug("gitlab-cyclonedx: No CycloneDX model present, skipping.")
+            return None
+
+        # Serialize to dict for manipulation
+        doc = model.cyclonedx.model_dump(
+            by_alias=True,
+            exclude_unset=True,
+            exclude_none=True,
+            mode="json",
+        )
+
+        components = doc.get("components")
+        if not components:
+            ASH_LOGGER.debug(
+                "gitlab-cyclonedx: CycloneDX model has no components, skipping."
+            )
+            return None
+
+        # --- Inject metadata-level schema version property ---
+        metadata = doc.setdefault("metadata", {})
+        metadata_props = metadata.setdefault("properties", [])
+        metadata_props.append(
+            {"name": "gitlab:meta:schema_version", "value": GITLAB_SCHEMA_VERSION}
+        )
+
+        # --- Inject per-component properties ---
+        options = self.config.options
+        enriched_count = 0
+
+        for component in components:
+            gitlab_props = _build_gitlab_properties_for_component(component, options)
+            if gitlab_props:
+                component.setdefault("properties", []).extend(gitlab_props)
+                enriched_count += 1
+
+        ASH_LOGGER.info(
+            f"gitlab-cyclonedx: Enriched {enriched_count}/{len(components)} "
+            f"components with GitLab dependency scanning properties."
+        )
+
+        return json.dumps(doc, separators=(",", ":"))

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1396,6 +1396,17 @@
                 "exclude_suppressed": true
               }
             },
+            "gitlab-cyclonedx": {
+              "enabled": true,
+              "extension": "gl-dependency-scanning-report.cdx.json",
+              "name": "gitlab-cyclonedx",
+              "options": {
+                "category": "production",
+                "input_file_path_override": null,
+                "language_override": null,
+                "package_manager_override": null
+              }
+            },
             "gitlab-sast": {
               "enabled": true,
               "extension": "gl-sast-report.json",
@@ -7462,6 +7473,91 @@
       "title": "GHASReporterConfigOptions",
       "type": "object"
     },
+    "GitLabCycloneDXReporterConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "extension": {
+          "default": "gl-dependency-scanning-report.cdx.json",
+          "title": "Extension",
+          "type": "string"
+        },
+        "name": {
+          "const": "gitlab-cyclonedx",
+          "default": "gitlab-cyclonedx",
+          "title": "Name",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/GitLabCycloneDXReporterConfigOptions",
+          "default": {
+            "category": "production",
+            "input_file_path_override": null,
+            "language_override": null,
+            "package_manager_override": null
+          }
+        }
+      },
+      "title": "GitLabCycloneDXReporterConfig",
+      "type": "object"
+    },
+    "GitLabCycloneDXReporterConfigOptions": {
+      "additionalProperties": true,
+      "description": "Options for the gitlab-cyclonedx reporter.",
+      "properties": {
+        "category": {
+          "default": "production",
+          "description": "Default dependency category injected as gitlab:dependency_scanning:category. Typically 'production' or 'development'.",
+          "title": "Category",
+          "type": "string"
+        },
+        "input_file_path_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected input file path for ALL components. Useful when Syft reports absolute container paths that don't match the repo layout.",
+          "title": "Input File Path Override"
+        },
+        "language_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected language name for ALL components.",
+          "title": "Language Override"
+        },
+        "package_manager_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected package manager name for ALL components. Useful for single-ecosystem repos.",
+          "title": "Package Manager Override"
+        }
+      },
+      "title": "GitLabCycloneDXReporterConfigOptions",
+      "type": "object"
+    },
     "GitLabSASTReporterConfig": {
       "additionalProperties": true,
       "properties": {
@@ -13316,6 +13412,21 @@
             }
           },
           "description": "Configure the options for the GitHub Advanced Security (GHAS) SARIF reporter"
+        },
+        "gitlab-cyclonedx": {
+          "$ref": "#/$defs/GitLabCycloneDXReporterConfig",
+          "default": {
+            "enabled": true,
+            "extension": "gl-dependency-scanning-report.cdx.json",
+            "name": "gitlab-cyclonedx",
+            "options": {
+              "category": "production",
+              "input_file_path_override": null,
+              "language_override": null,
+              "package_manager_override": null
+            }
+          },
+          "description": "Configure the options for the GitLab CycloneDX dependency scanning reporter"
         },
         "gitlab-sast": {
           "$ref": "#/$defs/GitLabSASTReporterConfig",

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -158,6 +158,17 @@
                 "exclude_suppressed": true
               }
             },
+            "gitlab-cyclonedx": {
+              "enabled": true,
+              "extension": "gl-dependency-scanning-report.cdx.json",
+              "name": "gitlab-cyclonedx",
+              "options": {
+                "category": "production",
+                "input_file_path_override": null,
+                "language_override": null,
+                "package_manager_override": null
+              }
+            },
             "gitlab-sast": {
               "enabled": true,
               "extension": "gl-sast-report.json",
@@ -1562,6 +1573,91 @@
       "title": "GHASReporterConfigOptions",
       "type": "object"
     },
+    "GitLabCycloneDXReporterConfig": {
+      "additionalProperties": true,
+      "properties": {
+        "enabled": {
+          "default": true,
+          "title": "Enabled",
+          "type": "boolean"
+        },
+        "extension": {
+          "default": "gl-dependency-scanning-report.cdx.json",
+          "title": "Extension",
+          "type": "string"
+        },
+        "name": {
+          "const": "gitlab-cyclonedx",
+          "default": "gitlab-cyclonedx",
+          "title": "Name",
+          "type": "string"
+        },
+        "options": {
+          "$ref": "#/$defs/GitLabCycloneDXReporterConfigOptions",
+          "default": {
+            "category": "production",
+            "input_file_path_override": null,
+            "language_override": null,
+            "package_manager_override": null
+          }
+        }
+      },
+      "title": "GitLabCycloneDXReporterConfig",
+      "type": "object"
+    },
+    "GitLabCycloneDXReporterConfigOptions": {
+      "additionalProperties": true,
+      "description": "Options for the gitlab-cyclonedx reporter.",
+      "properties": {
+        "category": {
+          "default": "production",
+          "description": "Default dependency category injected as gitlab:dependency_scanning:category. Typically 'production' or 'development'.",
+          "title": "Category",
+          "type": "string"
+        },
+        "input_file_path_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected input file path for ALL components. Useful when Syft reports absolute container paths that don't match the repo layout.",
+          "title": "Input File Path Override"
+        },
+        "language_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected language name for ALL components.",
+          "title": "Language Override"
+        },
+        "package_manager_override": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If set, overrides the auto-detected package manager name for ALL components. Useful for single-ecosystem repos.",
+          "title": "Package Manager Override"
+        }
+      },
+      "title": "GitLabCycloneDXReporterConfigOptions",
+      "type": "object"
+    },
     "GitLabSASTReporterConfig": {
       "additionalProperties": true,
       "properties": {
@@ -2404,6 +2500,21 @@
             }
           },
           "description": "Configure the options for the GitHub Advanced Security (GHAS) SARIF reporter"
+        },
+        "gitlab-cyclonedx": {
+          "$ref": "#/$defs/GitLabCycloneDXReporterConfig",
+          "default": {
+            "enabled": true,
+            "extension": "gl-dependency-scanning-report.cdx.json",
+            "name": "gitlab-cyclonedx",
+            "options": {
+              "category": "production",
+              "input_file_path_override": null,
+              "language_override": null,
+              "package_manager_override": null
+            }
+          },
+          "description": "Configure the options for the GitLab CycloneDX dependency scanning reporter"
         },
         "gitlab-sast": {
           "$ref": "#/$defs/GitLabSASTReporterConfig",

--- a/tests/unit/reporters/test_gitlab_cyclonedx_reporter.py
+++ b/tests/unit/reporters/test_gitlab_cyclonedx_reporter.py
@@ -1,0 +1,146 @@
+"""Smoke tests for the gitlab-cyclonedx reporter."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.config.ash_config import AshConfig  # noqa: F401
+from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_cyclonedx_reporter import (
+    GitLabCycloneDXReporter,
+    GitLabCycloneDXReporterConfig,
+    _extract_purl_type,
+    _normalize_input_file_path,
+    _resolve_package_manager_and_language,
+    GitLabCycloneDXReporterConfigOptions,
+)
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.base.plugin_context import PluginContext
+
+AshAggregatedResults.model_rebuild()
+
+
+@pytest.fixture
+def model():
+    fixture_path = Path("tests/test_data/outputs/ash_aggregated_results.json")
+    with open(fixture_path) as f:
+        raw = json.load(f)
+    return AshAggregatedResults.model_validate(raw)
+
+
+@pytest.fixture
+def reporter(tmp_path):
+    ctx = PluginContext(source_dir=Path("."), output_dir=tmp_path)
+    return GitLabCycloneDXReporter(context=ctx, config=GitLabCycloneDXReporterConfig())
+
+
+def test_report_produces_output(reporter, model):
+    result = reporter.report(model)
+    assert result is not None
+
+
+def test_schema_version_injected(reporter, model):
+    result = reporter.report(model)
+    doc = json.loads(result)
+    meta_props = doc["metadata"]["properties"]
+    schema_props = [p for p in meta_props if p["name"] == "gitlab:meta:schema_version"]
+    assert len(schema_props) == 1
+    assert schema_props[0]["value"] == "1"
+
+
+def test_components_have_category(reporter, model):
+    result = reporter.report(model)
+    doc = json.loads(result)
+    first = doc["components"][0]
+    cats = [
+        p
+        for p in first["properties"]
+        if p["name"] == "gitlab:dependency_scanning:category"
+    ]
+    assert len(cats) == 1
+    assert cats[0]["value"] == "production"
+
+
+def test_components_have_package_manager(reporter, model):
+    result = reporter.report(model)
+    doc = json.loads(result)
+    first = doc["components"][0]
+    pms = [
+        p
+        for p in first["properties"]
+        if p["name"] == "gitlab:dependency_scanning:package_manager:name"
+    ]
+    assert len(pms) == 1
+    assert pms[0]["value"] == "npm"
+
+
+def test_components_have_input_file_path(reporter, model):
+    result = reporter.report(model)
+    doc = json.loads(result)
+    first = doc["components"][0]
+    paths = [
+        p
+        for p in first["properties"]
+        if p["name"] == "gitlab:dependency_scanning:input_file:path"
+    ]
+    assert len(paths) == 1
+    assert paths[0]["value"] == "yarn.lock"
+
+
+def test_returns_none_when_no_components(reporter):
+    model = AshAggregatedResults()
+    result = reporter.report(model)
+    assert result is None
+
+
+def test_extract_purl_type():
+    assert _extract_purl_type("pkg:npm/%40antfu/install-pkg@1.0.0") == "npm"
+    assert _extract_purl_type("pkg:pypi/requests@2.31.0") == "pypi"
+    assert _extract_purl_type("pkg:golang/github.com/foo/bar@v1.0.0") == "golang"
+    assert _extract_purl_type(None) is None
+    assert _extract_purl_type("") is None
+    assert _extract_purl_type("not-a-purl") is None
+
+
+def test_normalize_input_file_path():
+    assert (
+        _normalize_input_file_path(
+            "/.venv/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock"
+        )
+        == "yarn.lock"
+    )
+    assert _normalize_input_file_path("/app/go.sum") == "app/go.sum"
+    assert _normalize_input_file_path(None) is None
+    assert _normalize_input_file_path("") is None
+
+
+def test_resolve_package_manager_syft_type():
+    component = {
+        "properties": [{"name": "syft:package:type", "value": "python"}],
+        "purl": "pkg:pypi/requests@2.31.0",
+    }
+    options = GitLabCycloneDXReporterConfigOptions()
+    pm, lang = _resolve_package_manager_and_language(component, options)
+    assert pm == "pip"
+    assert lang == "Python"
+
+
+def test_resolve_package_manager_purl_fallback():
+    component = {"properties": [], "purl": "pkg:cargo/serde@1.0.0"}
+    options = GitLabCycloneDXReporterConfigOptions()
+    pm, lang = _resolve_package_manager_and_language(component, options)
+    assert pm == "cargo"
+    assert lang == "Rust"
+
+
+def test_resolve_package_manager_override():
+    component = {
+        "properties": [{"name": "syft:package:type", "value": "npm"}],
+        "purl": "pkg:npm/foo@1.0.0",
+    }
+    options = GitLabCycloneDXReporterConfigOptions(
+        package_manager_override="yarn", language_override="TypeScript"
+    )
+    pm, lang = _resolve_package_manager_and_language(component, options)
+    assert pm == "yarn"
+    assert lang == "TypeScript"


### PR DESCRIPTION
## Summary

- Add gitlab-cyclonedx reporter that generates CycloneDX BOM output enriched with GitLab Dependency List properties
- Wrap all network-dependent Dockerfile installs with `with-retry` (3 attempts, exponential backoff) to handle transient CDN flakiness

## GitLab CycloneDX reporter

Generates a CycloneDX BOM with GitLab-specific properties injected per-component:
- `gitlab:meta:schema_version` (metadata level)
- `gitlab:dependency_scanning:category`
- `gitlab:dependency_scanning:package_manager:name`
- `gitlab:dependency_scanning:language:name`
- `gitlab:dependency_scanning:input_file:path`

Resolution priority for package manager/language: config overrides > syft:package:type property > PURL type.

## Dockerfile reliability changes

- Wrap curl-based installs: uv, pip, yarn, pnpm, syft, grype, trivy, nodesource GPG key, semgrep rulesets
- Wrap package manager installs: gem (cfn-nag), npm
- Add `set -o pipefail` to `with-retry.sh` so pipe failures propagate
- Fix GPG key pipe placed inside retry scope (prevents partial-data corruption)
- Fix OFFLINE semgrep loop quoting (pre-compute outfile to avoid nested escape cascade)
- Fix `assets/Dockerfile` COPY paths for pip-installed build context

## Test plan

- [x] CycloneDX/GitLab reporter tests pass (45 tests)
- [x] Reporter returns None gracefully when no CycloneDX data exists
- [x] `with-retry.sh` syntax valid, `set -o pipefail` present
- [x] OFFLINE semgrep loop produces correct filenames (ci.yml, security-audit.yml, python.yml)
- [x] Dockerfile passes `docker build --check` syntax validation
- [x] `assets/Dockerfile` uses relative COPY path, root uses full path
- [x] GPG key pipe is inside retry scope in both Dockerfiles
- [ ] CI container build jobs pass (yarnpkg.com CDN dependent)
- [ ] OFFLINE=YES Docker build succeeds end-to-end