### PR TITLE
feat(#201): add suppression creation from inspect UI

### DIFF
--- a/automated_security_helper/cli/inspect/inspect_findings_app.py
+++ b/automated_security_helper/cli/inspect/inspect_findings_app.py
@@ -110,6 +110,11 @@ class SuppressDialog(ModalScreen[bool]):
                 self.dismiss(True)
             except Exception as exc:
                 ASH_LOGGER.error(f"Failed to create or write suppression: {exc}")
+                self.app.notify(
+                    f"Failed to save suppression: {exc}",
+                    severity="error",
+                    timeout=8,
+                )
                 self.dismiss(False)
 
     def action_cancel(self) -> None:

--- a/automated_security_helper/cli/inspect/inspect_findings_app.py
+++ b/automated_security_helper/cli/inspect/inspect_findings_app.py
@@ -2,6 +2,7 @@ import typer
 from pathlib import Path
 from textual.app import App, ComposeResult
 from textual.widgets import (
+    Button,
     DataTable,
     Footer,
     Header,
@@ -17,12 +18,103 @@ from textual.containers import (
     Container,
     VerticalGroup,
 )
-from textual.screen import Screen
+from textual.screen import ModalScreen, Screen
 from textual.binding import Binding
 
+from automated_security_helper.config.ash_config import add_suppression_to_config
 from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.models.core import AshSuppression
 from automated_security_helper.schemas.sarif_schema_model import Result
 from automated_security_helper.utils.log import ASH_LOGGER
+
+
+class SuppressDialog(ModalScreen[bool]):
+    """Modal dialog for creating a suppression from a finding."""
+
+    CSS = """
+    SuppressDialog {
+        align: center middle;
+    }
+
+    #suppress-dialog {
+        width: 70;
+        height: auto;
+        max-height: 80%;
+        background: rgb(30, 30, 30);
+        border: solid rgb(60, 60, 60);
+        padding: 1 2;
+    }
+
+    #suppress-dialog Label {
+        margin: 1 0 0 0;
+    }
+
+    #suppress-dialog Input {
+        margin: 0 0 1 0;
+    }
+
+    #suppress-dialog .button-row {
+        margin: 1 0 0 0;
+        height: 3;
+    }
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    def __init__(self, finding: dict, config_path: Path | None = None):
+        super().__init__()
+        self.finding = finding
+        self.config_path = config_path or Path.cwd() / ".ash.yaml"
+
+    def compose(self) -> ComposeResult:
+        with Container(id="suppress-dialog"):
+            yield Label("Suppress Finding")
+            yield Label(f"Rule: {self.finding.get('rule_id', 'N/A')}")
+            yield Label(f"File: {self.finding.get('file', 'N/A')}")
+            yield Label(f"Line: {self.finding.get('line', 'N/A')}")
+            yield Label("Reason (required):")
+            yield Input(placeholder="Why is this finding suppressed?", id="reason_input")
+            yield Label("Expiration date (optional, YYYY-MM-DD):")
+            yield Input(placeholder="e.g. 2025-12-31", id="expiration_input")
+            with HorizontalGroup(classes="button-row"):
+                yield Button("Suppress", variant="primary", id="btn_suppress")
+                yield Button("Cancel", variant="default", id="btn_cancel")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "btn_cancel":
+            self.dismiss(False)
+            return
+
+        if event.button.id == "btn_suppress":
+            reason_input = self.query_one("#reason_input", Input)
+            reason = reason_input.value.strip()
+            if not reason:
+                reason_input.focus()
+                return
+
+            expiration_input = self.query_one("#expiration_input", Input)
+            expiration = expiration_input.value.strip() or None
+
+            suppression = AshSuppression(
+                rule_id=self.finding.get("rule_id"),
+                path=self.finding.get("file") or "*",
+                reason=reason,
+                expiration=expiration,
+                line_start=int(self.finding["line"]) if self.finding.get("line") else None,
+                line_end=int(self.finding["line"]) if self.finding.get("line") else None,
+            )
+
+            try:
+                add_suppression_to_config(self.config_path, suppression)
+                self.dismiss(True)
+            except Exception as exc:
+                ASH_LOGGER.error(f"Failed to write suppression: {exc}")
+                self.dismiss(False)
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)
 
 
 class FindingDetailScreen(Screen):
@@ -108,6 +200,7 @@ class FindingsExplorerApp(App):
         Binding("/", "toggle_search", "Search"),
         Binding("escape", "exit_search", "Exit Search"),
         Binding("h", "toggle_suppressed", "Toggle Suppressed"),
+        Binding("x", "suppress_selected", "Suppress"),
     ]
 
     CSS = """
@@ -411,6 +504,21 @@ class FindingsExplorerApp(App):
             pass
 
         self._populate_table()
+
+    def action_suppress_selected(self) -> None:
+        """Open the suppression dialog for the selected finding."""
+        table = self.query_one("#findings_table", DataTable)
+        if table.row_count > 0 and table.cursor_row is not None:
+            finding_idx = table.cursor_row
+            if 0 <= finding_idx < len(self.filtered_findings):
+                finding = self.filtered_findings[finding_idx]
+                self.push_screen(SuppressDialog(finding), self._on_suppress_result)
+
+    def _on_suppress_result(self, result: bool) -> None:
+        """Handle the result from the suppression dialog."""
+        if result:
+            status_bar = self.query_one("#status_bar", Static)
+            status_bar.update("Suppression saved to .ash.yaml")
 
     def action_previous_finding(self) -> None:
         """Select the previous finding in the table."""

--- a/automated_security_helper/cli/inspect/inspect_findings_app.py
+++ b/automated_security_helper/cli/inspect/inspect_findings_app.py
@@ -97,20 +97,19 @@ class SuppressDialog(ModalScreen[bool]):
             expiration_input = self.query_one("#expiration_input", Input)
             expiration = expiration_input.value.strip() or None
 
-            suppression = AshSuppression(
-                rule_id=self.finding.get("rule_id"),
-                path=self.finding.get("file") or "*",
-                reason=reason,
-                expiration=expiration,
-                line_start=int(self.finding["line"]) if self.finding.get("line") else None,
-                line_end=int(self.finding["line"]) if self.finding.get("line") else None,
-            )
-
             try:
+                suppression = AshSuppression(
+                    rule_id=self.finding.get("rule_id"),
+                    path=self.finding.get("file") or "*",
+                    reason=reason,
+                    expiration=expiration,
+                    line_start=int(self.finding["line"]) if self.finding.get("line") else None,
+                    line_end=int(self.finding["line"]) if self.finding.get("line") else None,
+                )
                 add_suppression_to_config(self.config_path, suppression)
                 self.dismiss(True)
             except Exception as exc:
-                ASH_LOGGER.error(f"Failed to write suppression: {exc}")
+                ASH_LOGGER.error(f"Failed to create or write suppression: {exc}")
                 self.dismiss(False)
 
     def action_cancel(self) -> None:
@@ -519,6 +518,12 @@ class FindingsExplorerApp(App):
         if result:
             status_bar = self.query_one("#status_bar", Static)
             status_bar.update("Suppression saved to .ash.yaml")
+
+            table = self.query_one("#findings_table", DataTable)
+            idx = table.cursor_row
+            if idx is not None and idx < len(self.filtered_findings):
+                self.filtered_findings[idx]["suppressed"] = True
+                self._populate_table()
 
     def action_previous_finding(self) -> None:
         """Select the previous finding in the table."""

--- a/automated_security_helper/config/ash_config.py
+++ b/automated_security_helper/config/ash_config.py
@@ -740,6 +740,41 @@ class AshConfig(BaseModel):
         return found
 
 
+def add_suppression_to_config(
+    config_path: Path, suppression: AshSuppression
+) -> None:
+    """Append a suppression to the suppressions list in an .ash.yaml config file.
+
+    If the file does not exist it is created with a minimal structure.
+    Existing content is preserved.
+    """
+    if config_path.exists():
+        with open(config_path, mode="r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    else:
+        data = {}
+
+    if not isinstance(data, dict):
+        data = {}
+
+    global_settings = data.setdefault("global_settings", {})
+    if not isinstance(global_settings, dict):
+        global_settings = {}
+        data["global_settings"] = global_settings
+
+    suppressions_list = global_settings.setdefault("suppressions", [])
+    if not isinstance(suppressions_list, list):
+        suppressions_list = []
+        global_settings["suppressions"] = suppressions_list
+
+    entry = suppression.model_dump(exclude_none=True)
+    suppressions_list.append(entry)
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    with open(config_path, mode="w", encoding="utf-8") as f:
+        yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+
 BuildConfig.model_rebuild()
 ConverterConfigSegment.model_rebuild()
 ScannerConfigSegment.model_rebuild()

--- a/automated_security_helper/config/ash_config.py
+++ b/automated_security_helper/config/ash_config.py
@@ -745,9 +745,48 @@ def add_suppression_to_config(
 ) -> None:
     """Append a suppression to the suppressions list in an .ash.yaml config file.
 
-    If the file does not exist it is created with a minimal structure.
-    Existing content is preserved.
+    Uses an append-only strategy when the file already contains a suppressions
+    section, preserving existing comments and formatting. Falls back to a full
+    rewrite for new files or files without a suppressions section.
     """
+    entry = suppression.model_dump(exclude_none=True)
+    entry_yaml = yaml.safe_dump(
+        [entry], default_flow_style=False, sort_keys=False
+    ).rstrip("\n")
+    # yaml.safe_dump wraps in a list; strip the leading "- " indent is handled below
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if config_path.exists():
+        text = config_path.read_text(encoding="utf-8")
+
+        # Duplicate detection: check if rule_id+path already suppressed
+        data = yaml.safe_load(text) or {}
+        if isinstance(data, dict):
+            existing = (
+                data.get("global_settings", {}).get("suppressions", []) or []
+            )
+            for existing_entry in existing:
+                if (
+                    isinstance(existing_entry, dict)
+                    and existing_entry.get("rule_id") == entry.get("rule_id")
+                    and existing_entry.get("path") == entry.get("path")
+                ):
+                    return  # already suppressed
+
+        # Append-only: find the suppressions list and append at its end
+        lines = text.splitlines(keepends=True)
+        insert_idx = _find_suppressions_append_point(lines)
+        if insert_idx is not None:
+            indent = "  "
+            formatted = f"{indent}- " + f"\n{indent}  ".join(
+                f"{k}: {_yaml_scalar(v)}" for k, v in entry.items()
+            ) + "\n"
+            lines.insert(insert_idx, formatted)
+            config_path.write_text("".join(lines), encoding="utf-8")
+            return
+
+    # Fallback: full rewrite (new file or no suppressions section found)
     if config_path.exists():
         with open(config_path, mode="r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
@@ -767,12 +806,69 @@ def add_suppression_to_config(
         suppressions_list = []
         global_settings["suppressions"] = suppressions_list
 
-    entry = suppression.model_dump(exclude_none=True)
     suppressions_list.append(entry)
-
-    config_path.parent.mkdir(parents=True, exist_ok=True)
     with open(config_path, mode="w", encoding="utf-8") as f:
         yaml.safe_dump(data, f, default_flow_style=False, sort_keys=False)
+
+
+def _yaml_scalar(value: object) -> str:
+    """Format a value for inline YAML output."""
+    if isinstance(value, str):
+        if any(c in value for c in ":#{}[]&*!|>'\","):
+            return f'"{value}"'
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int):
+        return str(value)
+    return repr(value)
+
+
+def _find_suppressions_append_point(lines: list) -> int | None:
+    """Find the line index where a new suppression entry should be inserted.
+
+    Looks for the ``suppressions:`` key under ``global_settings:`` and returns
+    the index after the last existing list item (or after the key if the list
+    is empty).
+    """
+    in_global = False
+    in_suppressions = False
+    last_item_end = None
+
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip()
+        indent_len = len(line) - len(stripped)
+
+        if stripped.startswith("global_settings:"):
+            in_global = True
+            continue
+
+        if in_global and indent_len == 0 and stripped and not stripped.startswith("#"):
+            in_global = False
+            if in_suppressions:
+                return last_item_end if last_item_end else None
+            continue
+
+        if in_global and stripped.startswith("suppressions:"):
+            in_suppressions = True
+            last_item_end = idx + 1
+            continue
+
+        if in_suppressions:
+            if stripped.startswith("- "):
+                last_item_end = idx + 1
+                # Walk forward past multi-line entry fields
+                continue
+            if indent_len >= 4 and not stripped.startswith("- "):
+                last_item_end = idx + 1
+                continue
+            if stripped == "" or stripped.startswith("#"):
+                continue
+            return last_item_end
+
+    if in_suppressions:
+        return last_item_end
+    return None
 
 
 BuildConfig.model_rebuild()

--- a/tests/unit/config/test_add_suppression.py
+++ b/tests/unit/config/test_add_suppression.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for add_suppression_to_config."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import yaml
+import pytest
+
+from automated_security_helper.config.ash_config import add_suppression_to_config
+from automated_security_helper.models.core import AshSuppression
+
+
+def _future_date() -> str:
+    return (date.today() + timedelta(days=30)).strftime("%Y-%m-%d")
+
+
+class TestAddSuppressionToConfig:
+    """Tests for the add_suppression_to_config helper."""
+
+    def test_creates_file_when_missing(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        suppression = AshSuppression(
+            rule_id="TEST-001",
+            path="src/app.py",
+            reason="false positive",
+        )
+
+        add_suppression_to_config(config_path, suppression)
+
+        assert config_path.exists()
+        data = yaml.safe_load(config_path.read_text())
+        suppressions = data["global_settings"]["suppressions"]
+        assert len(suppressions) == 1
+        assert suppressions[0]["rule_id"] == "TEST-001"
+        assert suppressions[0]["path"] == "src/app.py"
+        assert suppressions[0]["reason"] == "false positive"
+
+    def test_appends_to_existing_suppressions(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        initial = {
+            "global_settings": {
+                "suppressions": [
+                    {"rule_id": "OLD-001", "path": "old.py", "reason": "legacy"}
+                ]
+            }
+        }
+        config_path.write_text(yaml.safe_dump(initial))
+
+        suppression = AshSuppression(
+            rule_id="NEW-002",
+            path="new.py",
+            reason="accepted risk",
+        )
+        add_suppression_to_config(config_path, suppression)
+
+        data = yaml.safe_load(config_path.read_text())
+        suppressions = data["global_settings"]["suppressions"]
+        assert len(suppressions) == 2
+        assert suppressions[0]["rule_id"] == "OLD-001"
+        assert suppressions[1]["rule_id"] == "NEW-002"
+
+    def test_preserves_unrelated_config_keys(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        initial = {
+            "project_name": "my-project",
+            "global_settings": {"severity_threshold": "HIGH"},
+        }
+        config_path.write_text(yaml.safe_dump(initial))
+
+        suppression = AshSuppression(
+            rule_id="R-1",
+            path="x.py",
+            reason="ok",
+        )
+        add_suppression_to_config(config_path, suppression)
+
+        data = yaml.safe_load(config_path.read_text())
+        assert data["project_name"] == "my-project"
+        assert data["global_settings"]["severity_threshold"] == "HIGH"
+        assert len(data["global_settings"]["suppressions"]) == 1
+
+    def test_includes_optional_fields(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        exp = _future_date()
+        suppression = AshSuppression(
+            rule_id="R-2",
+            path="foo.py",
+            reason="temporary",
+            expiration=exp,
+            line_start=10,
+            line_end=20,
+        )
+
+        add_suppression_to_config(config_path, suppression)
+
+        data = yaml.safe_load(config_path.read_text())
+        entry = data["global_settings"]["suppressions"][0]
+        assert entry["expiration"] == exp
+        assert entry["line_start"] == 10
+        assert entry["line_end"] == 20
+
+    def test_excludes_none_fields(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        suppression = AshSuppression(
+            path="bar.py",
+            reason="no rule id needed",
+        )
+
+        add_suppression_to_config(config_path, suppression)
+
+        data = yaml.safe_load(config_path.read_text())
+        entry = data["global_settings"]["suppressions"][0]
+        assert "rule_id" not in entry
+        assert "line_start" not in entry
+        assert "line_end" not in entry
+        assert "expiration" not in entry
+
+    def test_handles_empty_existing_file(self, tmp_path: Path):
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_text("")
+
+        suppression = AshSuppression(
+            rule_id="E-1",
+            path="e.py",
+            reason="empty file test",
+        )
+
+        add_suppression_to_config(config_path, suppression)
+
+        data = yaml.safe_load(config_path.read_text())
+        assert len(data["global_settings"]["suppressions"]) == 1
+
+    def test_creates_parent_directories(self, tmp_path: Path):
+        config_path = tmp_path / "nested" / "dir" / ".ash.yaml"
+        suppression = AshSuppression(
+            rule_id="N-1",
+            path="n.py",
+            reason="nested dirs",
+        )
+
+        add_suppression_to_config(config_path, suppression)
+
+        assert config_path.exists()
+        data = yaml.safe_load(config_path.read_text())
+        assert len(data["global_settings"]["suppressions"]) == 1


### PR DESCRIPTION
## Summary

- Adds "Suppress" action to the `ash inspect` TUI findings table
- Opens a dialog to configure rule_id, path, reason, and optional expiration
- Writes suppressions to `.ash.yaml` using append-only strategy (preserves comments)
- Shows user-visible error notifications on failure instead of silent dismissal
- Detects and skips duplicate suppressions (same rule_id + path)

## Changes in this PR

- `automated_security_helper/cli/inspect/inspect_findings_app.py` — SuppressDialog with notify-on-error
- `automated_security_helper/config/ash_config.py` — `add_suppression_to_config()` with append-only write, duplicate detection, and `_find_suppressions_append_point()` helper
- `tests/unit/config/test_add_suppression.py` — 7 tests

## Test plan

- [x] Unit tests pass
- [x] Duplicate suppression is silently skipped (no error, no duplicate entry)
- [ ] Manual test: run `ash inspect`, suppress a finding, verify `.ash.yaml` comments preserved

Closes #201