### PR TITLE
feat(#200): add interactive configuration wizard

### DIFF
--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -5,11 +5,13 @@ import logging
 import os
 from pathlib import Path
 import sys
-from typing import Annotated, List
+from typing import Annotated, Dict, List
 import yaml
 import typer
 from rich import print
+from rich.console import Console
 from rich.syntax import Syntax
+from rich.table import Table
 
 from automated_security_helper.config.ash_config import (
     AshConfig,
@@ -686,6 +688,254 @@ def _apply_unused_fixes(
         f"\n✅ Commented out {len(fixed_issues)} unused suppression(s) in {config_path}",
         fg=typer.colors.GREEN,
     )
+
+
+
+def _get_scanner_names() -> List[str]:
+    """Return the list of built-in scanner field names from the config model."""
+    return list(ScannerConfigSegment.model_fields.keys())
+
+
+def _get_reporter_names() -> List[str]:
+    """Return the list of built-in reporter field names from the config model."""
+    return list(ReporterConfigSegment.model_fields.keys())
+
+
+def _prompt_toggle_items(
+    items: List[str],
+    current_enabled: Dict[str, bool],
+    label: str,
+) -> Dict[str, bool]:
+    """Prompt the user to toggle each item on or off.
+
+    Returns a dict mapping item name to enabled state.
+    """
+    console = Console()
+    table = Table(title=label, show_header=True, header_style="bold cyan")
+    table.add_column("Name", style="white")
+    table.add_column("Currently enabled", justify="center")
+    for name in items:
+        status = current_enabled.get(name, True)
+        table.add_row(name, "[green]yes[/green]" if status else "[red]no[/red]")
+    console.print(table)
+
+    result = {}
+    for name in items:
+        default = current_enabled.get(name, True)
+        answer = typer.confirm(
+            f"  Enable {name}?",
+            default=default,
+        )
+        result[name] = answer
+    return result
+
+
+@config_app.command()
+def wizard(
+    config: Annotated[
+        str,
+        typer.Option(
+            "--config",
+            "-c",
+            help="Path to read/write the configuration file.",
+            envvar="ASH_CONFIG",
+        ),
+    ] = ".ash/.ash.yaml",
+    verbose: Annotated[
+        bool, typer.Option("--verbose", "-v", help="Enable verbose logging")
+    ] = False,
+    debug: Annotated[
+        bool, typer.Option("--debug", "-d", help="Enable debug logging")
+    ] = False,
+    color: Annotated[bool, typer.Option(help="Enable/disable colorized output")] = True,
+):
+    """Interactive configuration wizard.
+
+    Reads an existing .ash.yaml (if present), walks through scanner,
+    reporter, offline-mode, and community-plugin settings interactively,
+    then writes the result back.
+    """
+    get_logger(
+        level=(logging.DEBUG if debug else 15 if verbose else logging.INFO),
+        show_progress=False,
+        use_color=color,
+    )
+    console = Console()
+    config_path = Path(config)
+
+    # --- Load existing config or start from defaults ---
+    if config_path.exists():
+        console.print(
+            Panel(
+                f"Loading existing config from [bold]{config_path.absolute()}[/bold]",
+                title="ASH Config Wizard",
+            )
+        )
+        try:
+            ash_config = AshConfig.from_file(config_path=config_path)
+        except Exception as exc:
+            typer.secho(
+                f"Failed to load existing config: {exc}. Starting from defaults.",
+                fg=typer.colors.YELLOW,
+            )
+            ash_config = AshConfig()
+    else:
+        console.print(
+            Panel(
+                "No existing config found -- starting from defaults.",
+                title="ASH Config Wizard",
+            )
+        )
+        ash_config = AshConfig()
+
+    # --- 1. Project name ---
+    project_name = typer.prompt(
+        "Project name",
+        default=ash_config.project_name,
+    )
+    ash_config.project_name = project_name
+
+    # --- 2. Scanners ---
+    console.print("\n[bold]Scanner configuration[/bold]")
+    scanner_names = _get_scanner_names()
+    current_scanner_enabled: Dict[str, bool] = {}
+    for name in scanner_names:
+        scanner_cfg = getattr(ash_config.scanners, name, None)
+        current_scanner_enabled[name] = (
+            scanner_cfg.enabled if scanner_cfg is not None else True
+        )
+
+    scanner_states = _prompt_toggle_items(
+        scanner_names, current_scanner_enabled, "Scanners"
+    )
+    for name, enabled in scanner_states.items():
+        scanner_cfg = getattr(ash_config.scanners, name, None)
+        if scanner_cfg is not None:
+            scanner_cfg.enabled = enabled
+
+    # --- 3. Reporters (output formats) ---
+    console.print("\n[bold]Output format configuration[/bold]")
+    reporter_names = _get_reporter_names()
+    current_reporter_enabled: Dict[str, bool] = {}
+    for name in reporter_names:
+        reporter_cfg = getattr(ash_config.reporters, name, None)
+        current_reporter_enabled[name] = (
+            reporter_cfg.enabled if reporter_cfg is not None else True
+        )
+
+    reporter_states = _prompt_toggle_items(
+        reporter_names, current_reporter_enabled, "Output Formats"
+    )
+    for name, enabled in reporter_states.items():
+        reporter_cfg = getattr(ash_config.reporters, name, None)
+        if reporter_cfg is not None:
+            reporter_cfg.enabled = enabled
+
+    # --- 4. Offline mode ---
+    console.print("\n[bold]Offline mode[/bold]")
+    console.print(
+        "  Offline mode skips tool installation. Set the ASH_OFFLINE "
+        "environment variable at runtime to activate it."
+    )
+    current_offline = (
+        os.environ.get("ASH_OFFLINE", "NO").upper() in ("YES", "TRUE", "1")
+    )
+    enable_offline = typer.confirm(
+        "  Set ASH_OFFLINE=YES in the generated config comments as a reminder?",
+        default=current_offline,
+    )
+
+    # --- 5. Community plugin modules ---
+    console.print("\n[bold]Community plugin modules[/bold]")
+    console.print(
+        "  Provide Python module paths for additional plugins, "
+        "one per line. Leave blank to finish."
+    )
+    existing_modules = list(ash_config.ash_plugin_modules)
+    if existing_modules:
+        console.print(f"  Currently configured: {existing_modules}")
+
+    plugin_modules: List[str] = []
+    for mod in existing_modules:
+        keep = typer.confirm(f"  Keep module '{mod}'?", default=True)
+        if keep:
+            plugin_modules.append(mod)
+
+    while True:
+        new_mod = typer.prompt(
+            "  Add a plugin module (blank to finish)",
+            default="",
+            show_default=False,
+        )
+        if not new_mod.strip():
+            break
+        plugin_modules.append(new_mod.strip())
+
+    ash_config.ash_plugin_modules = plugin_modules
+
+    # --- Write config ---
+    config_path.parent.mkdir(exist_ok=True, parents=True)
+    if config_path.parent.name == ".ash":
+        ash_gitignore_path = config_path.parent.joinpath(".gitignore")
+        if not ash_gitignore_path.exists():
+            ash_gitignore_path.write_text(
+                "# ASH default output directory (and variants)\nash_output*\n"
+            )
+
+    internal_scanner_fields = {"name", "extension", "tool_version", "install_timeout"}
+    scanner_exclusions = {
+        scanner_name: internal_scanner_fields
+        for scanner_name in ScannerConfigSegment.model_fields
+    }
+    reporter_exclusions = {
+        reporter_name: internal_scanner_fields
+        for reporter_name in ReporterConfigSegment.model_fields
+    }
+    converter_exclusions = {
+        converter_name: internal_scanner_fields
+        for converter_name in ConverterConfigSegment.model_fields
+    }
+
+    config_strings = [
+        "# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json",
+    ]
+    if enable_offline:
+        config_strings.append("# Reminder: export ASH_OFFLINE=YES before running ASH for offline mode")
+
+    config_strings.append(
+        yaml.dump(
+            ash_config.model_dump(
+                by_alias=True,
+                exclude_defaults=False,
+                exclude_none=False,
+                exclude={
+                    "build": True,
+                    "mcp_resource_management": True,
+                    "scanners": scanner_exclusions,
+                    "reporters": reporter_exclusions,
+                    "converters": converter_exclusions,
+                },
+            ),
+            Dumper=IndentableYamlDumper,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    )
+    config_path.write_text("\n".join(config_strings))
+
+    console.print(
+        Panel(
+            f"Config written to [bold]{config_path.absolute()}[/bold]",
+            title="Done",
+            style="green",
+        )
+    )
+
+
+if __name__ == "__main__":
+    config_app()
+
+
 
 
 if __name__ == "__main__":

--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -10,6 +10,7 @@ import yaml
 import typer
 from rich import print
 from rich.console import Console
+from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.table import Table
 
@@ -691,42 +692,60 @@ def _apply_unused_fixes(
 
 
 
-def _get_scanner_names() -> List[str]:
-    """Return the list of built-in scanner field names from the config model."""
-    return list(ScannerConfigSegment.model_fields.keys())
+
+def _get_scanner_names() -> List[tuple]:
+    """Return (python_name, display_name) tuples for built-in scanners.
+
+    display_name uses the field's YAML alias when available, falling back
+    to replacing underscores with hyphens.
+    """
+    names = []
+    for name, field_info in ScannerConfigSegment.model_fields.items():
+        alias = field_info.alias or name.replace("_", "-")
+        names.append((name, alias))
+    return names
 
 
-def _get_reporter_names() -> List[str]:
-    """Return the list of built-in reporter field names from the config model."""
-    return list(ReporterConfigSegment.model_fields.keys())
+def _get_reporter_names() -> List[tuple]:
+    """Return (python_name, display_name) tuples for built-in reporters.
+
+    display_name uses the field's YAML alias when available, falling back
+    to replacing underscores with hyphens.
+    """
+    names = []
+    for name, field_info in ReporterConfigSegment.model_fields.items():
+        alias = field_info.alias or name.replace("_", "-")
+        names.append((name, alias))
+    return names
 
 
 def _prompt_toggle_items(
-    items: List[str],
+    items: List[tuple],
     current_enabled: Dict[str, bool],
     label: str,
 ) -> Dict[str, bool]:
     """Prompt the user to toggle each item on or off.
 
-    Returns a dict mapping item name to enabled state.
+    items is a list of (python_name, display_name) tuples.
+    Returns a dict mapping python_name to enabled state.
     """
     console = Console()
     table = Table(title=label, show_header=True, header_style="bold cyan")
     table.add_column("Name", style="white")
     table.add_column("Currently enabled", justify="center")
-    for name in items:
-        status = current_enabled.get(name, True)
-        table.add_row(name, "[green]yes[/green]" if status else "[red]no[/red]")
+    for python_name, display_name in items:
+        status = current_enabled.get(python_name, True)
+        table.add_row(display_name, "[green]yes[/green]" if status else "[red]no[/red]")
     console.print(table)
 
     result = {}
-    for name in items:
-        default = current_enabled.get(name, True)
+    for python_name, display_name in items:
+        default = current_enabled.get(python_name, True)
         answer = typer.confirm(
-            f"  Enable {name}?",
+            f"  Enable {display_name}?",
             default=default,
         )
-        result[name] = answer
+        result[python_name] = answer
     return result
 
 
@@ -797,16 +816,16 @@ def wizard(
 
     # --- 2. Scanners ---
     console.print("\n[bold]Scanner configuration[/bold]")
-    scanner_names = _get_scanner_names()
+    scanner_items = _get_scanner_names()
     current_scanner_enabled: Dict[str, bool] = {}
-    for name in scanner_names:
-        scanner_cfg = getattr(ash_config.scanners, name, None)
-        current_scanner_enabled[name] = (
+    for python_name, _ in scanner_items:
+        scanner_cfg = getattr(ash_config.scanners, python_name, None)
+        current_scanner_enabled[python_name] = (
             scanner_cfg.enabled if scanner_cfg is not None else True
         )
 
     scanner_states = _prompt_toggle_items(
-        scanner_names, current_scanner_enabled, "Scanners"
+        scanner_items, current_scanner_enabled, "Scanners"
     )
     for name, enabled in scanner_states.items():
         scanner_cfg = getattr(ash_config.scanners, name, None)
@@ -815,16 +834,16 @@ def wizard(
 
     # --- 3. Reporters (output formats) ---
     console.print("\n[bold]Output format configuration[/bold]")
-    reporter_names = _get_reporter_names()
+    reporter_items = _get_reporter_names()
     current_reporter_enabled: Dict[str, bool] = {}
-    for name in reporter_names:
-        reporter_cfg = getattr(ash_config.reporters, name, None)
-        current_reporter_enabled[name] = (
+    for python_name, _ in reporter_items:
+        reporter_cfg = getattr(ash_config.reporters, python_name, None)
+        current_reporter_enabled[python_name] = (
             reporter_cfg.enabled if reporter_cfg is not None else True
         )
 
     reporter_states = _prompt_toggle_items(
-        reporter_names, current_reporter_enabled, "Output Formats"
+        reporter_items, current_reporter_enabled, "Output Formats"
     )
     for name, enabled in reporter_states.items():
         reporter_cfg = getattr(ash_config.reporters, name, None)

--- a/tests/unit/cli/test_config_init_wizard.py
+++ b/tests/unit/cli/test_config_init_wizard.py
@@ -32,20 +32,20 @@ class TestHelperFunctions:
         names = _get_scanner_names()
         assert isinstance(names, list)
         assert len(names) > 0
-        assert "bandit" in names
+        python_names = [n[0] for n in names]
+        assert "bandit" in python_names
 
     def test_get_reporter_names_returns_non_empty_list(self):
         names = _get_reporter_names()
         assert isinstance(names, list)
         assert len(names) > 0
-        assert "html" in names
+        python_names = [n[0] for n in names]
+        assert "html" in python_names
 
     def test_prompt_toggle_items_respects_defaults(self, monkeypatch):
         """When user accepts all defaults, output matches input."""
-        items = ["a", "b"]
+        items = [("a", "A"), ("b", "B")]
         current = {"a": True, "b": False}
-        # typer.confirm reads from stdin; simulate pressing Enter for each prompt
-        # which accepts the default
         responses = iter([True, False])
         monkeypatch.setattr("typer.confirm", lambda *a, **kw: next(responses))
         result = _prompt_toggle_items(items, current, "Test")
@@ -79,18 +79,18 @@ class TestWizardCommand:
         lines.append(project_name)
 
         # 2. scanner toggles
-        scanner_names = _get_scanner_names()
+        scanner_items = _get_scanner_names()
         if scanner_answers is None:
-            scanner_answers = {name: True for name in scanner_names}
-        for name in scanner_names:
-            lines.append("Y" if scanner_answers.get(name, True) else "n")
+            scanner_answers = {python_name: True for python_name, _ in scanner_items}
+        for python_name, _ in scanner_items:
+            lines.append("Y" if scanner_answers.get(python_name, True) else "n")
 
         # 3. reporter toggles
-        reporter_names = _get_reporter_names()
+        reporter_items = _get_reporter_names()
         if reporter_answers is None:
-            reporter_answers = {name: True for name in reporter_names}
-        for name in reporter_names:
-            lines.append("Y" if reporter_answers.get(name, True) else "n")
+            reporter_answers = {python_name: True for python_name, _ in reporter_items}
+        for python_name, _ in reporter_items:
+            lines.append("Y" if reporter_answers.get(python_name, True) else "n")
 
         # 4. offline mode
         lines.append("Y" if enable_offline else "n")
@@ -128,7 +128,7 @@ class TestWizardCommand:
 
     def test_wizard_disables_scanner(self, cli_runner, config_path):
         """Disabling a scanner sets its enabled field to false."""
-        scanner_answers = {name: True for name in _get_scanner_names()}
+        scanner_answers = {python_name: True for python_name, _ in _get_scanner_names()}
         scanner_answers["bandit"] = False
 
         user_input = self._build_input(scanner_answers=scanner_answers)
@@ -146,7 +146,7 @@ class TestWizardCommand:
 
     def test_wizard_disables_reporter(self, cli_runner, config_path):
         """Disabling a reporter sets its enabled field to false."""
-        reporter_answers = {name: True for name in _get_reporter_names()}
+        reporter_answers = {python_name: True for python_name, _ in _get_reporter_names()}
         reporter_answers["html"] = False
 
         user_input = self._build_input(reporter_answers=reporter_answers)

--- a/tests/unit/cli/test_config_init_wizard.py
+++ b/tests/unit/cli/test_config_init_wizard.py
@@ -1,0 +1,260 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the interactive configuration wizard (ash config wizard)."""
+
+import yaml
+import pytest
+from typer.testing import CliRunner
+
+from automated_security_helper.cli.config import (
+    config_app,
+    _get_scanner_names,
+    _get_reporter_names,
+    _prompt_toggle_items,
+)
+
+
+@pytest.fixture
+def cli_runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def config_path(tmp_path):
+    return tmp_path / ".ash" / ".ash.yaml"
+
+
+class TestHelperFunctions:
+    """Tests for the internal helpers used by the wizard."""
+
+    def test_get_scanner_names_returns_non_empty_list(self):
+        names = _get_scanner_names()
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert "bandit" in names
+
+    def test_get_reporter_names_returns_non_empty_list(self):
+        names = _get_reporter_names()
+        assert isinstance(names, list)
+        assert len(names) > 0
+        assert "html" in names
+
+    def test_prompt_toggle_items_respects_defaults(self, monkeypatch):
+        """When user accepts all defaults, output matches input."""
+        items = ["a", "b"]
+        current = {"a": True, "b": False}
+        # typer.confirm reads from stdin; simulate pressing Enter for each prompt
+        # which accepts the default
+        responses = iter([True, False])
+        monkeypatch.setattr("typer.confirm", lambda *a, **kw: next(responses))
+        result = _prompt_toggle_items(items, current, "Test")
+        assert result == {"a": True, "b": False}
+
+
+class TestWizardCommand:
+    """Integration tests for the wizard command with mocked prompts."""
+
+    def _build_input(
+        self,
+        project_name="test-proj",
+        scanner_answers=None,
+        reporter_answers=None,
+        enable_offline=False,
+        existing_module_keeps=None,
+        new_modules=None,
+    ):
+        """Build the sequence of stdin lines the wizard expects.
+
+        The wizard prompts:
+        1. Project name (text prompt)
+        2. For each scanner: "Enable X? [Y/n]:" -> "Y" or "n"
+        3. For each reporter: "Enable X? [Y/n]:" -> "Y" or "n"
+        4. Offline reminder confirm
+        5. For each existing module: "Keep module 'X'? [Y/n]:"
+        6. Repeated "Add a plugin module (blank to finish):" until blank
+        """
+        lines = []
+        # 1. project name
+        lines.append(project_name)
+
+        # 2. scanner toggles
+        scanner_names = _get_scanner_names()
+        if scanner_answers is None:
+            scanner_answers = {name: True for name in scanner_names}
+        for name in scanner_names:
+            lines.append("Y" if scanner_answers.get(name, True) else "n")
+
+        # 3. reporter toggles
+        reporter_names = _get_reporter_names()
+        if reporter_answers is None:
+            reporter_answers = {name: True for name in reporter_names}
+        for name in reporter_names:
+            lines.append("Y" if reporter_answers.get(name, True) else "n")
+
+        # 4. offline mode
+        lines.append("Y" if enable_offline else "n")
+
+        # 5. existing module keeps
+        if existing_module_keeps:
+            for keep in existing_module_keeps:
+                lines.append("Y" if keep else "n")
+
+        # 6. new plugin modules
+        if new_modules:
+            for mod in new_modules:
+                lines.append(mod)
+        lines.append("")  # blank to finish
+
+        return "\n".join(lines) + "\n"
+
+    def test_wizard_creates_config_from_scratch(self, cli_runner, config_path):
+        """Wizard creates a valid config when none exists."""
+        user_input = self._build_input(project_name="my-project")
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+        assert config_path.exists()
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["project_name"] == "my-project"
+        assert "scanners" in data
+        assert "reporters" in data
+
+    def test_wizard_disables_scanner(self, cli_runner, config_path):
+        """Disabling a scanner sets its enabled field to false."""
+        scanner_answers = {name: True for name in _get_scanner_names()}
+        scanner_answers["bandit"] = False
+
+        user_input = self._build_input(scanner_answers=scanner_answers)
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["scanners"]["bandit"]["enabled"] is False
+
+    def test_wizard_disables_reporter(self, cli_runner, config_path):
+        """Disabling a reporter sets its enabled field to false."""
+        reporter_answers = {name: True for name in _get_reporter_names()}
+        reporter_answers["html"] = False
+
+        user_input = self._build_input(reporter_answers=reporter_answers)
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["reporters"]["html"]["enabled"] is False
+
+    def test_wizard_offline_reminder_comment(self, cli_runner, config_path):
+        """When offline mode is selected, the config includes a reminder comment."""
+        user_input = self._build_input(enable_offline=True)
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        raw = config_path.read_text()
+        assert "ASH_OFFLINE=YES" in raw
+
+    def test_wizard_no_offline_reminder_by_default(self, cli_runner, config_path):
+        """When offline mode is declined, no reminder comment appears."""
+        user_input = self._build_input(enable_offline=False)
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        raw = config_path.read_text()
+        assert "ASH_OFFLINE" not in raw
+
+    def test_wizard_adds_community_plugin_modules(self, cli_runner, config_path):
+        """New community plugin modules are written to the config."""
+        user_input = self._build_input(
+            new_modules=["my_company.ash_plugins.scanners"],
+        )
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        assert "my_company.ash_plugins.scanners" in data.get(
+            "ash_plugin_modules", []
+        )
+
+    def test_wizard_reads_existing_config(self, cli_runner, config_path):
+        """Wizard loads an existing config and preserves unchanged values."""
+        # First create a config with a known project name
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        seed = {
+            "project_name": "seed-project",
+            "scanners": {"bandit": {"enabled": False}},
+            "reporters": {"html": {"enabled": True}},
+        }
+        config_path.write_text(yaml.dump(seed))
+
+        # Accept all defaults (press Enter through everything)
+        # The project name prompt should default to "seed-project"
+        user_input = self._build_input(project_name="seed-project")
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        assert data["project_name"] == "seed-project"
+
+    def test_wizard_excludes_internal_fields(self, cli_runner, config_path):
+        """Generated config must not contain internal-only fields."""
+        user_input = self._build_input()
+        result = cli_runner.invoke(
+            config_app,
+            ["wizard", "--config", str(config_path)],
+            input=user_input,
+        )
+        assert result.exit_code == 0, f"wizard failed: {result.output}"
+
+        with open(config_path) as f:
+            data = yaml.safe_load(f)
+
+        # Internal top-level fields
+        assert "build" not in data
+        assert "mcp-resource-management" not in data
+
+        # Internal scanner fields
+        internal_fields = {"name", "extension", "tool_version", "install_timeout"}
+        for scanner_name, scanner_cfg in data.get("scanners", {}).items():
+            if isinstance(scanner_cfg, dict):
+                for field in internal_fields:
+                    assert field not in scanner_cfg, (
+                        f"Scanner '{scanner_name}' contains internal field '{field}'"
+                    )


### PR DESCRIPTION
## Summary

- Adds `ash config init` interactive wizard for guided first-time setup
- Walks through scanner selection, reporter selection, offline mode, and community plugins
- Displays user-facing aliases (e.g., `cdk-nag`) instead of internal Python names
- Generates valid `.ash.yaml` with internal fields excluded

## Changes in this PR

- `automated_security_helper/cli/config.py` — `wizard` command, `_get_scanner_names()` / `_get_reporter_names()` returning `(python_name, display_name)` tuples, `_prompt_toggle_items()` with Rich table display
- `tests/unit/cli/test_config_init_wizard.py` — 11 tests covering helpers and full wizard flow

## Test plan

- [x] All 11 unit tests pass
- [x] Tests correctly handle tuple return type from helper functions
- [ ] Manual test: run `ash config wizard` and verify generated YAML is valid

Closes #200