### PR TITLE
feat: config lint command

### DIFF
--- a/.github/workflows/ash-create-release.yml
+++ b/.github/workflows/ash-create-release.yml
@@ -62,6 +62,17 @@ jobs:
         if: steps.bump.outputs.bumped == 'true'
         run: uv run python scripts/version_template_manager.py generate
 
+      - name: Regenerate JSON schemas
+        if: steps.bump.outputs.bumped == 'true'
+        run: uv run python -m automated_security_helper.schemas.generate_schemas
+
+      - name: Smoke test release artifacts
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          uv run ash --help
+          uv run ash config validate
+          uv run python -m pytest tests/unit/cli/test_config_init.py -x -q --no-header
+
       - name: Create release PR
         if: steps.bump.outputs.bumped == 'true'
         env:

--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -400,6 +400,294 @@ def validate_plugin_dependencies(
         sys.exit(1)
 
 
+@config_app.command()
+def lint(
+    config: Annotated[
+        str,
+        typer.Option(
+            "--config",
+            "-c",
+            help="The path to the configuration file to lint. By default, ASH looks for config files in .ash/.ash.yaml",
+            envvar="ASH_CONFIG",
+        ),
+    ] = ".ash/.ash.yaml",
+    output_dir: Annotated[
+        str,
+        typer.Option(
+            "--output-dir",
+            "-o",
+            help="Path to the ASH output directory (for unused suppressions report). Defaults to .ash/ash_output",
+        ),
+    ] = None,
+    fix: Annotated[
+        bool,
+        typer.Option(
+            "--fix",
+            help="Auto-fix fixable issues (internal fields, missing line_end, expired suppressions)",
+        ),
+    ] = False,
+    fix_unused: Annotated[
+        bool,
+        typer.Option(
+            "--fix-unused",
+            help="Remove unused suppressions based on the last scan's unused suppressions report",
+        ),
+    ] = False,
+    non_interactive: Annotated[
+        bool,
+        typer.Option(
+            "--non-interactive",
+            "--yes",
+            "-y",
+            help="Accept all changes without prompting. Useful for pre-commit hooks and CI/CD",
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Enable verbose logging")
+    ] = False,
+    debug: Annotated[
+        bool, typer.Option("--debug", "-d", help="Enable debug logging")
+    ] = False,
+    color: Annotated[bool, typer.Option(help="Enable/disable colorized output")] = True,
+):
+    """Lint an ASH configuration file for issues and optionally auto-fix them.
+
+    This command performs all validation checks plus additional lint checks:
+    - Internal-only fields in scanners/reporters/converters
+    - Invalid or unknown top-level sections
+    - Duplicate field definitions
+    - Suppressions with line_start but missing line_end
+    - Expired suppressions
+    - Unused suppressions (from last scan report)
+
+    Use --fix to auto-fix common issues (removes internal fields, sets missing
+    line_end, removes expired suppressions).
+
+    Use --fix-unused to remove suppressions that are no longer matching any
+    findings (based on the unused suppressions report from the last scan).
+
+    Use --non-interactive (or --yes/-y) to skip confirmation prompts. This is
+    useful for pre-commit hooks or CI/CD pipelines.
+
+    Examples:
+        # Lint the default config
+        ash config lint
+
+        # Lint and auto-fix issues
+        ash config lint --fix
+
+        # Lint, fix, and remove unused suppressions
+        ash config lint --fix --fix-unused
+
+        # Non-interactive mode for pre-commit
+        ash config lint --fix --fix-unused --non-interactive
+
+        # Lint a specific config file
+        ash config lint --config path/to/config.yaml
+    """
+    from automated_security_helper.config.config_linter import (
+        ConfigLinter,
+        LintSeverity,
+    )
+
+    # Setup logging
+    get_logger(
+        name="ash.cli.config.lint",
+        level=logging.DEBUG
+        if debug
+        else (logging.INFO if verbose else logging.WARNING),
+        show_progress=False,
+        use_color=color,
+    )
+
+    config_path = Path(config)
+    output_dir_path = Path(output_dir) if output_dir else None
+
+    if not config_path.exists():
+        typer.secho(f"❌ Config file not found: {config_path}", fg=typer.colors.RED)
+        raise typer.Exit(1)
+
+    typer.secho(f"Linting configuration file: {config_path}", fg=typer.colors.BLUE)
+
+    # Run lint checks
+    lint_result = ConfigLinter.lint(
+        config_path=config_path,
+        output_dir=output_dir_path,
+        check_unused=fix_unused,  # Only check unused when explicitly requested
+    )
+
+    # Display issues
+    if not lint_result.issues:
+        typer.secho(
+            "✅ Configuration is clean! No issues found.", fg=typer.colors.GREEN
+        )
+        return
+
+    # Print all issues
+    typer.secho(
+        f"\nFound {len(lint_result.issues)} issue(s):",
+        fg=typer.colors.YELLOW,
+    )
+    for issue in lint_result.issues:
+        fg = {
+            LintSeverity.ERROR: typer.colors.RED,
+            LintSeverity.WARNING: typer.colors.YELLOW,
+            LintSeverity.INFO: typer.colors.CYAN,
+        }[issue.severity]
+        typer.secho(f"  {issue}", fg=fg)
+
+    typer.echo("")
+
+    # Summary
+    if lint_result.error_count:
+        typer.secho(f"  Errors: {lint_result.error_count}", fg=typer.colors.RED)
+    if lint_result.warning_count:
+        typer.secho(f"  Warnings: {lint_result.warning_count}", fg=typer.colors.YELLOW)
+    if lint_result.info_count:
+        typer.secho(f"  Info: {lint_result.info_count}", fg=typer.colors.CYAN)
+
+    fixable_count = len(lint_result.fixable_issues)
+    if fixable_count and not fix and not fix_unused:
+        typer.secho(
+            f"\n💡 {fixable_count} issue(s) can be auto-fixed. Run with --fix to apply fixes.",
+            fg=typer.colors.YELLOW,
+        )
+
+    # Apply fixes if requested
+    if fix:
+        _apply_fixes(config_path, lint_result, non_interactive, color)
+
+    # Apply unused suppression removal if requested
+    if fix_unused:
+        _apply_unused_fixes(config_path, output_dir_path, non_interactive, color)
+
+    # Exit with error code if there are unfixed errors
+    if not fix and not fix_unused and lint_result.has_errors:
+        raise typer.Exit(1)
+
+
+def _apply_fixes(
+    config_path: Path,
+    lint_result,
+    non_interactive: bool,
+    color: bool,
+) -> None:
+    """Apply auto-fixes to the config file."""
+    from automated_security_helper.config.config_linter import (
+        ConfigLinter,
+        LintCategory,
+    )
+
+    fixable = [
+        i
+        for i in lint_result.fixable_issues
+        if i.category != LintCategory.SUPPRESSION_UNUSED
+    ]
+
+    if not fixable:
+        typer.secho(
+            "No fixable issues found (excluding unused suppressions).",
+            fg=typer.colors.GREEN,
+        )
+        return
+
+    typer.secho(f"\n🔧 Fixing {len(fixable)} issue(s):", fg=typer.colors.BLUE)
+    for issue in fixable:
+        typer.secho(f"  • {issue.fix_description}", fg=typer.colors.CYAN)
+
+    if not non_interactive:
+        confirm = typer.confirm("\nApply these fixes?")
+        if not confirm:
+            typer.secho("Aborted.", fg=typer.colors.YELLOW)
+            raise typer.Exit(0)
+
+    fixed_content, fixed_issues = ConfigLinter.fix(config_path, fixable)
+
+    if fixed_issues:
+        config_path.write_text(fixed_content, encoding="utf-8")
+        typer.secho(
+            f"\n✅ Fixed {len(fixed_issues)} issue(s) in {config_path}",
+            fg=typer.colors.GREEN,
+        )
+    else:
+        typer.secho("No issues were fixed.", fg=typer.colors.YELLOW)
+
+
+def _apply_unused_fixes(
+    config_path: Path,
+    output_dir,
+    non_interactive: bool,
+    color: bool,
+) -> None:
+    """Remove unused suppressions from the config file."""
+    from automated_security_helper.config.config_linter import ConfigLinter
+
+    # Check report age first
+    report_info = ConfigLinter.get_unused_report_age(config_path, output_dir)
+
+    if report_info is None:
+        typer.secho(
+            "⚠️  No unused suppressions report found. Run a scan first to generate the report.",
+            fg=typer.colors.YELLOW,
+        )
+        return
+
+    report_path, report_timestamp, age_seconds = report_info
+
+    # Warn if report is too old
+    if age_seconds > ConfigLinter.MAX_REPORT_AGE_SECONDS:
+        age_hours = age_seconds / 3600
+        typer.secho(
+            f"\n⚠️  WARNING: The unused suppressions report is {age_hours:.1f} hours old "
+            f"(generated at {report_timestamp.strftime('%Y-%m-%d %H:%M:%S')}).",
+            fg=typer.colors.YELLOW,
+        )
+        typer.secho(
+            "   Results may not reflect the current state of your codebase.",
+            fg=typer.colors.YELLOW,
+        )
+        typer.secho(
+            "   Consider running a fresh scan: ash scan",
+            fg=typer.colors.YELLOW,
+        )
+
+        if not non_interactive:
+            confirm = typer.confirm(
+                "\nProceed with removing unused suppressions based on this old report?"
+            )
+            if not confirm:
+                typer.secho("Aborted.", fg=typer.colors.YELLOW)
+                raise typer.Exit(0)
+
+    # Perform the fix
+    fixed_content, fixed_issues, _ = ConfigLinter.fix_unused_suppressions(
+        config_path, output_dir
+    )
+
+    if not fixed_issues:
+        typer.secho("✅ No unused suppressions to remove.", fg=typer.colors.GREEN)
+        return
+
+    typer.secho(
+        f"\n🗑️  Removing {len(fixed_issues)} unused suppression(s):",
+        fg=typer.colors.BLUE,
+    )
+    for issue in fixed_issues:
+        typer.secho(f"  • {issue.message}", fg=typer.colors.CYAN)
+
+    if not non_interactive:
+        confirm = typer.confirm("\nRemove these unused suppressions?")
+        if not confirm:
+            typer.secho("Aborted.", fg=typer.colors.YELLOW)
+            raise typer.Exit(0)
+
+    config_path.write_text(fixed_content, encoding="utf-8")
+    typer.secho(
+        f"\n✅ Removed {len(fixed_issues)} unused suppression(s) from {config_path}",
+        fg=typer.colors.GREEN,
+    )
+
+
 if __name__ == "__main__":
     config_app()
 

--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -430,7 +430,7 @@ def lint(
         bool,
         typer.Option(
             "--fix-unused",
-            help="Remove unused suppressions based on the last scan's unused suppressions report",
+            help="Comment out unused suppressions based on the last scan's unused suppressions report",
         ),
     ] = False,
     non_interactive: Annotated[
@@ -619,7 +619,7 @@ def _apply_unused_fixes(
     non_interactive: bool,
     color: bool,
 ) -> None:
-    """Remove unused suppressions from the config file."""
+    """Comment out unused suppressions in the config file."""
     from automated_security_helper.config.config_linter import ConfigLinter
 
     # Check report age first
@@ -653,7 +653,7 @@ def _apply_unused_fixes(
 
         if not non_interactive:
             confirm = typer.confirm(
-                "\nProceed with removing unused suppressions based on this old report?"
+                "\nProceed with commenting out unused suppressions based on this old report?"
             )
             if not confirm:
                 typer.secho("Aborted.", fg=typer.colors.YELLOW)
@@ -665,25 +665,25 @@ def _apply_unused_fixes(
     )
 
     if not fixed_issues:
-        typer.secho("✅ No unused suppressions to remove.", fg=typer.colors.GREEN)
+        typer.secho("✅ No unused suppressions to comment out.", fg=typer.colors.GREEN)
         return
 
     typer.secho(
-        f"\n🗑️  Removing {len(fixed_issues)} unused suppression(s):",
+        f"\n💬 Commenting out {len(fixed_issues)} unused suppression(s):",
         fg=typer.colors.BLUE,
     )
     for issue in fixed_issues:
         typer.secho(f"  • {issue.message}", fg=typer.colors.CYAN)
 
     if not non_interactive:
-        confirm = typer.confirm("\nRemove these unused suppressions?")
+        confirm = typer.confirm("\nComment out these unused suppressions?")
         if not confirm:
             typer.secho("Aborted.", fg=typer.colors.YELLOW)
             raise typer.Exit(0)
 
     config_path.write_text(fixed_content, encoding="utf-8")
     typer.secho(
-        f"\n✅ Removed {len(fixed_issues)} unused suppression(s) from {config_path}",
+        f"\n✅ Commented out {len(fixed_issues)} unused suppression(s) in {config_path}",
         fg=typer.colors.GREEN,
     )
 

--- a/automated_security_helper/config/ash_config.py
+++ b/automated_security_helper/config/ash_config.py
@@ -443,6 +443,9 @@ class AshConfig(BaseModel):
         extra="ignore",
     )
 
+    # Internal field to track config resolution warnings (not serialized)
+    _resolution_warnings: List[str] = []
+
     # Project information
     project_name: Annotated[
         str,

--- a/automated_security_helper/config/config_linter.py
+++ b/automated_security_helper/config/config_linter.py
@@ -229,14 +229,19 @@ class ConfigLinter:
         config_path: Path,
         output_dir: Optional[Path] = None,
     ) -> Tuple[str, List[LintIssue], Optional[datetime]]:
-        """Remove unused suppressions from the config based on the unused suppressions report.
+        """Comment out unused suppressions in the config based on the unused suppressions report.
+
+        Instead of removing unused suppressions entirely, this method comments them out
+        with a note including the date and reason. This is safer because a suppression
+        that appears unused in local mode might be needed in CI where different scanners
+        are available.
 
         Args:
             config_path: Path to the configuration file
             output_dir: Path to the ASH output directory
 
         Returns:
-            Tuple of (fixed_content, list_of_removed_suppressions, report_timestamp)
+            Tuple of (fixed_content, list_of_commented_suppressions, report_timestamp)
         """
         config_data = cls._load_config(config_path)
         raw_content = config_path.read_text(encoding="utf-8")
@@ -255,44 +260,151 @@ class ConfigLinter:
         if not unused_suppressions:
             return raw_content, [], report_timestamp
 
-        # Remove unused suppressions from config
-        fixed_issues: List[LintIssue] = []
-        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
-
         # Build a set of unused suppression identifiers for matching
         unused_ids = set()
         for unused in unused_suppressions:
             unused_id = cls._make_suppression_id(unused)
             unused_ids.add(unused_id)
 
-        # Filter out unused suppressions
-        remaining_suppressions = []
+        # Work with the raw YAML lines to comment out unused suppressions
+        fixed_issues: List[LintIssue] = []
+        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
+
+        # Identify which suppression indices are unused
+        unused_indices = set()
         for i, suppression in enumerate(suppressions):
             supp_id = cls._make_suppression_id(suppression)
             if supp_id in unused_ids:
+                unused_indices.add(i)
                 fixed_issues.append(
                     LintIssue(
                         severity=LintSeverity.INFO,
                         category=LintCategory.SUPPRESSION_UNUSED,
-                        message=f"Removed unused suppression: path='{suppression.get('path', '')}', rule_id='{suppression.get('rule_id', '*')}'",
+                        message=f"Commented out unused suppression: path='{suppression.get('path', '')}', rule_id='{suppression.get('rule_id', '*')}'",
                         path=f"global_settings.suppressions[{i}]",
                         fixable=True,
-                        fix_description="Remove unused suppression",
+                        fix_description="Comment out unused suppression",
                     )
                 )
-            else:
-                remaining_suppressions.append(suppression)
 
-        # Update the config data
-        if "global_settings" in config_data:
-            config_data["global_settings"]["suppressions"] = remaining_suppressions
+        if not unused_indices:
+            return raw_content, [], report_timestamp
 
-        # Generate the fixed content
-        fixed_content = cls._generate_config_content(
-            config_path, raw_content, config_data
+        # Comment out the unused suppressions in the raw YAML
+        today = datetime.now().strftime("%Y-%m-%d")
+        fixed_content = cls._comment_out_suppressions(
+            raw_content, suppressions, unused_indices, today
         )
 
         return fixed_content, fixed_issues, report_timestamp
+
+    @classmethod
+    def _comment_out_suppressions(
+        cls,
+        raw_content: str,
+        suppressions: List[Dict[str, Any]],
+        unused_indices: set,
+        date_str: str,
+    ) -> str:
+        """Comment out specific suppressions in the raw YAML content.
+
+        Finds each suppression block in the YAML and comments it out with a note.
+        """
+        lines = raw_content.split("\n")
+        result_lines = []
+
+        # Find the suppressions list in the YAML by locating suppression entries
+        # Each suppression starts with "- path:" at the appropriate indentation
+        in_suppressions_section = False
+        current_suppression_idx = -1
+        suppression_indent = None
+        i = 0
+
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.lstrip()
+
+            # Detect entry into the suppressions section
+            if stripped.startswith("suppressions:") and not stripped.startswith("#"):
+                in_suppressions_section = True
+                current_suppression_idx = -1
+                suppression_indent = None
+                result_lines.append(line)
+                i += 1
+                continue
+
+            # If we're in the suppressions section, look for list items
+            if in_suppressions_section:
+                # Detect end of suppressions section (less or equal indentation, non-empty, non-comment)
+                if stripped and not stripped.startswith("#"):
+                    line_indent = len(line) - len(line.lstrip())
+                    if suppression_indent is not None and line_indent <= (
+                        suppression_indent - 2
+                    ):
+                        # We've left the suppressions section
+                        in_suppressions_section = False
+                        result_lines.append(line)
+                        i += 1
+                        continue
+
+                # Detect a new suppression entry (starts with "- ")
+                if stripped.startswith("- ") and not stripped.startswith("#"):
+                    current_suppression_idx += 1
+                    if suppression_indent is None:
+                        suppression_indent = len(line) - len(line.lstrip())
+
+                    if current_suppression_idx in unused_indices:
+                        # Comment out this entire suppression block
+                        comment_note = f"{' ' * suppression_indent}# [ash-lint {date_str}] Commented out: unused suppression (not matched in last scan)"
+                        result_lines.append(comment_note)
+
+                        # Comment out the first line of the suppression
+                        result_lines.append(f"{' ' * suppression_indent}# {stripped}")
+                        i += 1
+
+                        # Comment out continuation lines (indented more than the "- " line)
+                        while i < len(lines):
+                            next_line = lines[i]
+                            next_stripped = next_line.lstrip()
+                            next_indent = len(next_line) - len(next_line.lstrip())
+
+                            # Stop if we hit another list item at same level, a blank line
+                            # followed by non-continuation, or less indentation
+                            if next_stripped == "":
+                                result_lines.append(next_line)
+                                i += 1
+                                continue
+                            if (
+                                next_stripped.startswith("- ")
+                                and next_indent <= suppression_indent
+                            ):
+                                break
+                            if (
+                                next_indent <= suppression_indent
+                                and not next_stripped.startswith("#")
+                            ):
+                                break
+
+                            # Comment out this continuation line
+                            result_lines.append(
+                                f"{' ' * suppression_indent}# {next_stripped}"
+                            )
+                            i += 1
+                        continue
+                    else:
+                        result_lines.append(line)
+                        i += 1
+                        continue
+                else:
+                    result_lines.append(line)
+                    i += 1
+                    continue
+            else:
+                result_lines.append(line)
+                i += 1
+                continue
+
+        return "\n".join(result_lines)
 
     @classmethod
     def get_unused_report_age(

--- a/automated_security_helper/config/config_linter.py
+++ b/automated_security_helper/config/config_linter.py
@@ -1,0 +1,741 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration linting utilities for ASH.
+
+Provides lint checks that go beyond basic validation, including:
+- All checks from ConfigValidator (internal fields, invalid sections, etc.)
+- Suppression issues (missing line_end when line_start is present)
+- Expired suppressions
+- Auto-fix capabilities for common issues
+- Unused suppression removal based on scan reports
+"""
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from automated_security_helper.config.config_validator import ConfigValidator
+
+logger = logging.getLogger(__name__)
+
+
+class LintSeverity(str, Enum):
+    """Severity level for lint issues."""
+
+    ERROR = "error"
+    WARNING = "warning"
+    INFO = "info"
+
+
+class LintCategory(str, Enum):
+    """Category of lint issue."""
+
+    INTERNAL_FIELD = "internal-field"
+    INVALID_SECTION = "invalid-section"
+    MISSING_FIELD = "missing-field"
+    UNKNOWN_FIELD = "unknown-field"
+    DUPLICATE_FIELD = "duplicate-field"
+    SUPPRESSION_LINE_RANGE = "suppression-line-range"
+    SUPPRESSION_EXPIRED = "suppression-expired"
+    SUPPRESSION_UNUSED = "suppression-unused"
+    SYNTAX_ERROR = "syntax-error"
+
+
+@dataclass
+class LintIssue:
+    """Represents a single lint issue found in the config."""
+
+    severity: LintSeverity
+    category: LintCategory
+    message: str
+    path: str = ""  # dot-notation path in config (e.g., "scanners.bandit.name")
+    fixable: bool = False
+    fix_description: str = ""
+
+    def __str__(self) -> str:
+        prefix = {
+            LintSeverity.ERROR: "❌",
+            LintSeverity.WARNING: "⚠️ ",
+            LintSeverity.INFO: "ℹ️ ",
+        }[self.severity]
+        fix_hint = " [auto-fixable]" if self.fixable else ""
+        path_hint = f" at '{self.path}'" if self.path else ""
+        return f"{prefix} {self.message}{path_hint}{fix_hint}"
+
+
+@dataclass
+class LintResult:
+    """Result of a lint operation."""
+
+    issues: List[LintIssue] = field(default_factory=list)
+    config_path: Optional[Path] = None
+
+    @property
+    def has_errors(self) -> bool:
+        return any(i.severity == LintSeverity.ERROR for i in self.issues)
+
+    @property
+    def has_warnings(self) -> bool:
+        return any(i.severity == LintSeverity.WARNING for i in self.issues)
+
+    @property
+    def fixable_issues(self) -> List[LintIssue]:
+        return [i for i in self.issues if i.fixable]
+
+    @property
+    def error_count(self) -> int:
+        return sum(1 for i in self.issues if i.severity == LintSeverity.ERROR)
+
+    @property
+    def warning_count(self) -> int:
+        return sum(1 for i in self.issues if i.severity == LintSeverity.WARNING)
+
+    @property
+    def info_count(self) -> int:
+        return sum(1 for i in self.issues if i.severity == LintSeverity.INFO)
+
+
+class ConfigLinter:
+    """Lints ASH configuration files for issues and can auto-fix them."""
+
+    # Default output directory relative to project root
+    DEFAULT_OUTPUT_DIR = ".ash/ash_output"
+    UNUSED_SUPPRESSIONS_REPORT = "reports/ash.unused-suppressions.json"
+
+    # Maximum age (in seconds) for the unused suppressions report before warning
+    MAX_REPORT_AGE_SECONDS = 3600  # 1 hour
+
+    @classmethod
+    def lint(
+        cls,
+        config_path: Path,
+        output_dir: Optional[Path] = None,
+        check_unused: bool = False,
+    ) -> LintResult:
+        """Lint a configuration file and return all issues found.
+
+        Args:
+            config_path: Path to the configuration file
+            output_dir: Path to the ASH output directory (for unused suppressions check)
+            check_unused: Whether to check for unused suppressions
+
+        Returns:
+            LintResult with all issues found
+        """
+        result = LintResult(config_path=config_path)
+
+        # Load the raw config data
+        try:
+            config_data = cls._load_config(config_path)
+        except Exception as e:
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.ERROR,
+                    category=LintCategory.SYNTAX_ERROR,
+                    message=f"Failed to parse config file: {e}",
+                )
+            )
+            return result
+
+        # Run validation checks (same as `ash config validate`)
+        cls._check_validation_issues(config_path, config_data, result)
+
+        # Run suppression-specific lint checks
+        cls._check_suppression_issues(config_data, result)
+
+        # Check for unused suppressions if requested
+        if check_unused:
+            cls._check_unused_suppressions(config_path, config_data, output_dir, result)
+
+        return result
+
+    @classmethod
+    def fix(
+        cls,
+        config_path: Path,
+        issues: Optional[List[LintIssue]] = None,
+    ) -> Tuple[str, List[LintIssue]]:
+        """Auto-fix fixable issues in the config file.
+
+        Args:
+            config_path: Path to the configuration file
+            issues: Pre-computed issues to fix (if None, will re-lint)
+
+        Returns:
+            Tuple of (fixed_content, list_of_fixed_issues)
+        """
+        config_data = cls._load_config(config_path)
+        raw_content = config_path.read_text(encoding="utf-8")
+
+        if issues is None:
+            lint_result = cls.lint(config_path)
+            issues = lint_result.fixable_issues
+
+        fixed_issues: List[LintIssue] = []
+
+        # Separate removal operations from in-place modifications.
+        # Removals must be processed in reverse index order to avoid shifting.
+        removal_issues = []
+        modification_issues = []
+
+        for issue in issues:
+            if not issue.fixable:
+                continue
+            if issue.category in (LintCategory.SUPPRESSION_EXPIRED,):
+                removal_issues.append(issue)
+            else:
+                modification_issues.append(issue)
+
+        # Apply in-place modifications first (these don't shift indices)
+        for issue in modification_issues:
+            if issue.category == LintCategory.INTERNAL_FIELD:
+                if cls._fix_internal_field(config_data, issue):
+                    fixed_issues.append(issue)
+
+            elif issue.category == LintCategory.INVALID_SECTION:
+                if cls._fix_invalid_section(config_data, issue):
+                    fixed_issues.append(issue)
+
+            elif issue.category == LintCategory.SUPPRESSION_LINE_RANGE:
+                if cls._fix_suppression_line_range(config_data, issue):
+                    fixed_issues.append(issue)
+
+        # Apply removals in reverse index order to preserve indices
+        removal_issues.sort(
+            key=lambda i: cls._parse_suppression_index(i.path) or 0, reverse=True
+        )
+        for issue in removal_issues:
+            if issue.category == LintCategory.SUPPRESSION_EXPIRED:
+                if cls._fix_expired_suppression(config_data, issue):
+                    fixed_issues.append(issue)
+
+        # Generate the fixed content
+        fixed_content = cls._generate_config_content(
+            config_path, raw_content, config_data
+        )
+
+        return fixed_content, fixed_issues
+
+    @classmethod
+    def fix_unused_suppressions(
+        cls,
+        config_path: Path,
+        output_dir: Optional[Path] = None,
+    ) -> Tuple[str, List[LintIssue], Optional[datetime]]:
+        """Remove unused suppressions from the config based on the unused suppressions report.
+
+        Args:
+            config_path: Path to the configuration file
+            output_dir: Path to the ASH output directory
+
+        Returns:
+            Tuple of (fixed_content, list_of_removed_suppressions, report_timestamp)
+        """
+        config_data = cls._load_config(config_path)
+        raw_content = config_path.read_text(encoding="utf-8")
+
+        # Find the unused suppressions report
+        report_path, report_timestamp = cls._find_unused_report(config_path, output_dir)
+
+        if report_path is None:
+            return raw_content, [], None
+
+        # Load the report
+        with open(report_path, "r", encoding="utf-8") as f:
+            report_data = json.load(f)
+
+        unused_suppressions = report_data.get("unused_suppressions", [])
+        if not unused_suppressions:
+            return raw_content, [], report_timestamp
+
+        # Remove unused suppressions from config
+        fixed_issues: List[LintIssue] = []
+        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
+
+        # Build a set of unused suppression identifiers for matching
+        unused_ids = set()
+        for unused in unused_suppressions:
+            unused_id = cls._make_suppression_id(unused)
+            unused_ids.add(unused_id)
+
+        # Filter out unused suppressions
+        remaining_suppressions = []
+        for i, suppression in enumerate(suppressions):
+            supp_id = cls._make_suppression_id(suppression)
+            if supp_id in unused_ids:
+                fixed_issues.append(
+                    LintIssue(
+                        severity=LintSeverity.INFO,
+                        category=LintCategory.SUPPRESSION_UNUSED,
+                        message=f"Removed unused suppression: path='{suppression.get('path', '')}', rule_id='{suppression.get('rule_id', '*')}'",
+                        path=f"global_settings.suppressions[{i}]",
+                        fixable=True,
+                        fix_description="Remove unused suppression",
+                    )
+                )
+            else:
+                remaining_suppressions.append(suppression)
+
+        # Update the config data
+        if "global_settings" in config_data:
+            config_data["global_settings"]["suppressions"] = remaining_suppressions
+
+        # Generate the fixed content
+        fixed_content = cls._generate_config_content(
+            config_path, raw_content, config_data
+        )
+
+        return fixed_content, fixed_issues, report_timestamp
+
+    @classmethod
+    def get_unused_report_age(
+        cls,
+        config_path: Path,
+        output_dir: Optional[Path] = None,
+    ) -> Optional[Tuple[Path, datetime, float]]:
+        """Get the age of the unused suppressions report.
+
+        Returns:
+            Tuple of (report_path, report_timestamp, age_in_seconds) or None if not found
+        """
+        report_path, report_timestamp = cls._find_unused_report(config_path, output_dir)
+        if report_path is None or report_timestamp is None:
+            return None
+
+        age_seconds = (datetime.now() - report_timestamp).total_seconds()
+        return report_path, report_timestamp, age_seconds
+
+    # -------------------------------------------------------------------------
+    # Private helpers
+    # -------------------------------------------------------------------------
+
+    @classmethod
+    def _load_config(cls, config_path: Path) -> Dict[str, Any]:
+        """Load and parse a config file."""
+        with open(config_path, "r", encoding="utf-8") as f:
+            if str(config_path).endswith(".json"):
+                return json.load(f)
+            else:
+                return yaml.safe_load(f) or {}
+
+    @classmethod
+    def _check_validation_issues(
+        cls, config_path: Path, config_data: Dict[str, Any], result: LintResult
+    ) -> None:
+        """Run the same checks as ConfigValidator but produce LintIssues."""
+        if not isinstance(config_data, dict):
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.ERROR,
+                    category=LintCategory.SYNTAX_ERROR,
+                    message=f"Configuration must be a dictionary/object, got {type(config_data).__name__}",
+                )
+            )
+            return
+
+        # Check for required fields
+        for field_name in ConfigValidator.REQUIRED_TOP_LEVEL_FIELDS:
+            if field_name not in config_data:
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.ERROR,
+                        category=LintCategory.MISSING_FIELD,
+                        message=f"Missing required top-level field: '{field_name}'",
+                        path=field_name,
+                    )
+                )
+
+        # Check for invalid top-level fields
+        for field_name in config_data.keys():
+            if field_name in ConfigValidator.INVALID_TOP_LEVEL_FIELDS:
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.ERROR,
+                        category=LintCategory.INVALID_SECTION,
+                        message=f"Invalid top-level field '{field_name}' - this is an internal field and should not be in user configs",
+                        path=field_name,
+                        fixable=True,
+                        fix_description=f"Remove internal field '{field_name}'",
+                    )
+                )
+            elif field_name not in ConfigValidator.VALID_TOP_LEVEL_FIELDS:
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.WARNING,
+                        category=LintCategory.UNKNOWN_FIELD,
+                        message=f"Unknown top-level field '{field_name}' - may cause parsing issues",
+                        path=field_name,
+                    )
+                )
+
+        # Check for duplicate field definitions
+        raw_content = config_path.read_text(encoding="utf-8")
+        top_level_fields: Dict[str, int] = {}
+        for line in raw_content.split("\n"):
+            stripped = line.strip()
+            if (
+                stripped
+                and not stripped.startswith("#")
+                and ":" in stripped
+                and not line[0].isspace()
+            ):
+                field_name = stripped.split(":")[0].strip()
+                if field_name in ConfigValidator.VALID_TOP_LEVEL_FIELDS:
+                    if field_name in top_level_fields:
+                        result.issues.append(
+                            LintIssue(
+                                severity=LintSeverity.ERROR,
+                                category=LintCategory.DUPLICATE_FIELD,
+                                message=f"Duplicate top-level field '{field_name}' found at multiple locations",
+                                path=field_name,
+                            )
+                        )
+                    top_level_fields[field_name] = 1
+
+        # Validate scanners section
+        if "scanners" in config_data and isinstance(config_data["scanners"], dict):
+            for scanner_name, scanner_config in config_data["scanners"].items():
+                if isinstance(scanner_config, dict):
+                    for field_name in scanner_config.keys():
+                        if field_name in ConfigValidator.INTERNAL_SCANNER_FIELDS:
+                            result.issues.append(
+                                LintIssue(
+                                    severity=LintSeverity.ERROR,
+                                    category=LintCategory.INTERNAL_FIELD,
+                                    message=f"Scanner '{scanner_name}' contains internal-only field '{field_name}'",
+                                    path=f"scanners.{scanner_name}.{field_name}",
+                                    fixable=True,
+                                    fix_description=f"Remove internal field '{field_name}' from scanner '{scanner_name}'",
+                                )
+                            )
+
+        # Validate reporters section
+        if "reporters" in config_data and isinstance(config_data["reporters"], dict):
+            for reporter_name, reporter_config in config_data["reporters"].items():
+                if isinstance(reporter_config, dict):
+                    for field_name in reporter_config.keys():
+                        if field_name in ConfigValidator.INTERNAL_REPORTER_FIELDS:
+                            result.issues.append(
+                                LintIssue(
+                                    severity=LintSeverity.ERROR,
+                                    category=LintCategory.INTERNAL_FIELD,
+                                    message=f"Reporter '{reporter_name}' contains internal-only field '{field_name}'",
+                                    path=f"reporters.{reporter_name}.{field_name}",
+                                    fixable=True,
+                                    fix_description=f"Remove internal field '{field_name}' from reporter '{reporter_name}'",
+                                )
+                            )
+
+        # Validate converters section
+        if "converters" in config_data and isinstance(config_data["converters"], dict):
+            for converter_name, converter_config in config_data["converters"].items():
+                if isinstance(converter_config, dict):
+                    for field_name in converter_config.keys():
+                        if field_name in ConfigValidator.INTERNAL_CONVERTER_FIELDS:
+                            result.issues.append(
+                                LintIssue(
+                                    severity=LintSeverity.ERROR,
+                                    category=LintCategory.INTERNAL_FIELD,
+                                    message=f"Converter '{converter_name}' contains internal-only field '{field_name}'",
+                                    path=f"converters.{converter_name}.{field_name}",
+                                    fixable=True,
+                                    fix_description=f"Remove internal field '{field_name}' from converter '{converter_name}'",
+                                )
+                            )
+
+    @classmethod
+    def _check_suppression_issues(
+        cls, config_data: Dict[str, Any], result: LintResult
+    ) -> None:
+        """Check for suppression-specific issues."""
+        global_settings = config_data.get("global_settings", {})
+        if not isinstance(global_settings, dict):
+            return
+
+        suppressions = global_settings.get("suppressions", [])
+        if not isinstance(suppressions, list):
+            return
+
+        for i, suppression in enumerate(suppressions):
+            if not isinstance(suppression, dict):
+                continue
+
+            path_prefix = f"global_settings.suppressions[{i}]"
+
+            # Check: line_start present but line_end missing
+            line_start = suppression.get("line_start")
+            line_end = suppression.get("line_end")
+
+            if line_start is not None and line_end is None:
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.WARNING,
+                        category=LintCategory.SUPPRESSION_LINE_RANGE,
+                        message=f"Suppression has 'line_start' ({line_start}) but missing 'line_end' - will default to line_start value",
+                        path=path_prefix,
+                        fixable=True,
+                        fix_description=f"Set line_end = {line_start} (same as line_start)",
+                    )
+                )
+
+            # Check: expired suppressions
+            expiration = suppression.get("expiration")
+            if expiration is not None:
+                try:
+                    from datetime import date as date_type
+
+                    exp_date = datetime.strptime(expiration, "%Y-%m-%d").date()
+                    if exp_date < date_type.today():
+                        result.issues.append(
+                            LintIssue(
+                                severity=LintSeverity.WARNING,
+                                category=LintCategory.SUPPRESSION_EXPIRED,
+                                message=f"Suppression has expired (expiration: {expiration})",
+                                path=path_prefix,
+                                fixable=True,
+                                fix_description="Remove expired suppression",
+                            )
+                        )
+                except ValueError:
+                    result.issues.append(
+                        LintIssue(
+                            severity=LintSeverity.ERROR,
+                            category=LintCategory.SUPPRESSION_LINE_RANGE,
+                            message=f"Suppression has invalid expiration date format: '{expiration}' (expected YYYY-MM-DD)",
+                            path=path_prefix,
+                        )
+                    )
+
+    @classmethod
+    def _check_unused_suppressions(
+        cls,
+        config_path: Path,
+        config_data: Dict[str, Any],
+        output_dir: Optional[Path],
+        result: LintResult,
+    ) -> None:
+        """Check for unused suppressions based on the report."""
+        report_path, report_timestamp = cls._find_unused_report(config_path, output_dir)
+
+        if report_path is None:
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.INFO,
+                    category=LintCategory.SUPPRESSION_UNUSED,
+                    message="No unused suppressions report found. Run a scan first to generate the report.",
+                )
+            )
+            return
+
+        # Load the report
+        try:
+            with open(report_path, "r", encoding="utf-8") as f:
+                report_data = json.load(f)
+        except (json.JSONDecodeError, OSError) as e:
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.WARNING,
+                    category=LintCategory.SUPPRESSION_UNUSED,
+                    message=f"Failed to read unused suppressions report: {e}",
+                )
+            )
+            return
+
+        # Report age warning
+        if report_timestamp:
+            age_seconds = (datetime.now() - report_timestamp).total_seconds()
+            if age_seconds > cls.MAX_REPORT_AGE_SECONDS:
+                age_hours = age_seconds / 3600
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.WARNING,
+                        category=LintCategory.SUPPRESSION_UNUSED,
+                        message=f"Unused suppressions report is {age_hours:.1f} hours old. Consider re-running a scan for accurate results.",
+                    )
+                )
+
+        unused_suppressions = report_data.get("unused_suppressions", [])
+        for unused in unused_suppressions:
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.INFO,
+                    category=LintCategory.SUPPRESSION_UNUSED,
+                    message=f"Unused suppression: path='{unused.get('path', '')}', rule_id='{unused.get('rule_id', '*')}'",
+                    fixable=True,
+                    fix_description="Remove unused suppression (use --fix-unused)",
+                )
+            )
+
+    @classmethod
+    def _find_unused_report(
+        cls,
+        config_path: Path,
+        output_dir: Optional[Path],
+    ) -> Tuple[Optional[Path], Optional[datetime]]:
+        """Find the unused suppressions report file.
+
+        Returns:
+            Tuple of (report_path, report_modification_time) or (None, None)
+        """
+        # Determine the output directory
+        if output_dir is not None:
+            search_dirs = [output_dir]
+        else:
+            # Try common locations relative to the config file
+            config_parent = config_path.resolve().parent
+            if config_parent.name == ".ash":
+                project_root = config_parent.parent
+            else:
+                project_root = config_parent
+
+            search_dirs = [
+                project_root / ".ash" / "ash_output",
+                project_root / "ash_output",
+            ]
+
+        for search_dir in search_dirs:
+            report_path = search_dir / cls.UNUSED_SUPPRESSIONS_REPORT
+            if report_path.exists():
+                # Get the modification time of the report
+                mtime = report_path.stat().st_mtime
+                report_timestamp = datetime.fromtimestamp(mtime)
+                return report_path, report_timestamp
+
+        return None, None
+
+    @classmethod
+    def _make_suppression_id(cls, suppression: Dict[str, Any]) -> str:
+        """Create a unique identifier for a suppression (matches reporter logic)."""
+        line_start = suppression.get("line_start")
+        line_end = suppression.get("line_end")
+
+        # If line_start is specified but line_end is not, use line_start for both
+        line_end_val = line_end if line_end is not None else line_start
+
+        parts = [
+            suppression.get("path", ""),
+            suppression.get("rule_id") or "*",
+            str(line_start) if line_start is not None else "*",
+            str(line_end_val) if line_end_val is not None else "*",
+        ]
+        return "|".join(parts)
+
+    @classmethod
+    def _fix_internal_field(cls, config_data: Dict[str, Any], issue: LintIssue) -> bool:
+        """Remove an internal-only field from a scanner/reporter/converter."""
+        parts = issue.path.split(".")
+        if len(parts) != 3:
+            return False
+
+        section, plugin_name, field_name = parts
+        if section in config_data and isinstance(config_data[section], dict):
+            plugin_config = config_data[section].get(plugin_name)
+            if isinstance(plugin_config, dict) and field_name in plugin_config:
+                del plugin_config[field_name]
+                return True
+        return False
+
+    @classmethod
+    def _fix_invalid_section(
+        cls, config_data: Dict[str, Any], issue: LintIssue
+    ) -> bool:
+        """Remove an invalid top-level section."""
+        field_name = issue.path
+        if field_name in config_data:
+            del config_data[field_name]
+            return True
+        return False
+
+    @classmethod
+    def _fix_suppression_line_range(
+        cls, config_data: Dict[str, Any], issue: LintIssue
+    ) -> bool:
+        """Fix a suppression with line_start but missing line_end."""
+        # Parse the path: global_settings.suppressions[N]
+        idx = cls._parse_suppression_index(issue.path)
+        if idx is None:
+            return False
+
+        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
+        if idx < len(suppressions):
+            suppression = suppressions[idx]
+            if (
+                isinstance(suppression, dict)
+                and suppression.get("line_start") is not None
+            ):
+                suppression["line_end"] = suppression["line_start"]
+                return True
+        return False
+
+    @classmethod
+    def _fix_expired_suppression(
+        cls, config_data: Dict[str, Any], issue: LintIssue
+    ) -> bool:
+        """Remove an expired suppression."""
+        idx = cls._parse_suppression_index(issue.path)
+        if idx is None:
+            return False
+
+        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
+        if idx < len(suppressions):
+            suppressions.pop(idx)
+            return True
+        return False
+
+    @classmethod
+    def _parse_suppression_index(cls, path: str) -> Optional[int]:
+        """Parse a suppression index from a path like 'global_settings.suppressions[2]'."""
+        try:
+            # Extract the index from brackets
+            start = path.index("[")
+            end = path.index("]")
+            return int(path[start + 1 : end])
+        except (ValueError, IndexError):
+            return None
+
+    @classmethod
+    def _generate_config_content(
+        cls,
+        config_path: Path,
+        raw_content: str,
+        config_data: Dict[str, Any],
+    ) -> str:
+        """Generate the fixed config file content, preserving the schema comment."""
+        config_strings = []
+
+        # Preserve the schema reference if it exists in the original file
+        for line in raw_content.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("#") and "schema" in stripped.lower():
+                config_strings.append(line)
+                break
+            elif stripped and not stripped.startswith("#"):
+                # Reached non-comment content, stop looking
+                break
+
+        # If no schema reference was found, add the default one
+        if not config_strings:
+            config_strings.append(
+                "# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json"
+            )
+
+        # Dump the config data
+        from automated_security_helper.cli.config import IndentableYamlDumper
+
+        config_strings.append(
+            yaml.dump(
+                config_data,
+                Dumper=IndentableYamlDumper,
+                default_flow_style=False,
+                sort_keys=False,
+            )
+        )
+
+        return "\n".join(config_strings)

