### PR TITLE
fix(ci): skip SARIF upload in merge_group events

### DIFF
--- a/.github/workflows/run-ash-security-scan.yml
+++ b/.github/workflows/run-ash-security-scan.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Upload ASH SARIF file
         uses: github/codeql-action/upload-sarif@v4
-        if: inputs.collect-sarif-report && (success() || failure())
+        if: inputs.collect-sarif-report && github.event_name != 'merge_group' && (success() || failure())
         with:
           sarif_file: ${{ inputs.output-dir }}/reports/ash.sarif
           wait-for-processing: true


### PR DESCRIPTION
## Summary

- Skip `github/codeql-action/upload-sarif` when event is `merge_group`
- The `security-events: write` permission required by upload-sarif is not available in merge queue context
- SARIF upload runs on `push` to main after merge instead

## Root cause

Merge queue creates a temporary branch (`gh-readonly-queue/main/...`) where the GITHUB_TOKEN lacks `security-events: write`. The upload-sarif action fails with "Resource not accessible by integration."

## Test plan

- [ ] PR #291 enters merge queue without the SARIF upload failure