--- a/automated_security_helper/config/config_validator.py
+++ b/automated_security_helper/config/config_validator.py
@@ -41,7 +41,6 @@ class ConfigValidator:
     # Top-level fields that should NOT appear in user configs
     INVALID_TOP_LEVEL_FIELDS = {
         "build",
-        "mcp-resource-management",
     }
 
     # Required top-level fields
@@ -59,6 +58,7 @@ class ConfigValidator:
         "scanners",
         "reporters",
         "converters",
+        "mcp-resource-management",
     }
 
     @classmethod

--- a/automated_security_helper/config/resolve_config.py
+++ b/automated_security_helper/config/resolve_config.py
@@ -250,7 +250,11 @@ def resolve_config(
                 ASH_LOGGER.warning("Using default configuration due to file load error")
                 # Apply overrides to default config if provided
                 if config_overrides and config:
-                    return apply_config_overrides(config, config_overrides)
+                    config = apply_config_overrides(config, config_overrides)
+                config._resolution_warnings.append(
+                    f"Failed to load configuration file: {str(e)}. "
+                    "Using default configuration — suppressions and custom settings are NOT active."
+                )
                 return config  # Return default config on file error
             else:
                 raise e
@@ -263,7 +267,12 @@ def resolve_config(
                 )
                 # Apply overrides to default config if provided
                 if config_overrides and config:
-                    return apply_config_overrides(config, config_overrides)
+                    config = apply_config_overrides(config, config_overrides)
+                config._resolution_warnings.append(
+                    f"Configuration validation failed: {str(e)}. "
+                    "Using default configuration — suppressions and custom settings are NOT active. "
+                    "Run 'ash config lint' to identify and fix issues."
+                )
                 return config  # Return default config on validation error
             else:
                 raise e

--- a/automated_security_helper/core/orchestrator.py
+++ b/automated_security_helper/core/orchestrator.py
@@ -166,6 +166,11 @@ class ASHScanOrchestrator(BaseModel):
             else [],
         )
 
+        # Surface config resolution warnings prominently
+        if self.config._resolution_warnings:
+            for warning in self.config._resolution_warnings:
+                ASH_LOGGER.warning(f"⚠️  CONFIG WARNING: {warning}")
+
         ASH_LOGGER.verbose("Setting up working directories")
         if self.source_dir is None:
             ASH_LOGGER.warning(
@@ -440,6 +445,21 @@ class ASHScanOrchestrator(BaseModel):
             except Exception as e:
                 ASH_LOGGER.error(f"Execution failed: {str(e)}")
                 raise
+
+            # Add config resolution warnings to validation checkpoints
+            if self.config._resolution_warnings:
+                for warning in self.config._resolution_warnings:
+                    asharp_model_results.validation_checkpoints.append(
+                        {
+                            "type": "config_warning",
+                            "severity": "warning",
+                            "message": warning,
+                            "metadata": {
+                                "source": "config_resolution",
+                                "impact": "Suppressions and custom settings may not be active",
+                            },
+                        }
+                    )
 
             if not self.no_cleanup:
                 if self.work_dir and Path(self.work_dir).exists():

--- a/automated_security_helper/interactions/run_ash_scan.py
+++ b/automated_security_helper/interactions/run_ash_scan.py
@@ -374,11 +374,7 @@ def run_ash_scan(
                     if color
                     else None
                 ),
-                offline=(
-                    offline
-                    if offline is not None
-                    else is_offline_mode()
-                ),
+                offline=(offline if offline is not None else is_offline_mode()),
                 existing_results_path=(
                     Path(existing_results) if existing_results else None
                 ),
@@ -530,6 +526,19 @@ def run_ash_scan(
             relative_out_dir.as_posix(),
         )
         if not quiet:
+            # Show config resolution warnings prominently before results
+            if results and hasattr(results, "validation_checkpoints"):
+                config_warnings = [
+                    cp
+                    for cp in results.validation_checkpoints
+                    if cp.get("type") == "config_warning"
+                ]
+                if config_warnings:
+                    print("\n[bold yellow]⚠️  CONFIGURATION WARNING ⚠️[/bold yellow]")
+                    for cw in config_warnings:
+                        print(f"[yellow]  {cw['message']}[/yellow]")
+                    print("")
+
             print(
                 f"\n[cyan]=== ASH Scan Completed in {duration_str}: Next Steps ===[/cyan]"
             )

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -21212,7 +21212,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.2.7"
+                "version": "3.4.0"
               },
               "extensions": [],
               "properties": null

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1483,6 +1483,7 @@
               "enabled": true,
               "name": "cdk-nag",
               "options": {
+                "include_compliant_checks": false,
                 "nag_packs": {
                   "AwsSolutionsChecks": true,
                   "HIPAASecurityChecks": false,
@@ -1531,6 +1532,7 @@
                   "results": {},
                   "version": null
                 },
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -2158,6 +2160,7 @@
         "options": {
           "$ref": "#/$defs/CdkNagScannerConfigOptions",
           "default": {
+            "include_compliant_checks": false,
             "nag_packs": {
               "AwsSolutionsChecks": true,
               "HIPAASecurityChecks": false,
@@ -2177,6 +2180,12 @@
       "additionalProperties": true,
       "description": "CDK Nag IAC SAST scanner options.",
       "properties": {
+        "include_compliant_checks": {
+          "default": false,
+          "description": "Include INFO-level findings for compliant resources in the report.",
+          "title": "Include Compliant Checks",
+          "type": "boolean"
+        },
         "nag_packs": {
           "$ref": "#/$defs/CdkNagPacks",
           "default": {
@@ -2561,7 +2570,6 @@
           "type": "integer"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, disabling policy downloads",
           "title": "Offline",
           "type": "boolean"
@@ -5506,6 +5514,7 @@
               "results": {},
               "version": null
             },
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure detect-secrets scanner"
@@ -5544,6 +5553,12 @@
             "version": null
           },
           "description": "Settings to use with detect-secrets. Refer to the detect-secrets documentation for formatting information. By default, all plugins will be used and no filters are configured. scan_settings takes precedence over baseline_file"
+        },
+        "scan_timeout": {
+          "default": 300,
+          "description": "Maximum time in seconds to allow the detect-secrets scan to run before aborting. Prevents hangs on pathological files.",
+          "title": "Scan Timeout",
+          "type": "integer"
         },
         "severity_threshold": {
           "anyOf": [
@@ -7839,7 +7854,6 @@
           "title": "Config File"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, disabling database updates and validation",
           "title": "Offline",
           "type": "boolean"
@@ -10704,7 +10718,6 @@
       "additionalProperties": true,
       "properties": {
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached data",
           "title": "Offline",
           "type": "boolean"
@@ -10926,7 +10939,6 @@
           "type": "string"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"
@@ -15426,6 +15438,7 @@
             "enabled": true,
             "name": "cdk-nag",
             "options": {
+              "include_compliant_checks": false,
               "nag_packs": {
                 "AwsSolutionsChecks": true,
                 "HIPAASecurityChecks": false,
@@ -15486,6 +15499,7 @@
                 "results": {},
                 "version": null
               },
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -16169,7 +16183,6 @@
           "type": "string"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"
@@ -21212,7 +21225,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.4.0"
+                "version": "3.4.1"
               },
               "extensions": [],
               "properties": null

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -245,6 +245,7 @@
               "enabled": true,
               "name": "cdk-nag",
               "options": {
+                "include_compliant_checks": false,
                 "nag_packs": {
                   "AwsSolutionsChecks": true,
                   "HIPAASecurityChecks": false,
@@ -293,6 +294,7 @@
                   "results": {},
                   "version": null
                 },
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -746,6 +748,7 @@
         "options": {
           "$ref": "#/$defs/CdkNagScannerConfigOptions",
           "default": {
+            "include_compliant_checks": false,
             "nag_packs": {
               "AwsSolutionsChecks": true,
               "HIPAASecurityChecks": false,
@@ -765,6 +768,12 @@
       "additionalProperties": true,
       "description": "CDK Nag IAC SAST scanner options.",
       "properties": {
+        "include_compliant_checks": {
+          "default": false,
+          "description": "Include INFO-level findings for compliant resources in the report.",
+          "title": "Include Compliant Checks",
+          "type": "boolean"
+        },
         "nag_packs": {
           "$ref": "#/$defs/CdkNagPacks",
           "default": {
@@ -988,7 +997,6 @@
           "type": "integer"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, disabling policy downloads",
           "title": "Offline",
           "type": "boolean"
@@ -1379,6 +1387,7 @@
               "results": {},
               "version": null
             },
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure detect-secrets scanner"
@@ -1417,6 +1426,12 @@
             "version": null
           },
           "description": "Settings to use with detect-secrets. Refer to the detect-secrets documentation for formatting information. By default, all plugins will be used and no filters are configured. scan_settings takes precedence over baseline_file"
+        },
+        "scan_timeout": {
+          "default": 300,
+          "description": "Maximum time in seconds to allow the detect-secrets scan to run before aborting. Prevents hangs on pathological files.",
+          "title": "Scan Timeout",
+          "type": "integer"
         },
         "severity_threshold": {
           "anyOf": [
@@ -1587,7 +1602,6 @@
           "title": "Config File"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, disabling database updates and validation",
           "title": "Offline",
           "type": "boolean"
@@ -2009,7 +2023,6 @@
       "additionalProperties": true,
       "properties": {
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached data",
           "title": "Offline",
           "type": "boolean"
@@ -2149,7 +2162,6 @@
           "type": "string"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"
@@ -2587,6 +2599,7 @@
             "enabled": true,
             "name": "cdk-nag",
             "options": {
+              "include_compliant_checks": false,
               "nag_packs": {
                 "AwsSolutionsChecks": true,
                 "HIPAASecurityChecks": false,
@@ -2647,6 +2660,7 @@
                 "results": {},
                 "version": null
               },
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -3125,7 +3139,6 @@
           "type": "string"
         },
         "offline": {
-          "default": false,
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -140,6 +140,7 @@ ash config [subcommand] [options]
 | `get`      | Display current configuration                                    |
 | `update`   | Update configuration values                                      |
 | `validate` | Validate configuration file against JSON schema and check syntax |
+| `lint`     | Lint configuration for issues and optionally auto-fix them       |
 
 ### Config Options
 
@@ -150,6 +151,10 @@ ash config [subcommand] [options]
 | `--set`              | Set configuration values (with `update`)        |                  |                      |
 | `--dry-run`          | Preview changes without writing (with `update`) | `False`          |                      |
 | `--force`            | Overwrite existing config file (with `init`)    | `False`          |                      |
+| `--fix`              | Auto-fix common issues (with `lint`)            | `False`          |                      |
+| `--fix-unused`       | Comment out unused suppressions (with `lint`)   | `False`          |                      |
+| `--non-interactive`  | Skip confirmation prompts (with `lint`)         | `False`          |                      |
+| `--output-dir`, `-o` | Path to ASH output directory (with `lint`)      | `.ash/ash_output`|                      |
 | `--debug`, `-d`      | Enable debug logging                            | `False`          | `ASH_DEBUG`          |
 | `--verbose`, `-v`    | Enable verbose logging                          | `False`          | `ASH_VERBOSE`        |
 | `--no-color`         | Disable colored output                          | `False`          | `ASH_NO_COLOR`       |
@@ -183,6 +188,21 @@ ash config validate --config /path/to/config.yaml
 
 # Validate with verbose output showing all checks
 ash config validate --verbose
+
+# Lint configuration for issues
+ash config lint
+
+# Lint and auto-fix common issues
+ash config lint --fix
+
+# Lint, fix, and comment out unused suppressions
+ash config lint --fix --fix-unused
+
+# Non-interactive mode (for pre-commit hooks and CI/CD)
+ash config lint --fix --fix-unused --non-interactive
+
+# Lint a specific config file
+ash config lint --config path/to/config.yaml
 ```
 
 ### Config Validate Details
@@ -233,6 +253,66 @@ Please fix these errors and try again.
 - Verify configuration after manual edits
 - CI/CD pipeline checks to ensure valid configuration
 - Pre-deployment validation in automated workflows
+
+### Config Lint Details
+
+The `ash config lint` command performs all validation checks plus additional lint checks that can identify and auto-fix common configuration issues:
+
+**Lint Checks:**
+- **All validation checks**: Same checks as `ash config validate`
+- **Internal fields**: Detects internal-only fields leaked from older `ash config init` versions (e.g., `name`, `extension`, `tool_version` in scanner configs)
+- **Invalid sections**: Detects internal top-level sections like `build` that shouldn't be in user configs
+- **Missing line_end**: Detects suppressions with `line_start` but no `line_end`
+- **Expired suppressions**: Detects suppressions past their expiration date
+- **Unused suppressions**: Detects suppressions not matching any findings (requires `--fix-unused`)
+
+**Auto-fix Behavior (`--fix`):**
+- Removes internal-only fields from scanner/reporter/converter configs
+- Removes invalid top-level sections (e.g., `build`)
+- Sets `line_end` equal to `line_start` when missing
+- Removes expired suppressions
+
+**Unused Suppression Handling (`--fix-unused`):**
+- Comments out unused suppressions instead of removing them
+- Adds a dated note explaining why they were commented out
+- Preserves suppressions for easy re-activation if needed
+- This is intentionally conservative: a suppression unused locally may still be needed in CI/CD where different scanners are available
+
+**Non-interactive Mode (`--non-interactive` / `--yes` / `-y`):**
+- Skips all confirmation prompts
+- Useful for pre-commit hooks and CI/CD pipelines
+- Warns (but proceeds) when the unused suppressions report is older than 1 hour
+
+**Exit Codes:**
+- `0`: No errors found (warnings and info are acceptable)
+- `1`: Configuration has errors that need attention
+
+**Example Output:**
+
+```bash
+$ ash config lint
+Linting configuration file: .ash/.ash.yaml
+
+Found 3 issue(s):
+  ❌ Scanner 'bandit' contains internal-only field 'name' [auto-fixable]
+  ⚠️  Suppression has 'line_start' (42) but missing 'line_end' [auto-fixable]
+  ⚠️  Suppression has expired (expiration: 2024-01-01) [auto-fixable]
+
+  Errors: 1
+  Warnings: 2
+
+💡 3 issue(s) can be auto-fixed. Run with --fix to apply fixes.
+
+$ ash config lint --fix --non-interactive
+Linting configuration file: .ash/.ash.yaml
+
+🔧 Fixing 3 issue(s):
+  • Remove internal field 'name' from scanner 'bandit'
+  • Set line_end = 42 (same as line_start)
+  • Remove expired suppression
+
+✅ Fixed 3 issue(s) in .ash/.ash.yaml
+```
 
 ## Plugin Command
 

--- a/tests/unit/cli/test_config_lint.py
+++ b/tests/unit/cli/test_config_lint.py
@@ -53,7 +53,6 @@ def config_with_internal_fields(tmp_path):
     config_data = {
         "project_name": "test-project",
         "build": {"some": "value"},
-        "mcp-resource-management": {"enabled": True},
         "scanners": {
             "bandit": {
                 "enabled": True,
@@ -223,11 +222,96 @@ class TestConfigLinterUnit:
         invalid_section_issues = [
             i for i in result.issues if i.category == LintCategory.INVALID_SECTION
         ]
-        assert len(invalid_section_issues) == 2
+        assert len(invalid_section_issues) == 1
         paths = {i.path for i in invalid_section_issues}
         assert "build" in paths
-        assert "mcp-resource-management" in paths
         assert all(i.fixable for i in invalid_section_issues)
+
+    def test_lint_detects_mcp_resource_management(self, tmp_path):
+        """mcp-resource-management is a valid user-configurable field."""
+        config_path = tmp_path / ".ash" / ".ash.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        # Users can configure MCP resource management in their configs
+        config_content = """project_name: my-project
+mcp-resource-management:
+  max_concurrent_scans: 5
+  scan_timeout_seconds: 3600
+  memory_warning_threshold_mb: 2048
+scanners:
+  bandit:
+    enabled: true
+"""
+        config_path.write_text(config_content)
+
+        result = ConfigLinter.lint(config_path)
+
+        # mcp-resource-management should NOT be flagged as invalid
+        mcp_issues = [
+            i
+            for i in result.issues
+            if "mcp-resource-management" in (i.path or "")
+            or "mcp-resource-management" in i.message
+        ]
+        assert len(mcp_issues) == 0
+        assert not result.has_errors
+
+    def test_lint_detects_mcp_underscore_variant(self, tmp_path):
+        """Should detect mcp_resource_management (underscore) as unknown field."""
+        config_path = tmp_path / ".ash" / ".ash.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        # The underscore variant is NOT the correct YAML key (alias is hyphenated)
+        config_content = """project_name: my-project
+mcp_resource_management:
+  max_concurrent_scans: 5
+scanners:
+  bandit:
+    enabled: true
+"""
+        config_path.write_text(config_content)
+
+        result = ConfigLinter.lint(config_path)
+
+        unknown_issues = [
+            i
+            for i in result.issues
+            if i.category == LintCategory.UNKNOWN_FIELD
+            and "mcp_resource_management" in i.path
+        ]
+        assert len(unknown_issues) == 1
+        assert "Unknown top-level field" in unknown_issues[0].message
+
+    def test_fix_removes_build_but_keeps_mcp(self, tmp_path):
+        """--fix should remove 'build' but keep 'mcp-resource-management'."""
+        config_path = tmp_path / ".ash" / ".ash.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_content = """project_name: my-project
+build:
+  some: value
+mcp-resource-management:
+  max_concurrent_scans: 5
+  scan_timeout_seconds: 3600
+global_settings:
+  severity_threshold: MEDIUM
+scanners:
+  bandit:
+    enabled: true
+"""
+        config_path.write_text(config_content)
+
+        fixed_content, fixed_issues = ConfigLinter.fix(config_path)
+
+        # Parse the fixed content
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        # build should be removed (internal-only)
+        assert "build" not in fixed_data
+        # mcp-resource-management should be preserved (valid user config)
+        assert "mcp-resource-management" in fixed_data
+        assert fixed_data["mcp-resource-management"]["max_concurrent_scans"] == 5
+        assert fixed_data["project_name"] == "my-project"
 
     def test_lint_detects_missing_line_end(self, config_with_suppression_issues):
         """Should detect suppressions with line_start but no line_end."""

--- a/tests/unit/cli/test_config_lint.py
+++ b/tests/unit/cli/test_config_lint.py
@@ -1,0 +1,627 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the config lint command."""
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from automated_security_helper.cli.config import config_app
+from automated_security_helper.config.config_linter import (
+    ConfigLinter,
+    LintCategory,
+    LintSeverity,
+)
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def valid_config(tmp_path):
+    """Create a valid config file."""
+    config_path = tmp_path / ".ash" / ".ash.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "severity_threshold": "MEDIUM",
+            "suppressions": [],
+        },
+        "scanners": {
+            "bandit": {"enabled": True},
+        },
+    }
+    content = "# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json\n"
+    content += yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+    config_path.write_text(content)
+    return config_path
+
+
+@pytest.fixture
+def config_with_internal_fields(tmp_path):
+    """Create a config with internal-only fields (from old ash config init)."""
+    config_path = tmp_path / ".ash" / ".ash.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_data = {
+        "project_name": "test-project",
+        "build": {"some": "value"},
+        "mcp-resource-management": {"enabled": True},
+        "scanners": {
+            "bandit": {
+                "enabled": True,
+                "name": "bandit",
+                "extension": "json",
+                "tool_version": "1.0.0",
+            },
+        },
+        "reporters": {
+            "markdown": {
+                "enabled": True,
+                "name": "markdown",
+                "extension": "md",
+            },
+        },
+        "converters": {
+            "sarif": {
+                "enabled": True,
+                "name": "sarif",
+                "tool_version": "2.0.0",
+                "install_timeout": 30,
+            },
+        },
+    }
+    content = yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+    config_path.write_text(content)
+    return config_path
+
+
+@pytest.fixture
+def config_with_suppression_issues(tmp_path):
+    """Create a config with suppression issues."""
+    config_path = tmp_path / ".ash" / ".ash.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "severity_threshold": "MEDIUM",
+            "suppressions": [
+                {
+                    "path": "src/app.py",
+                    "rule_id": "B201",
+                    "line_start": 42,
+                    # Missing line_end
+                    "reason": "False positive",
+                },
+                {
+                    "path": "src/utils.py",
+                    "rule_id": "B603",
+                    "line_start": 10,
+                    "line_end": 10,
+                    "reason": "Safe usage",
+                    "expiration": "2020-01-01",  # Expired
+                },
+                {
+                    "path": "src/valid.py",
+                    "rule_id": "B101",
+                    "line_start": 5,
+                    "line_end": 5,
+                    "reason": "Test assertion",
+                },
+            ],
+        },
+    }
+    content = yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+    config_path.write_text(content)
+    return config_path
+
+
+@pytest.fixture
+def config_with_unused_suppressions(tmp_path):
+    """Create a config with suppressions and a corresponding unused report."""
+    config_path = tmp_path / ".ash" / ".ash.yaml"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "severity_threshold": "MEDIUM",
+            "suppressions": [
+                {
+                    "path": "src/app.py",
+                    "rule_id": "B201",
+                    "line_start": 42,
+                    "line_end": 42,
+                    "reason": "False positive",
+                },
+                {
+                    "path": "src/old_file.py",
+                    "rule_id": "B603",
+                    "line_start": 10,
+                    "line_end": 10,
+                    "reason": "File was deleted",
+                },
+                {
+                    "path": "src/still_needed.py",
+                    "rule_id": "B101",
+                    "reason": "Still needed",
+                },
+            ],
+        },
+    }
+    content = yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+    config_path.write_text(content)
+
+    # Create the unused suppressions report
+    output_dir = tmp_path / ".ash" / "ash_output" / "reports"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    report_data = {
+        "summary": {
+            "total_suppressions": 3,
+            "used_suppressions": 1,
+            "unused_suppressions": 2,
+        },
+        "unused_suppressions": [
+            {
+                "path": "src/app.py",
+                "rule_id": "B201",
+                "line_start": 42,
+                "line_end": 42,
+                "reason": "False positive",
+                "expiration": None,
+            },
+            {
+                "path": "src/old_file.py",
+                "rule_id": "B603",
+                "line_start": 10,
+                "line_end": 10,
+                "reason": "File was deleted",
+                "expiration": None,
+            },
+        ],
+    }
+    report_path = output_dir / "ash.unused-suppressions.json"
+    report_path.write_text(json.dumps(report_data, indent=2))
+
+    return config_path
+
+
+class TestConfigLinterUnit:
+    """Unit tests for the ConfigLinter class."""
+
+    def test_lint_valid_config(self, valid_config):
+        """A valid config should produce no issues."""
+        result = ConfigLinter.lint(valid_config)
+        assert not result.has_errors
+        assert not result.has_warnings
+        assert len(result.issues) == 0
+
+    def test_lint_detects_internal_fields(self, config_with_internal_fields):
+        """Should detect internal-only fields in scanners/reporters/converters."""
+        result = ConfigLinter.lint(config_with_internal_fields)
+        assert result.has_errors
+
+        internal_issues = [
+            i for i in result.issues if i.category == LintCategory.INTERNAL_FIELD
+        ]
+        # bandit has: name, extension, tool_version (3)
+        # markdown has: name, extension (2)
+        # sarif has: name, tool_version, install_timeout (3)
+        assert len(internal_issues) == 8
+        assert all(i.fixable for i in internal_issues)
+
+    def test_lint_detects_invalid_sections(self, config_with_internal_fields):
+        """Should detect invalid top-level sections like 'build'."""
+        result = ConfigLinter.lint(config_with_internal_fields)
+
+        invalid_section_issues = [
+            i for i in result.issues if i.category == LintCategory.INVALID_SECTION
+        ]
+        assert len(invalid_section_issues) == 2
+        paths = {i.path for i in invalid_section_issues}
+        assert "build" in paths
+        assert "mcp-resource-management" in paths
+        assert all(i.fixable for i in invalid_section_issues)
+
+    def test_lint_detects_missing_line_end(self, config_with_suppression_issues):
+        """Should detect suppressions with line_start but no line_end."""
+        result = ConfigLinter.lint(config_with_suppression_issues)
+
+        line_range_issues = [
+            i
+            for i in result.issues
+            if i.category == LintCategory.SUPPRESSION_LINE_RANGE
+            and "missing 'line_end'" in i.message
+        ]
+        assert len(line_range_issues) == 1
+        assert line_range_issues[0].fixable
+        assert "42" in line_range_issues[0].message
+
+    def test_lint_detects_expired_suppressions(self, config_with_suppression_issues):
+        """Should detect expired suppressions."""
+        result = ConfigLinter.lint(config_with_suppression_issues)
+
+        expired_issues = [
+            i for i in result.issues if i.category == LintCategory.SUPPRESSION_EXPIRED
+        ]
+        assert len(expired_issues) == 1
+        assert expired_issues[0].fixable
+        assert "2020-01-01" in expired_issues[0].message
+
+    def test_lint_detects_unused_suppressions(self, config_with_unused_suppressions):
+        """Should detect unused suppressions from the report."""
+        result = ConfigLinter.lint(config_with_unused_suppressions, check_unused=True)
+
+        unused_issues = [
+            i
+            for i in result.issues
+            if i.category == LintCategory.SUPPRESSION_UNUSED
+            and "Unused suppression:" in i.message
+        ]
+        assert len(unused_issues) == 2
+
+    def test_fix_removes_internal_fields(self, config_with_internal_fields):
+        """Fix should remove internal-only fields."""
+        fixed_content, fixed_issues = ConfigLinter.fix(config_with_internal_fields)
+
+        # Parse the fixed content
+        # Skip the schema comment line
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        # Internal fields should be gone
+        assert "name" not in fixed_data["scanners"]["bandit"]
+        assert "extension" not in fixed_data["scanners"]["bandit"]
+        assert "tool_version" not in fixed_data["scanners"]["bandit"]
+        assert "name" not in fixed_data["reporters"]["markdown"]
+        assert "extension" not in fixed_data["reporters"]["markdown"]
+        assert "name" not in fixed_data["converters"]["sarif"]
+
+        # Valid fields should remain
+        assert fixed_data["scanners"]["bandit"]["enabled"] is True
+        assert fixed_data["reporters"]["markdown"]["enabled"] is True
+
+    def test_fix_removes_invalid_sections(self, config_with_internal_fields):
+        """Fix should remove invalid top-level sections."""
+        fixed_content, fixed_issues = ConfigLinter.fix(config_with_internal_fields)
+
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        assert "build" not in fixed_data
+        assert "mcp-resource-management" not in fixed_data
+
+    def test_fix_sets_missing_line_end(self, config_with_suppression_issues):
+        """Fix should set line_end = line_start when line_end is missing."""
+        fixed_content, fixed_issues = ConfigLinter.fix(config_with_suppression_issues)
+
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        # First suppression had line_start=42, line_end should now be 42
+        first_supp = suppressions[0]
+        assert first_supp["line_start"] == 42
+        assert first_supp["line_end"] == 42
+
+    def test_fix_removes_expired_suppressions(self, config_with_suppression_issues):
+        """Fix should remove expired suppressions."""
+        fixed_content, fixed_issues = ConfigLinter.fix(config_with_suppression_issues)
+
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        # The expired suppression (2020-01-01) should be removed
+        # Original had 3 suppressions, one expired -> 2 remaining
+        assert len(suppressions) == 2
+        # Verify the expired one is gone
+        for supp in suppressions:
+            assert supp.get("expiration") != "2020-01-01"
+
+    def test_fix_multiple_expired_suppressions(self, tmp_path):
+        """Fix should correctly remove multiple expired suppressions (index shifting)."""
+        config_path = tmp_path / ".ash" / ".ash.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "suppressions": [
+                    {
+                        "path": "src/a.py",
+                        "rule_id": "B101",
+                        "reason": "expired 1",
+                        "expiration": "2020-01-01",
+                    },
+                    {
+                        "path": "src/b.py",
+                        "rule_id": "B201",
+                        "reason": "keep this one",
+                    },
+                    {
+                        "path": "src/c.py",
+                        "rule_id": "B301",
+                        "reason": "expired 2",
+                        "expiration": "2021-06-15",
+                    },
+                    {
+                        "path": "src/d.py",
+                        "rule_id": "B401",
+                        "reason": "also keep",
+                    },
+                ],
+            },
+        }
+        config_path.write_text(
+            yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+        )
+
+        fixed_content, fixed_issues = ConfigLinter.fix(config_path)
+
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        # Two expired removed, two should remain
+        assert len(suppressions) == 2
+        assert suppressions[0]["path"] == "src/b.py"
+        assert suppressions[1]["path"] == "src/d.py"
+
+    def test_fix_unused_suppressions(self, config_with_unused_suppressions):
+        """Should remove unused suppressions based on the report."""
+        fixed_content, fixed_issues, timestamp = ConfigLinter.fix_unused_suppressions(
+            config_with_unused_suppressions
+        )
+
+        assert len(fixed_issues) == 2
+        assert timestamp is not None
+
+        yaml_content = "\n".join(
+            line for line in fixed_content.split("\n") if not line.startswith("#")
+        )
+        fixed_data = yaml.safe_load(yaml_content)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        # Only the "still_needed" suppression should remain
+        assert len(suppressions) == 1
+        assert suppressions[0]["path"] == "src/still_needed.py"
+
+    def test_report_age_detection(self, config_with_unused_suppressions, tmp_path):
+        """Should detect the age of the unused suppressions report."""
+        report_info = ConfigLinter.get_unused_report_age(
+            config_with_unused_suppressions
+        )
+        assert report_info is not None
+        report_path, report_timestamp, age_seconds = report_info
+        # Report was just created, should be very recent
+        assert age_seconds < 60
+
+    def test_old_report_warning(self, tmp_path):
+        """Should warn when the unused suppressions report is too old."""
+        config_path = tmp_path / ".ash" / ".ash.yaml"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "suppressions": [
+                    {"path": "src/app.py", "rule_id": "B201", "reason": "test"},
+                ],
+            },
+        }
+        config_path.write_text(
+            yaml.dump(config_data, default_flow_style=False, sort_keys=False)
+        )
+
+        # Create an old report
+        output_dir = tmp_path / ".ash" / "ash_output" / "reports"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        report_path = output_dir / "ash.unused-suppressions.json"
+        report_data = {
+            "summary": {
+                "total_suppressions": 1,
+                "used_suppressions": 0,
+                "unused_suppressions": 1,
+            },
+            "unused_suppressions": [
+                {
+                    "path": "src/app.py",
+                    "rule_id": "B201",
+                    "line_start": None,
+                    "line_end": None,
+                    "reason": "test",
+                    "expiration": None,
+                }
+            ],
+        }
+        report_path.write_text(json.dumps(report_data))
+
+        # Make the file appear old by setting mtime to 2 hours ago
+        import os
+
+        old_time = time.time() - 7200  # 2 hours ago
+        os.utime(report_path, (old_time, old_time))
+
+        result = ConfigLinter.lint(config_path, check_unused=True)
+
+        # Should have a warning about old report
+        age_warnings = [i for i in result.issues if "hours old" in i.message]
+        assert len(age_warnings) == 1
+
+    def test_no_unused_report_info_message(self, valid_config):
+        """Should show info message when no unused report exists."""
+        # Use a custom output_dir that definitely doesn't have a report
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as empty_dir:
+            result = ConfigLinter.lint(
+                valid_config, output_dir=Path(empty_dir), check_unused=True
+            )
+
+        info_issues = [
+            i
+            for i in result.issues
+            if "No unused suppressions report found" in i.message
+        ]
+        assert len(info_issues) == 1
+        assert info_issues[0].severity == LintSeverity.INFO
+
+
+class TestConfigLintCLI:
+    """Integration tests for the `ash config lint` CLI command."""
+
+    def test_lint_valid_config_exits_zero(self, cli_runner, valid_config):
+        """Linting a valid config should exit with code 0."""
+        result = cli_runner.invoke(config_app, ["lint", "--config", str(valid_config)])
+        assert result.exit_code == 0
+        assert "clean" in result.output or "No issues" in result.output
+
+    def test_lint_invalid_config_exits_one(
+        self, cli_runner, config_with_internal_fields
+    ):
+        """Linting an invalid config should exit with code 1."""
+        result = cli_runner.invoke(
+            config_app, ["lint", "--config", str(config_with_internal_fields)]
+        )
+        assert result.exit_code == 1
+        assert "issue" in result.output.lower()
+
+    def test_lint_missing_config_exits_one(self, cli_runner, tmp_path):
+        """Linting a non-existent config should exit with code 1."""
+        result = cli_runner.invoke(
+            config_app, ["lint", "--config", str(tmp_path / "nonexistent.yaml")]
+        )
+        assert result.exit_code == 1
+        assert "not found" in result.output.lower()
+
+    def test_lint_fix_applies_changes(self, cli_runner, config_with_internal_fields):
+        """--fix should apply fixes and modify the file."""
+        result = cli_runner.invoke(
+            config_app,
+            [
+                "lint",
+                "--config",
+                str(config_with_internal_fields),
+                "--fix",
+                "--non-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+
+        # Verify the file was fixed
+        with open(config_with_internal_fields) as f:
+            fixed_data = yaml.safe_load(f)
+
+        assert "build" not in fixed_data
+        assert "mcp-resource-management" not in fixed_data
+        assert "name" not in fixed_data["scanners"]["bandit"]
+
+    def test_lint_fix_suppression_line_end(
+        self, cli_runner, config_with_suppression_issues
+    ):
+        """--fix should set missing line_end."""
+        result = cli_runner.invoke(
+            config_app,
+            [
+                "lint",
+                "--config",
+                str(config_with_suppression_issues),
+                "--fix",
+                "--non-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+
+        with open(config_with_suppression_issues) as f:
+            fixed_data = yaml.safe_load(f)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        # First suppression should now have line_end set
+        first_supp = next(s for s in suppressions if s["path"] == "src/app.py")
+        assert first_supp["line_end"] == 42
+
+    def test_lint_fix_unused_removes_suppressions(
+        self, cli_runner, config_with_unused_suppressions
+    ):
+        """--fix-unused should remove unused suppressions."""
+        result = cli_runner.invoke(
+            config_app,
+            [
+                "lint",
+                "--config",
+                str(config_with_unused_suppressions),
+                "--fix-unused",
+                "--non-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+
+        with open(config_with_unused_suppressions) as f:
+            fixed_data = yaml.safe_load(f)
+
+        suppressions = fixed_data["global_settings"]["suppressions"]
+        assert len(suppressions) == 1
+        assert suppressions[0]["path"] == "src/still_needed.py"
+
+    def test_lint_non_interactive_no_prompts(
+        self, cli_runner, config_with_internal_fields
+    ):
+        """--non-interactive should not prompt for confirmation."""
+        result = cli_runner.invoke(
+            config_app,
+            [
+                "lint",
+                "--config",
+                str(config_with_internal_fields),
+                "--fix",
+                "--non-interactive",
+            ],
+        )
+        # Should complete without hanging for input
+        assert result.exit_code == 0
+
+    def test_lint_fix_and_fix_unused_together(
+        self, cli_runner, config_with_unused_suppressions
+    ):
+        """--fix and --fix-unused should work together."""
+        result = cli_runner.invoke(
+            config_app,
+            [
+                "lint",
+                "--config",
+                str(config_with_unused_suppressions),
+                "--fix",
+                "--fix-unused",
+                "--non-interactive",
+            ],
+        )
+        assert result.exit_code == 0
+
+    def test_lint_shows_fixable_hint(self, cli_runner, config_with_internal_fields):
+        """Without --fix, should show a hint about auto-fixable issues."""
+        result = cli_runner.invoke(
+            config_app, ["lint", "--config", str(config_with_internal_fields)]
+        )
+        assert "auto-fix" in result.output.lower() or "--fix" in result.output
+
+    def test_lint_verbose_output(self, cli_runner, valid_config):
+        """--verbose should not crash."""
+        result = cli_runner.invoke(
+            config_app, ["lint", "--config", str(valid_config), "--verbose"]
+        )
+        assert result.exit_code == 0

--- a/tests/unit/cli/test_config_lint.py
+++ b/tests/unit/cli/test_config_lint.py
@@ -468,7 +468,7 @@ scanners:
         assert suppressions[1]["path"] == "src/d.py"
 
     def test_fix_unused_suppressions(self, config_with_unused_suppressions):
-        """Should remove unused suppressions based on the report."""
+        """Should comment out unused suppressions based on the report."""
         fixed_content, fixed_issues, timestamp = ConfigLinter.fix_unused_suppressions(
             config_with_unused_suppressions
         )
@@ -476,13 +476,30 @@ scanners:
         assert len(fixed_issues) == 2
         assert timestamp is not None
 
-        yaml_content = "\n".join(
-            line for line in fixed_content.split("\n") if not line.startswith("#")
-        )
-        fixed_data = yaml.safe_load(yaml_content)
+        # Verify the unused suppressions are commented out, not removed
+        assert "# [ash-lint" in fixed_content
+        assert "unused suppression" in fixed_content
 
-        suppressions = fixed_data["global_settings"]["suppressions"]
-        # Only the "still_needed" suppression should remain
+        # The commented-out suppressions should still be in the file as comments
+        assert (
+            "# - path: src/app.py" in fixed_content
+            or "# - path: 'src/app.py'" in fixed_content
+        )
+        assert (
+            "# - path: src/old_file.py" in fixed_content
+            or "# - path: 'src/old_file.py'" in fixed_content
+        )
+
+        # The "still_needed" suppression should remain active (not commented)
+        # Parse only non-commented lines to verify
+        active_yaml = "\n".join(
+            line
+            for line in fixed_content.split("\n")
+            if not line.strip().startswith("#")
+        )
+        active_data = yaml.safe_load(active_yaml)
+
+        suppressions = active_data["global_settings"]["suppressions"]
         assert len(suppressions) == 1
         assert suppressions[0]["path"] == "src/still_needed.py"
 
@@ -639,10 +656,10 @@ class TestConfigLintCLI:
         first_supp = next(s for s in suppressions if s["path"] == "src/app.py")
         assert first_supp["line_end"] == 42
 
-    def test_lint_fix_unused_removes_suppressions(
+    def test_lint_fix_unused_comments_out_suppressions(
         self, cli_runner, config_with_unused_suppressions
     ):
-        """--fix-unused should remove unused suppressions."""
+        """--fix-unused should comment out unused suppressions, not remove them."""
         result = cli_runner.invoke(
             config_app,
             [
@@ -655,10 +672,19 @@ class TestConfigLintCLI:
         )
         assert result.exit_code == 0
 
-        with open(config_with_unused_suppressions) as f:
-            fixed_data = yaml.safe_load(f)
+        raw_content = config_with_unused_suppressions.read_text()
 
-        suppressions = fixed_data["global_settings"]["suppressions"]
+        # Verify suppressions are commented out with a note
+        assert "# [ash-lint" in raw_content
+        assert "unused suppression" in raw_content
+
+        # Parse only active (non-commented) YAML to verify
+        active_yaml = "\n".join(
+            line for line in raw_content.split("\n") if not line.strip().startswith("#")
+        )
+        active_data = yaml.safe_load(active_yaml)
+
+        suppressions = active_data["global_settings"]["suppressions"]
         assert len(suppressions) == 1
         assert suppressions[0]["path"] == "src/still_needed.py"
 


### PR DESCRIPTION
## Summary

- Add `ash config lint` command with auto-fix for config issues (internal fields, missing line_end, expired/unused suppressions)
- Add schema regeneration and smoke test to the release workflow
- Fix `mcp-resource-management` treated as invalid user config field
- Wrap all network-dependent Dockerfile installs with `with-retry` (3 attempts, exponential backoff) to handle transient CDN flakiness

## Dockerfile reliability changes

- Wrap curl-based installs: uv, pip, yarn, pnpm, syft, grype, trivy, nodesource GPG key, semgrep rulesets
- Wrap package manager installs: gem (cfn-nag), npm
- Add `set -o pipefail` to `with-retry.sh` so pipe failures propagate
- Fix GPG key pipe placed inside retry scope (prevents partial-data corruption)
- Fix OFFLINE semgrep loop quoting (pre-compute outfile to avoid nested escape cascade)
- Fix `assets/Dockerfile` COPY paths for pip-installed build context

## Test plan

- [x] `ash config lint` command exists and shows help
- [x] `ash config lint` catches config issues (missing required fields, unknown fields)
- [x] `ash config lint --fix --non-interactive` runs without error
- [x] Unit tests pass (255 pass, 1 pre-existing unrelated failure in mcp debug prints)
- [x] `with-retry.sh` syntax valid, `set -o pipefail` present
- [x] OFFLINE semgrep loop produces correct filenames (ci.yml, security-audit.yml, python.yml)
- [x] Dockerfile passes `docker build --check` syntax validation
- [x] `assets/Dockerfile` uses relative COPY path, root uses full path
- [x] GPG key pipe is inside retry scope in both Dockerfiles
- [ ] CI container build jobs pass (yarnpkg.com CDN dependent)
- [ ] OFFLINE=YES Docker build succeeds end-to-end