### PR TITLE
docs: comprehensive documentation overhaul with source-derived generation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug Report
+description: Report a bug in ASH
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: version
+    attributes:
+      label: ASH Version
+      description: Which version of ASH are you using?
+      options:
+        - v3.4.x
+        - v3.3.x
+        - Other
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Linux
+        - macOS
+        - Windows
+    validations:
+      required: true
+
+  - type: dropdown
+    id: install-method
+    attributes:
+      label: Installation Method
+      options:
+        - uvx
+        - pip
+        - pipx
+        - container
+        - homebrew
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the behavior.
+      placeholder: |
+        1. Run `ash ...`
+        2. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen.
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened.
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Log Output
+      description: Paste any relevant log output here.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,30 @@
+name: Feature Request
+description: Suggest a new feature
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description
+      description: What problem does this solve?
+      placeholder: I'm frustrated when...
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you like this to work?
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Other approaches you've thought about.
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Any other information that helps explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## Summary
+<!-- Brief description of what this PR does -->
+
+## Related Issues
+<!-- Link to related issues: Closes #123 -->
+
+## Type of Change
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation update
+- [ ] CI/build change
+- [ ] Refactoring (no functional change)
+
+## Checklist
+- [ ] Tests added/updated for the change
+- [ ] Documentation updated (if applicable)
+- [ ] `uv run pytest tests/unit/` passes locally
+- [ ] Commit messages follow conventional format

--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -41,6 +41,14 @@ jobs:
             echo "::error::JSON schemas are out of date. Run 'python -m automated_security_helper.schemas.generate_schemas' and commit the result."
             exit 1
           fi
+      - name: Regenerate CLI reference docs
+        run: uv run python scripts/generate_cli_docs.py
+      - name: Check CLI docs are up to date
+        run: |
+          if ! git diff --exit-code docs/content/docs/cli-reference-generated.md; then
+            echo "::error::CLI reference docs are out of date. Run 'uv run python scripts/generate_cli_docs.py' and commit the result."
+            exit 1
+          fi
       - name: Verify documentation freshness
         run: uv run python scripts/verify_docs_freshness.py
 

--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -41,6 +41,8 @@ jobs:
             echo "::error::JSON schemas are out of date. Run 'python -m automated_security_helper.schemas.generate_schemas' and commit the result."
             exit 1
           fi
+      - name: Verify documentation freshness
+        run: uv run python scripts/verify_docs_freshness.py
 
   unit-test:
     name: "unit-test (${{ matrix.os }}, py${{ matrix.python-version }})"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,12 @@ repos:
         language: system
         verbose: true
         pass_filenames: false
+      - id: generate-cli-docs
+        name: Generate CLI reference docs
+        entry: uv run python scripts/generate_cli_docs.py
+        language: system
+        verbose: true
+        pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ brew install ash
 
 ```bash
 # Install with pipx (isolated environment)
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.0,1
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Use as normal
 ash --help
@@ -225,7 +225,7 @@ The ASH MCP server provides:
     "ash": {
       "command": "uvx",
       "args": [
-        "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+        "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
         "ash",
         "mcp"
       ],
@@ -243,7 +243,7 @@ The ASH MCP server provides:
     "ash-security": {
       "command": "uvx",
       "args": [
-        "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+        "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
         "ash",
         "mcp"
       ]
@@ -259,7 +259,7 @@ The ASH MCP server provides:
     "ash": {
       "command": "uvx",
       "args": [
-        "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+        "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
         "ash",
         "mcp"
       ],
@@ -321,7 +321,7 @@ based on the instructions provided in the prompt.
 
 The MCP server supports all ASH configuration methods:
 
-- **Configuration files**: `.ash/ash.yaml` or custom config paths
+- **Configuration files**: `.ash/.ash.yaml` or custom config paths
 - **Environment variables**: `ASH_DEFAULT_SEVERITY_LEVEL`, `ASH_OFFLINE`, etc.
 - **CLI parameters**: Severity thresholds, custom output directories
 
@@ -330,7 +330,7 @@ For detailed information about streaming capabilities and advanced usage, see th
 
 ## Configuration
 
-ASH v3 uses a YAML configuration file (`.ash/ash.yaml`) with support for JSON Schema validation:
+ASH v3 uses a YAML configuration file (`.ash/.ash.yaml`) with support for JSON Schema validation:
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json
@@ -359,7 +359,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0
+    rev: v3.4.1
     hooks:
       - id: ash-simple-scan
 ```
@@ -382,7 +382,7 @@ ASH v3 produces several output files in the `.ash/ash_output/` directory:
 - `reports/ash.html`: Interactive HTML report
 - `reports/ash.csv`: CSV report for filtering and sorting findings
 
-ASH also supports CycloneDX, SPDX, OCSF, GitLab SAST, JUnit XML, and YAML output. Enable any combination of reporters in your `.ash/ash.yaml` configuration. For the complete schema reference, consumption examples, and format details, see [Output Formats](https://awslabs.github.io/automated-security-helper/docs/output-formats/).
+ASH also supports CycloneDX, SPDX, OCSF, GitLab SAST, JUnit XML, and YAML output. Enable any combination of reporters in your `.ash/.ash.yaml` configuration. For the complete schema reference, consumption examples, and format details, see [Output Formats](https://awslabs.github.io/automated-security-helper/docs/output-formats/).
 
 The `ash_aggregated_results.json` file includes comprehensive validation information that tracks scanner registration, enablement, execution, and result inclusion throughout the scan process. The Scanner Validation System can also generate detailed validation reports that provide comprehensive analysis of scanner states, validation checkpoints, dependency issues, and actionable recommendations for troubleshooting scan issues.
 
@@ -403,7 +403,7 @@ ASH can be run in container mode in any CI/CD environment that supports containe
 <details>
 <summary>How do I exclude files from scanning?</summary>
 
-ASH respects `.gitignore` files. You can also configure ignore paths in your `.ash/ash.yaml` configuration file.
+ASH respects `.gitignore` files. You can also configure ignore paths in your `.ash/.ash.yaml` configuration file.
 </details>
 
 <details>

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 3.x     | Yes                |
+| 2.x     | No (end of life)   |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in this project, please report it responsibly.
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, use one of the following channels:
+
+- Email: aws-security@amazon.com
+- GitHub Security Advisories: use the "Report a vulnerability" button on the [Security tab](../../security/advisories/new)
+
+### What to include
+
+- A description of the vulnerability and its potential impact
+- Steps to reproduce or a proof of concept
+- The affected version(s)
+- Any suggested fix, if you have one
+
+### Response timeline
+
+- **Acknowledgment**: within 48 hours of receipt
+- **Fix timeline**: depends on severity. Critical issues are prioritized for the next patch release; lower-severity issues are scheduled into the regular release cycle.
+
+## Scope
+
+### In scope
+
+- Vulnerabilities in ASH source code (Python, shell scripts)
+- Dependency vulnerabilities that affect ASH at runtime
+- CI/CD injection or supply-chain risks in the build pipeline
+- Authentication or authorization flaws in MCP server endpoints
+
+### Out of scope
+
+- False positives produced by scanners that ASH orchestrates (e.g., Semgrep, Bandit, cfn-lint)
+- Bugs in third-party tools that ASH invokes but does not maintain
+- Reports that require physical access to the machine running ASH
+- Social engineering attacks against maintainers
+
+## Preferred Languages
+
+We accept vulnerability reports in English.

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/csv_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/csv_reporter.py
@@ -17,6 +17,8 @@ class CSVReporterConfigOptions(ReporterOptionsBase):
 
 
 class CSVReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the CSV findings export reporter."""
+
     name: Literal["csv"] = "csv"
     extension: str = "csv"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/cyclonedx_reporter.py
@@ -17,6 +17,8 @@ class CycloneDXReporterConfigOptions(ReporterOptionsBase):
 
 
 class CycloneDXReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the CycloneDX SBOM reporter."""
+
     name: Literal["cyclonedx"] = "cyclonedx"
     extension: str = "cdx.json"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/github_ghas_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/github_ghas_reporter.py
@@ -59,6 +59,8 @@ class GHASReporterConfigOptions(ReporterOptionsBase):
 
 
 class GHASReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the GitHub Advanced Security SARIF reporter."""
+
     name: Literal["github-ghas"] = "github-ghas"
     extension: str = "ghas.sarif"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
@@ -134,6 +134,8 @@ class GitLabCycloneDXReporterConfigOptions(ReporterOptionsBase):
 
 
 class GitLabCycloneDXReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the GitLab Dependency List CycloneDX reporter."""
+
     name: Literal["gitlab-cyclonedx"] = "gitlab-cyclonedx"
     extension: str = "gl-dependency-scanning-report.cdx.json"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
@@ -36,6 +36,8 @@ class GitLabSASTReporterConfigOptions(ReporterOptionsBase):
 
 
 class GitLabSASTReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the GitLab SAST report format."""
+
     name: Literal["gitlab-sast"] = "gitlab-sast"
     extension: str = "gl-sast-report.json"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
@@ -24,6 +24,8 @@ class HTMLReporterConfigOptions(ReporterOptionsBase):
 
 
 class HTMLReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the interactive HTML findings report."""
+
     name: Literal["html"] = "html"
     extension: str = "html"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/junitxml_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/junitxml_reporter.py
@@ -22,6 +22,8 @@ class JUnitXMLReporterConfigOptions(ReporterOptionsBase):
 
 
 class JUnitXMLReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the JUnit XML test report format."""
+
     name: Literal["junitxml"] = "junitxml"
     extension: str = "junit.xml"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/ocsf_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/ocsf_reporter.py
@@ -36,6 +36,8 @@ class OCSFReporterConfigOptions(ReporterOptionsBase):
 
 
 class OCSFReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the OCSF security event reporter."""
+
     name: Literal["ocsf"] = "ocsf"
     extension: str = "ocsf.json"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/sarif_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/sarif_reporter.py
@@ -17,6 +17,8 @@ class SARIFReporterConfigOptions(ReporterOptionsBase):
 
 
 class SARIFReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the SARIF 2.1.0 standard output."""
+
     name: Literal["sarif"] = "sarif"
     extension: str = "sarif"
     enabled: bool = True

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
@@ -19,6 +19,8 @@ class SPDXReporterConfigOptions(ReporterOptionsBase):
 
 
 class SPDXReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the SPDX 2.3 SBOM reporter."""
+
     name: Literal["spdx"] = "spdx"
     extension: str = "spdx.json"
     enabled: bool = False

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
@@ -19,6 +19,8 @@ class YAMLReporterConfigOptions(ReporterOptionsBase):
 
 
 class YAMLReporterConfig(ReporterPluginConfigBase):
+    """Configuration for the YAML findings export."""
+
     name: Literal["yaml"] = "yaml"
     extension: str = "yaml"
     enabled: bool = False

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
@@ -83,6 +83,8 @@ class BanditScannerConfigOptions(ScannerOptionsBase):
 
 
 class BanditScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the Bandit Python security linter."""
+
     name: Literal["bandit"] = "bandit"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -92,6 +92,8 @@ class CdkNagScannerConfigOptions(ScannerOptionsBase):
 
 
 class CdkNagScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the CDK Nag AWS best-practices checker."""
+
     name: Literal["cdk-nag"] = "cdk-nag"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
@@ -40,6 +40,8 @@ class CfnNagScannerConfigOptions(ScannerOptionsBase):
 
 
 class CfnNagScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the cfn-nag CloudFormation linter."""
+
     name: Literal["cfn-nag"] = "cfn-nag"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
@@ -133,6 +133,8 @@ class CheckovScannerConfigOptions(ScannerOptionsBase):
 
 
 class CheckovScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the Checkov infrastructure-as-code scanner."""
+
     name: Literal["checkov"] = "checkov"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
@@ -97,6 +97,8 @@ class DetectSecretsScannerConfigOptions(ScannerOptionsBase):
 
 
 class DetectSecretsScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the detect-secrets credential scanner."""
+
     name: Literal["detect-secrets"] = "detect-secrets"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/grype_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/grype_scanner.py
@@ -52,6 +52,8 @@ class GrypeScannerConfigOptions(ScannerOptionsBase):
 
 
 class GrypeScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the Grype vulnerability scanner."""
+
     name: Literal["grype"] = "grype"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
@@ -52,6 +52,8 @@ class NpmAuditScannerConfigOptions(ScannerOptionsBase):
 
 
 class NpmAuditScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the npm/pnpm/yarn audit dependency scanner."""
+
     name: Literal["npm-audit"] = "npm-audit"
     enabled: bool = True
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/opengrep_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/opengrep_scanner.py
@@ -98,6 +98,8 @@ class OpengrepScannerConfigOptions(ScannerOptionsBase):
 
 
 class OpengrepScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the OpenGrep SAST scanner."""
+
     name: Literal["opengrep"] = "opengrep"
     enabled: bool = platform.system().lower() != "windows"
     options: Annotated[

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/semgrep_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/semgrep_scanner.py
@@ -91,6 +91,8 @@ class SemgrepScannerConfigOptions(ScannerOptionsBase):
 
 
 class SemgrepScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the Semgrep SAST scanner."""
+
     name: Literal["semgrep"] = "semgrep"
     # Semgrep does not support Windows at all
     enabled: bool = platform.system().lower() != "windows"

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
@@ -58,6 +58,8 @@ class SyftScannerConfigOptions(ScannerOptionsBase):
 
 
 class SyftScannerConfig(ScannerPluginConfigBase):
+    """Configuration for the Syft SBOM generator."""
+
     name: Literal["syft"] = "syft"
     enabled: bool = True
     options: Annotated[

--- a/docs/content/.nav.yml
+++ b/docs/content/.nav.yml
@@ -6,6 +6,10 @@ nav:
       - Migrating from ASH v2 to v3: docs/migration-guide.md
       - Troubleshooting UV Installation: docs/troubleshooting-uv-installation.md
       - UV Tool Installation Guide: docs/uv-tool-installation-guide.md
+  - Concepts:
+      - Core Concepts: docs/concepts.md
+      - Supported Languages & Frameworks: docs/supported-languages.md
+      - Glossary: docs/glossary.md
   - User Guide:
       - Configuration: docs/configuration-guide.md
       - CLI Reference: docs/cli-reference.md
@@ -79,5 +83,6 @@ nav:
           - Parallel Testing: docs/testing/parallel_testing.md
           - Test Utilities: docs/testing/test_utilities.md
   - Reference:
+      - API Reference: docs/api-reference.md
       - Support: docs/support.md
       - FAQ: faq.md

--- a/docs/content/docs/advanced-usage.md
+++ b/docs/content/docs/advanced-usage.md
@@ -255,7 +255,7 @@ print(f"Found {results.summary_stats.total_findings} findings")
 
 ## CI/CD Integration
 
-> **Tip**: The examples below use pinned versions (`@v3.4.0`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
+> **Tip**: The examples below use pinned versions (`@v3.4.1`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD.
 
 ### GitHub Actions
 
@@ -278,7 +278,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -294,7 +294,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
     - ash --mode local
   artifacts:
     paths:

--- a/docs/content/docs/api-reference.md
+++ b/docs/content/docs/api-reference.md
@@ -1,11 +1,69 @@
 # Python API Reference
 
+## Scan Execution
+
 ::: automated_security_helper.interactions.run_ash_scan
     options:
       show_root_heading: true
       members_order: source
 
+## Data Models
+
 ::: automated_security_helper.models.core
     options:
       show_root_heading: true
       members_order: source
+
+## Configuration Models
+
+::: automated_security_helper.config.ash_config.ScannerConfigSegment
+    options:
+      show_root_heading: true
+      members_order: source
+      show_bases: false
+
+::: automated_security_helper.config.ash_config.ReporterConfigSegment
+    options:
+      show_root_heading: true
+      members_order: source
+      show_bases: false
+
+## Scanner Plugins
+
+::: automated_security_helper.plugin_modules.ash_builtin.scanners.bandit_scanner.BanditScanner
+    options:
+      show_root_heading: true
+      members: [scan]
+      show_bases: false
+
+::: automated_security_helper.plugin_modules.ash_builtin.scanners.checkov_scanner.CheckovScanner
+    options:
+      show_root_heading: true
+      members: [scan]
+      show_bases: false
+
+::: automated_security_helper.plugin_modules.ash_builtin.scanners.semgrep_scanner.SemgrepScanner
+    options:
+      show_root_heading: true
+      members: [scan]
+      show_bases: false
+
+## Reporter Plugins
+
+::: automated_security_helper.plugin_modules.ash_builtin.reporters.sarif_reporter.SarifReporter
+    options:
+      show_root_heading: true
+      members: [report]
+      show_bases: false
+
+::: automated_security_helper.plugin_modules.ash_builtin.reporters.html_reporter.HtmlReporter
+    options:
+      show_root_heading: true
+      members: [report]
+      show_bases: false
+
+::: automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_cyclonedx_reporter.GitLabCycloneDXReporter
+    options:
+      show_root_heading: true
+      members: [report]
+      show_bases: false

--- a/docs/content/docs/api-reference.md
+++ b/docs/content/docs/api-reference.md
@@ -1,0 +1,11 @@
+# Python API Reference
+
+::: automated_security_helper.interactions.run_ash_scan
+    options:
+      show_root_heading: true
+      members_order: source
+
+::: automated_security_helper.models.core
+    options:
+      show_root_heading: true
+      members_order: source

--- a/docs/content/docs/cli-reference-generated.md
+++ b/docs/content/docs/cli-reference-generated.md
@@ -1,0 +1,299 @@
+# CLI Reference (Auto-Generated)
+
+This document is auto-generated from the ASH CLI source code using introspection.
+Do not edit manually. Regenerate with: `uv run python scripts/generate_cli_docs.py`
+
+## Commands
+
+### `ash scan`
+
+Runs an ASH scan against the source-dir, outputting results to the output-dir.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--source-dir` | str |  | ASH_SOURCE_DIR | The source directory to scan |
+| `--output-dir` | str |  | ASH_OUTPUT_DIR | The directory to output results to |
+| `--scanners` | List[str] |  | ASH_SCANNERS | Specific scanner names to run. Defaults to all scanners. |
+| `--exclude-scanners` | List[str] |  | ASH_EXCLUDED_SCANNERS | Specific scanner names to exclude from running. Takes precedence over scanners parameter. |
+| `--ash-plugin-modules` | List[str] |  | ASH_PLUGIN_MODULES | List of Python modules to import containing ASH plugins and/or event subscribers. These are loaded in addition to the default modules. |
+| `--config-overrides` | List[str] |  |  | Configuration overrides specified as key-value pairs (e.g., 'reporters.cloudwatch-logs.options.aws_region=us-west-2'). Supports lists with [item1,item2], append mode with key+=[value], and JSON syntax. See docs/config-overrides.md |
+| `--offline` | bool | False |  | Run scan in offline/airgapped mode (skips NPM/PNPM/Yarn Audit checks). IMPORTANT: Online access is needed when building ASH to prepare it for usage during a scan! If selecting Offline while performing a build, the ASH container image will be built in offline mode and any typically online-only dependencies like downloadable tool vulnerability databases will be cached in the image itself before publishing for scan usage. |
+| `--offline-semgrep-rulesets` | str | `p/ci` |  | Specify Semgrep rulesets for use in ASH offline mode |
+| `--strategy` | enum(sequential, parallel) | `parallel` |  | Whether to run scanners in parallel or sequential |
+| `-p/-P` | bool | True |  | Show progress of each job live in the console. Defaults to True. |
+| `--output-format`, `--formats`, `--format`, `-f` | List[str] |  |  | The output formats to use (comma-separated). Available formats: aggregated, text, flat-json, yaml, csv, html, dict, junitxml, markdown, sarif, asff, ocsf, cyclonedx, spdx, custom |
+| `--cleanup` | bool | False |  | Clean up 'converted' directory and other temporary files after scan completes. Defaults to False. Note: Scans will always clean up existing files in the output directory before a new scan starts. This parameter only affects the cleanup of the temporary work directory after a scan has completed, typically for inspection of temporary artifacts. |
+| `--phases` | List[enum(convert, scan, report, inspect)] |  |  | The phases to run. Defaults to all phases except inspect. |
+| `--inspect` | bool | False |  | Enable inspection of SARIF fields after running. This adds the inspect phase to the execution. |
+| `--use-existing` | bool | False |  | Use an existing ash_aggregated_results.json file in the output-dir. If True, the scan phase will be skipped and reports will be generated from this file. |
+| `--version` | bool | False |  | Prints version number |
+| `--mode` | enum(precommit, container, local) | `RunMode.local` | ASH_MODE | Execution mode preset. 'precommit' enables python-based plugins only and simplified output. 'container' runs non-Python plugins in a container. 'local' (default) runs everything in the local Python process. |
+| `--python-based-scanners-only/--all-enabled-scanners`, `--python-based-plugins-only/--all-enabled-plugins` | bool | False |  | Exclude execution of any plugins or tools that have depencies external to Python. |
+| `--show-summary` | bool | True |  | Show metrics table and results summary |
+| `--quiet` | bool | False |  | Hide all log output |
+| `--log-level` | enum(QUIET, SIMPLE, ERROR, INFO, ...) | `AshLogLevel.INFO` |  | Set the log level. |
+| `-c` | str |  | ASH_CONFIG | The path to the configuration file. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. Alternatively, the full path to a config file can be provided by setting the ASH_CONFIG environment variable before running ASH. |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+| `--fail-on-findings` | bool |  |  | Enable/disable throwing non-successful exit codes if any actionable findings are found. Defaults to unset, which prefers the configuration value. If this is set directly, it takes precedence over the configuration value. |
+| `--simple` | bool | False |  | Simplified output mode with minimal logging |
+| `--ignore-suppressions` | bool | False |  | Ignore all suppression rules and report all findings regardless of suppression status. |
+| `--min-severity` | str | `low` |  | Minimum severity to trigger non-zero exit code (critical, high, medium, low, none). 'critical' and 'high' are equivalent because SARIF does not distinguish them. Findings below this threshold are still reported but don't affect the exit code. |
+| `--compact-report` | bool | False |  | Produce a shorter markdown report suitable for PR comments. Omits the severity legend, scan metadata, footer, and rows for scanners that were skipped or had zero findings. |
+| `--changed-files-only` | bool | False | ASH_CHANGED_FILES_ONLY | Limit the scan to files changed between the base branch and HEAD. Useful in CI to scan only PR changes. Falls back to a full scan when git is unavailable. |
+| `--base-ref` | str | `origin/main` | ASH_BASE_REF | Git ref to diff against when --changed-files-only is set. |
+| `-b/-B` | bool | True |  | Whether to build the ASH container image |
+| `-r/-R` | bool | True |  | Whether to run the ASH container image |
+| `--force` | bool | False |  | Force rebuild of the ASH container image |
+| `--oci`, `--runner`, `-o` | str |  | OCI_RUNNER | Use the specified OCI runner instead of docker to run the containerized tools |
+| `--build-target` | enum(non-root, ci) |  |  | Specify the target stage of the ASH image to build |
+| `-u` | str |  |  | UID to use for the container user |
+| `-g` | str |  |  | GID to use for the container user |
+| `--ash-revision-to-install` | str |  |  | ASH branch or tag to install in the container image for usage during containerized scans |
+| `--custom-containerfile` | str |  |  | Path to a custom container definition (e.g. Dockerfile) that you would like to build *after* the ASH container image builds. This is typically used when building a custom container image for ASH and including custom tooling that ASH does not come with by default. The fully qualified image name for the ASH image is passed in as the `ASH_BASE_IMAGE` build-arg so you can use it as a base. IMPORTANT: When a custom_containerfile path is provided, the build-target is set to `ci` so the container run-as configuration is not shifted to the non-root user. If you are using this parameter, you are responsible for securing your final container as appropriate. |
+| `--custom-build-arg` | List[str] |  |  | Custom build arguments to pass to the container build |
+
+### `ash build-image`
+
+Builds the ASH container image then runs a scan with it.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `-f` | bool | False |  | Force rebuild of the ASH container image |
+| `--oci`, `--runner`, `-r` | str |  | OCI_RUNNER | Use the specified OCI runner instead of docker to run the containerized tools |
+| `--build-target` | enum(non-root, ci) | `BuildTarget.NON_ROOT` |  | Specify the target stage of the ASH image to build |
+| `--offline-semgrep-rulesets` | str | `p/ci` |  | Specify Semgrep rulesets for use in ASH offline mode |
+| `-u` | str |  |  | UID to use for the container user |
+| `-g` | str |  |  | GID to use for the container user |
+| `--ash-revision-to-install` | str |  |  | ASH branch or tag to install in the container image for usage during containerized scans |
+| `--custom-containerfile` | str |  |  | Path to a custom container definition (e.g. Dockerfile) that you would like to build *after* the ASH container image builds. This is typically used when building a custom container image for ASH and including custom tooling that ASH does not come with by default. The fully qualified image name for the ASH image is passed in as the `ASH_BASE_IMAGE` build-arg so you can use it as a base. IMPORTANT: When a custom_containerfile path is provided, the build-target is set to `ci` so the container run-as configuration is not shifted to the non-root user. If you are using this parameter, you are responsible for securing your final container as appropriate. |
+| `--custom-build-arg` | List[str] |  |  | Custom build arguments to pass to the container build |
+| `--config-overrides` | List[str] |  |  | Configuration overrides specified as key-value pairs (e.g., 'reporters.cloudwatch-logs.options.aws_region=us-west-2') |
+| `--offline` | bool | False |  | Run scan in offline/airgapped mode (skips NPM/PNPM/Yarn Audit checks). IMPORTANT: Online access is needed when building ASH to prepare it for usage during a scan! If selecting Offline while performing a build, the ASH container image will be built in offline mode and any typically online-only dependencies like downloadable tool vulnerability databases will be cached in the image itself before publishing for scan usage. |
+| `--quiet` | bool | False |  | Hide all log output |
+| `--log-level` | enum(QUIET, SIMPLE, ERROR, INFO, ...) | `AshLogLevel.INFO` |  | Set the log level. |
+| `-c` | str |  | ASH_CONFIG | The path to the configuration file. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. Alternatively, the full path to a config file can be provided by setting the ASH_CONFIG environment variable before running ASH. |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash report`
+
+Generate a report from ASH scan results using the specified reporter plugin.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--report-format` | str | `markdown` |  | Report format to generate (reporter plugin name). Defaults to 'markdown'. Examples values: aggregated, text, flat-json, yaml, csv, html, dict, junitxml, markdown, sarif, asff, ocsf, cyclonedx, spdx, custom |
+| `--output-dir` | str |  | ASH_OUTPUT_DIR | The directory to output results to |
+| `--log-level` | enum(QUIET, SIMPLE, ERROR, INFO, ...) | `AshLogLevel.INFO` |  | Set the log level. |
+| `-c` | str |  | ASH_CONFIG | The path to the configuration file. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. Alternatively, the full path to a config file can be provided by setting the ASH_CONFIG environment variable before running ASH. |
+| `--config-overrides` | List[str] |  |  | Configuration overrides specified as key-value pairs (e.g., 'reporters.cloudwatch-logs.options.aws_region=us-west-2') |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash mcp`
+
+Start the ASH MCP server (Model Context Protocol).
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--log-level` | str | `INFO` |  | Log level |
+| `--verbose` | bool | False |  | Verbose output |
+| `--debug` | bool | False |  | Debug output |
+| `--color` | bool | True |  | Enable color output |
+| `--quiet` | bool | False |  | Quiet output |
+
+### `ash get-genai-guide`
+
+Download the ASH GenAI Integration Guide for use with AI assistants and LLMs.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--output`, `-o` | str | `ash-genai-guide.md` |  | Output path for the GenAI integration guide |
+| `--from-github` | bool | False |  | Fetch from GitHub instead of local installation |
+| `--branch`, `-b` | str | `main` |  | GitHub branch to fetch from when using --from-github (default: main) |
+
+## Config Subcommands
+
+### `ash config init`
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `-c` | str | `.ash/.ash.yaml` | ASH_CONFIG | The path to the configuration file. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. Alternatively, the full path to a config file can be provided by setting the ASH_CONFIG environment variable before running ASH. |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+| `--force` | bool | False |  | Overwrite the config file if it already exists at the target path. |
+
+### `ash config get`
+
+**Arguments:**
+
+| Argument | Type | Default | Env Var | Description |
+|----------|------|---------|---------|-------------|
+| `CONFIG_PATH` | str |  |  | The name of the config file to get. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. If  a different filename is specified, it must be provided when running ASH via the `--config` option or by setting the `ASH_CONFIG` environment variable. |
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--config-overrides` | List[str] | [] |  | Configuration overrides specified as key-value pairs (e.g., 'global_settings.severity_threshold=LOW') |
+| `--verbose` | bool | False |  | Enable verbose logging |
+| `--debug` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash config update`
+
+Update an existing configuration file with the specified modifications.
+
+**Arguments:**
+
+| Argument | Type | Default | Env Var | Description |
+|----------|------|---------|---------|-------------|
+| `CONFIG_PATH` | str |  |  | The path to the configuration file to update. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. |
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--modifications` | List[str] | [] |  | Configuration modifications specified as key-value pairs (e.g., 'global_settings.severity_threshold=LOW'). Supports lists with [item1,item2], append mode with key+=[value], and JSON syntax. |
+| `--verbose` | bool | False |  | Enable verbose logging |
+| `--debug` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+| `--dry-run` | bool | False |  | Show changes without writing to file |
+
+### `ash config validate-plugin-dependencies`
+
+**Arguments:**
+
+| Argument | Type | Default | Env Var | Description |
+|----------|------|---------|---------|-------------|
+| `CONFIG_PATH` | str |  |  | The name of the config file to create. By default, ASH looks for the following config file names in the source directory of a scan: ['.ash.yml', '.ash.yaml', '.ash.json', 'ash.yml', 'ash.yaml', 'ash.json']. If  a different filename is specified, it must be provided when running ASH via the `--config` option or by setting the `ASH_CONFIG` environment variable. |
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--config-overrides` | List[str] | [] |  | Configuration overrides specified as key-value pairs (e.g., 'global_settings.severity_threshold=LOW') |
+| `--verbose` | bool | False |  | Enable verbose logging |
+| `--debug` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash config lint`
+
+Lint an ASH configuration file for issues and optionally auto-fix them.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `-c` | str | `.ash/.ash.yaml` | ASH_CONFIG | The path to the configuration file to lint. By default, ASH looks for config files in .ash/.ash.yaml |
+| `-o` | str |  |  | Path to the ASH output directory (for unused suppressions report). Defaults to .ash/ash_output |
+| `--fix` | bool | False |  | Auto-fix fixable issues (internal fields, missing line_end, expired suppressions) |
+| `--fix-unused` | bool | False |  | Comment out unused suppressions based on the last scan's unused suppressions report |
+| `--yes`, `-y` | bool | False |  | Accept all changes without prompting. Useful for pre-commit hooks and CI/CD |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash config wizard`
+
+Interactive configuration wizard.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `-c` | str | `.ash/.ash.yaml` | ASH_CONFIG | Path to read/write the configuration file. |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+| `--color` | bool | True |  | Enable/disable colorized output |
+
+### `ash config validate`
+
+Validate an ASH configuration file for common issues.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `-c` | str | `.ash/.ash.yaml` | ASH_CONFIG | The path to the configuration file to validate. By default, ASH looks for config files in .ash/.ash.yaml |
+| `-v` | bool | False |  | Enable verbose logging |
+| `-d` | bool | False |  | Enable debug logging |
+
+## Inspect Subcommands
+
+### `ash inspect findings`
+
+Interactively explore security findings.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--output-dir` | Path |  |  | Path to the output directory containing an ASH Aggregated Results JSON report file to analyze. |
+| `--report-file` | str | `ash_aggregated_results.json` |  | Name of the report file to analyze. Defaults to 'ash_aggregated_results.json'. |
+
+### `ash inspect sarif-fields`
+
+Analyze SARIF fields across different scanners to understand their schema.
+
+| Flag | Type | Default | Env Var | Description |
+|------|------|---------|---------|-------------|
+| `--sarif-dir` | str |  |  | Directory containing SARIF files to analyze |
+| `--output-dir` | str |  |  | Directory to write output files |
+
+## MCP Tools
+
+The ASH MCP server exposes the following tools for integration with AI assistants via the Model Context Protocol.
+
+### `cancel_scan`
+
+Cancel a running scan and clean up its resources.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scan_id` | str | *required* | The scan ID to cancel |
+
+### `check_installation`
+
+Check if ASH is properly installed and ready to use.
+
+### `get_scan_progress`
+
+Get current progress and partial results for a running scan.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `scan_id` | str | *required* | The scan ID returned from run_ash_scan |
+
+### `get_scan_result_paths`
+
+Get file paths for all scan result files by type.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `output_dir` | str | `.ash/ash_output` | Path to the scan output directory (absolute path recommended) |
+
+### `get_scan_results`
+
+Get final results for a completed scan with optional filtering.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `output_dir` | str | `.ash/ash_output` | Path to the scan output directory (absolute path recommended) |
+| `filter_level` | str | `full` | Filter level for response data. Options: |
+| `scanners` | str |  | Comma-separated list of scanner names to include (e.g., "bandit,semgrep"). |
+| `severities` | str |  | Comma-separated list of severity levels to include (e.g., "critical,high,medium"). |
+| `actionable_only` | bool | False | If True, exclude suppressed findings from results. This filters out findings |
+
+### `get_scan_summary`
+
+Get a lightweight summary of scan results without detailed findings.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `output_dir` | str | `.ash/ash_output` | Path to the scan output directory (absolute path recommended) |
+
+### `list_active_scans`
+
+List all active and recent scans with their current status.
+
+### `run_ash_scan`
+
+Start a security scan and return immediately.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `source_dir` | str |  | Path to the directory to scan. This should be the absolute path! |
+| `severity_threshold` | str | `MEDIUM` | Minimum severity threshold (LOW, MEDIUM, HIGH, CRITICAL) |
+| `config_path` | str |  | Optional path to ASH configuration file |
+| `clean_output` | bool | True | Whether to clean up existing output files before starting the scan |

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -657,7 +657,7 @@ For Amazon Q CLI (`~/.aws/amazonq/mcp.json`):
     "ash": {
       "command": "uvx",
       "args": [
-        "--from=git+https://github.com/awslabs/automated-security-helper@v3.2.2",
+        "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
         "ash",
         "mcp"
       ],

--- a/docs/content/docs/concepts.md
+++ b/docs/content/docs/concepts.md
@@ -1,0 +1,64 @@
+# Core Concepts
+
+This page explains the domain model behind ASH — the key abstractions and how they fit together.
+
+## Finding
+
+A finding is a single security issue detected by a scanner. Each finding has a rule ID, severity level, source location (file and line), and a message describing the problem. Internally, ASH represents all findings in SARIF format regardless of which scanner produced them.
+
+## Scanner
+
+A scanner is a plugin that analyzes source code, configuration files, or container images for a specific class of vulnerabilities. Each scanner wraps an external tool (like Bandit, Checkov, or Grype), invokes it against the target, and translates its output into SARIF findings. ASH ships with built-in scanners and supports community-contributed ones.
+
+## Converter
+
+A converter transforms input files into a format that scanners can process. For example, a converter might extract files from a ZIP archive, convert Jupyter notebooks to Python scripts, or render Helm charts into Kubernetes manifests. Converters run before scanners in the pipeline.
+
+## Reporter
+
+A reporter takes the aggregated SARIF findings and produces output in a specific format. Built-in reporters generate HTML dashboards, CSV spreadsheets, SARIF files, CycloneDX SBOMs, and OCSF events. AWS reporters can push findings to Security Hub, CloudWatch Logs, or S3.
+
+## Suppression
+
+A suppression is a rule that hides a known-accepted finding from results. Suppressions can be config-based (defined in `.ash-config.yml` by rule ID, file path, or pattern) or inline (a code comment like `# ash-ignore:rule-id` placed next to the flagged line). Suppressed findings are still recorded but marked as suppressed in the output.
+
+## Phases
+
+ASH processes code in four sequential phases:
+
+1. **Convert** — transform input files into scannable formats
+2. **Scan** — run all enabled scanners against the (converted) source
+3. **Report** — generate output files from the collected findings
+4. **Inspect** — launch an interactive UI for reviewing results (optional)
+
+## Modes
+
+ASH supports three execution modes:
+
+- **Local** — runs scanners directly on the host using UV-managed tool installations
+- **Container** — runs inside a Docker container with all tools pre-installed
+- **Pre-commit** — runs as a Git pre-commit hook, scanning only staged files
+
+## SARIF
+
+SARIF (Static Analysis Results Interchange Format) is the internal data model. Every scanner produces SARIF output, every suppression rule matches against SARIF properties, and every reporter consumes SARIF as input. This common format lets ASH treat all scanners uniformly regardless of their native output format.
+
+## Data Flow
+
+The following diagram shows how findings flow through the system:
+
+```mermaid
+flowchart LR
+    A[Source Code] --> B[Convert]
+    B --> C[Scan]
+    C --> D[SARIF Findings]
+    D --> E[Suppression Filtering]
+    E --> F[Reporters]
+    F --> G[Output Files]
+
+    style A fill:#f9f9f9,stroke:#333
+    style D fill:#e8f4fd,stroke:#0969da
+    style G fill:#f0fff0,stroke:#2da44e
+```
+
+Source code enters the pipeline, converters prepare it, scanners produce SARIF findings, suppression rules filter out accepted issues, and reporters write the final output in the requested formats.

--- a/docs/content/docs/configuration-guide.md
+++ b/docs/content/docs/configuration-guide.md
@@ -66,13 +66,13 @@ global_settings:
   # Findings to suppress based on rule ID, file path, and line numbers
   suppressions:
     - rule_id: 'RULE-123'  # Scanner-specific rule ID
-      file_path: 'src/example.py'  # File path (supports glob patterns)
+      path: 'src/example.py'  # File path (supports glob patterns)
       line_start: 10  # Optional starting line number
       line_end: 15  # Optional ending line number
       reason: 'False positive due to test mock'  # Reason for suppression
       expiration: '2025-12-31'  # Optional expiration date (YYYY-MM-DD)
     - rule_id: 'RULE-456'
-      file_path: 'src/*.js'  # Glob pattern matching all JS files in src/
+      path: 'src/*.js'  # Glob pattern matching all JS files in src/
       reason: 'Known issue, planned for fix in v2.0'
 
   # Whether to fail with non-zero exit code if actionable findings are found

--- a/docs/content/docs/glossary.md
+++ b/docs/content/docs/glossary.md
@@ -1,0 +1,32 @@
+# Glossary
+
+| Term | Definition |
+|------|------------|
+| **Actionable finding** | A finding that is not suppressed and has severity above the configured threshold. These appear in reports and affect exit codes. |
+| **ASH** | Automated Security Helper — a meta-scanner that orchestrates multiple security tools and unifies their output. |
+| **Converter** | A plugin that transforms input files into formats that scanners can process (e.g., extracting archives, rendering templates). |
+| **CycloneDX** | An OWASP standard for Software Bill of Materials (SBOM) and vulnerability exchange. ASH can produce CycloneDX output via its reporter. |
+| **Event Subscriber** | A plugin that reacts to lifecycle events during an ASH run (e.g., scan started, finding detected, run completed). Used for custom integrations. |
+| **Finding** | A single security issue detected by a scanner, represented as a SARIF result with a rule ID, severity, location, and message. |
+| **GHAS** | GitHub Advanced Security — GitHub's native security scanning platform. ASH can produce SARIF compatible with GHAS code scanning. |
+| **IaC** | Infrastructure as Code — configuration files that define cloud resources (Terraform, CloudFormation, Kubernetes manifests, etc.). |
+| **Inline Suppression** | A code comment (e.g., `# ash-ignore:rule-id`) that suppresses a specific finding at the line where it appears. |
+| **MCP** | Model Context Protocol — a standard for connecting AI assistants to external tools. ASH exposes an MCP server for AI-driven security scanning. |
+| **Mode** | How ASH executes: `local` (direct on host), `container` (inside Docker), or `precommit` (as a Git hook on staged files). |
+| **OCSF** | Open Cybersecurity Schema Framework — a standard schema for security telemetry. ASH can emit findings in OCSF format. |
+| **Phase** | A stage in the ASH pipeline: convert, scan, report, or inspect. Phases run sequentially in that order. |
+| **Plugin** | A self-contained extension that adds scanning, reporting, converting, or event-handling capability to ASH. |
+| **Pre-commit hook** | A Git hook that runs ASH automatically before each commit, scanning only staged files for fast feedback. |
+| **Reporter** | A plugin that transforms aggregated SARIF findings into a specific output format (HTML, CSV, SARIF file, Security Hub, etc.). |
+| **Rule ID** | A unique identifier for a class of finding (e.g., `B105` for Bandit's hardcoded password check, `CKV_AWS_18` for a Checkov rule). |
+| **SARIF** | Static Analysis Results Interchange Format — an OASIS standard JSON format for static analysis output. ASH uses SARIF as its internal data model. |
+| **SAST** | Static Application Security Testing — analysis of source code for vulnerabilities without executing it. |
+| **SBOM** | Software Bill of Materials — a machine-readable inventory of all components in a software project. |
+| **SCA** | Software Composition Analysis — identifying known vulnerabilities in third-party dependencies. |
+| **Scanner** | A plugin that wraps a security tool, runs it against target code, and produces SARIF findings. |
+| **Severity** | The impact level of a finding: Critical, High, Medium, Low, or Info (also called Note). Determines whether a finding is actionable. |
+| **SPDX** | Software Package Data Exchange — an ISO standard for communicating SBOM information. |
+| **Strategy** | How ASH runs multiple scanners: `parallel` (concurrent execution, default) or `sequential` (one at a time). |
+| **Suppression** | A config-based rule in `.ash-config.yml` that marks specific findings as accepted, hiding them from actionable results. |
+| **UV** | A fast Python package installer and resolver used by ASH to manage scanner tool installations. |
+| **UVX** | A UV subcommand that runs Python CLI tools in isolated environments without permanent installation. ASH uses `uvx` to invoke scanners. |

--- a/docs/content/docs/installation-guide.md
+++ b/docs/content/docs/installation-guide.md
@@ -33,7 +33,7 @@ ASH v3 uses UV's tool isolation system to automatically manage most scanner depe
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 
 # Use as normal
 ash --help
@@ -45,14 +45,14 @@ ash --help
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1 $args }
 
 # Use as normal
 ash --help
 ```
 
 !!! tip "Floating tag `v3`"
-    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.4.0`) when you need reproducible builds, such as in CI/CD pipelines.
+    We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.4.1`) when you need reproducible builds, such as in CI/CD pipelines.
 
 #### 2. Using `pipx`
 
@@ -60,7 +60,7 @@ ash --help
 
 ```bash
 # Works on Windows, macOS, and Linux
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Use as normal
 ash --help
@@ -72,7 +72,7 @@ Standard Python package installation:
 
 ```bash
 # Works on Windows, macOS, and Linux
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Use as normal
 ash --help
@@ -134,7 +134,7 @@ To upgrade ASH to the latest version:
 ### If installed with `uvx`
 ```bash
 # Your alias will use the latest version when specified
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 ```
 
 ### If installed with `pipx`
@@ -144,7 +144,7 @@ pipx upgrade automated-security-helper
 
 ### If installed with `pip`
 ```bash
-pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install --upgrade git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ### If installed from repository

--- a/docs/content/docs/mcp-performance-scalability.md
+++ b/docs/content/docs/mcp-performance-scalability.md
@@ -249,7 +249,7 @@ Test your configuration with representative projects:
 
 ```bash
 # Test with debug logging
-uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.0.0 ash mcp --debug
+uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.4.1 ash mcp --debug
 
 # Monitor system resources during scans
 top -p $(pgrep -f "ash mcp")

--- a/docs/content/docs/migration-guide.md
+++ b/docs/content/docs/migration-guide.md
@@ -48,13 +48,13 @@ export PATH="${PATH}:/path/to/automated-security-helper"
 
 ```bash
 # Option 1: Using uvx (recommended) -- add to shell profile
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 
 # Option 2: Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Option 3: Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 > **Tip**: You can also use the `v3` floating tag (`@v3`) instead of a specific version to always get the latest stable v3.x release. Pin a specific version for CI/CD or reproducible environments.
@@ -248,7 +248,7 @@ repos:
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0
+    rev: v3.4.1
     hooks:
       - id: ash-simple-scan
 ```

--- a/docs/content/docs/output-formats.md
+++ b/docs/content/docs/output-formats.md
@@ -24,7 +24,7 @@ ASH produces scan results in multiple formats. Every scan writes an internal agg
 By default, ASH generates flat-json, SARIF, CycloneDX, OCSF, GitLab SAST, JUnit XML, CSV, HTML, Markdown, and Text reports. SPDX and YAML are available but disabled by default. To request a specific set of formats, use the `reporters` section in your configuration file:
 
 ```yaml
-# .ash/ash.yaml
+# .ash/.ash.yaml
 reporters:
   flat-json:
     enabled: true

--- a/docs/content/docs/quick-start-guide.md
+++ b/docs/content/docs/quick-start-guide.md
@@ -25,7 +25,7 @@ Prerequisites: Python 3.10+, [uv](https://docs.astral.sh/uv/getting-started/inst
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 ```
 
 #### Windows PowerShell
@@ -34,17 +34,17 @@ alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1 $args }
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.4.0`) when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of a specific version to stay up to date automatically. Pin a specific version (e.g., `@v3.4.1`) when you need reproducible builds.
 
 ### Option 2: Using pipx
 
 Prerequisites: Python 3.10+, [pipx](https://pipx.pypa.io/stable/installation/)
 
 ```bash
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ### Option 3: Using pip
@@ -52,7 +52,7 @@ pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
 Prerequisites: Python 3.10+
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ## Basic Usage
@@ -127,13 +127,13 @@ global_settings:
       reason: 'Test data only'
   suppressions:
     - rule_id: 'RULE-123'
-      file_path: 'src/example.py'
+      path: 'src/example.py'
       line_start: 10
       line_end: 15
       reason: 'False positive due to test mock'
       expiration: '2025-12-31'
     - rule_id: 'RULE-456'
-      file_path: 'src/*.js'
+      path: 'src/*.js'
       reason: 'Known issue, planned for fix in v2.0'
 scanners:
   bandit:
@@ -189,7 +189,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0
+    rev: v3.4.1
     hooks:
       - id: ash-simple-scan
 ```

--- a/docs/content/docs/supported-languages.md
+++ b/docs/content/docs/supported-languages.md
@@ -1,0 +1,29 @@
+# Supported Languages & Frameworks
+
+ASH is a **meta-scanner** — it orchestrates established open-source security tools rather than implementing its own analysis engine. This means you get the combined coverage of multiple specialized tools through a single interface, with unified SARIF output and consistent suppression handling.
+
+## Scanner Matrix
+
+| Scanner | Languages / Frameworks | What It Checks |
+|---------|----------------------|----------------|
+| **Bandit** | Python | Security anti-patterns: hardcoded passwords, subprocess injection, insecure deserialization, weak cryptography |
+| **cdk-nag** | AWS CDK (TypeScript, Python) | AWS best practices for CDK constructs: overly permissive IAM, unencrypted storage, missing logging |
+| **cfn-nag** | CloudFormation (YAML/JSON) | CloudFormation security misconfigurations: open security groups, missing encryption, wildcard IAM policies |
+| **Checkov** | Terraform, CloudFormation, Kubernetes, Dockerfile, Helm, ARM, Bicep, and 30+ more | IaC misconfigurations across cloud providers: insecure defaults, missing encryption, public exposure |
+| **detect-secrets** | All (language-agnostic) | Hardcoded secrets, API keys, tokens, and credentials in any file type |
+| **Grype** | Container images, SBOMs | Known vulnerabilities (CVEs) in OS packages and application libraries |
+| **npm-audit** | JavaScript/TypeScript (npm, pnpm, yarn) | Known vulnerabilities in npm dependency trees |
+| **OpenGrep** | Python, JavaScript, TypeScript, Java, Go, Ruby, C#, Kotlin, Scala, PHP, and more | SAST rules from the Semgrep/OpenGrep registry: injection flaws, authentication bugs, insecure configurations |
+| **Semgrep** | Same as OpenGrep | SAST rules (overlaps with OpenGrep; ASH uses both for broader rule coverage) |
+| **Syft** | All (language-agnostic) | Software Bill of Materials (SBOM) generation — inventories all packages and dependencies |
+
+## Coverage Notes
+
+- **IaC coverage** is strongest through Checkov, which supports Terraform (HCL), CloudFormation, Kubernetes, Docker, Helm, Serverless Framework, ARM templates, Bicep, Ansible, and more.
+- **Secret detection** via detect-secrets is file-format agnostic — it scans any text file regardless of language.
+- **Container scanning** via Grype works on built images or on SBOMs produced by Syft, covering OS-level and application-level packages.
+- **SAST coverage** via OpenGrep/Semgrep draws from thousands of community rules. The exact language support depends on rule availability in the registry.
+
+## Adding More Scanners
+
+ASH's plugin system lets you add additional scanners. Community plugins exist for tools like Trivy, Snyk, and Ferret. See the [Plugin Development Guide](plugins/development-guide.md) for instructions on writing your own scanner plugin.

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -23,25 +23,25 @@ No. ASH is designed to help identify common security issues early in the develop
 You have several options:
 ```bash
 # Using uvx (recommended)
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 
 # Using pipx
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Using pip
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ### What are the prerequisites for ASH v3?
 
 ### What is the `v3` floating tag?
-We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.4.0`:
+We maintain a `v3` Git tag that always points to the latest stable v3.x release. This means you can use `@v3` in your installation commands instead of a specific version like `@v3.4.1`:
 
 ```bash
 alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3"
 ```
 
-This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.4.0`).
+This is convenient for local development where you always want the latest version. For CI/CD pipelines or environments where reproducibility matters, we recommend pinning to a specific release tag (e.g., `@v3.4.1`).
 
 ### What are the prerequisites for ASH v3?
 - For local mode: Python 3.10 or later, UV package manager
@@ -165,7 +165,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0
+    rev: v3.4.1
     hooks:
       - id: ash-simple-scan
 ```
@@ -260,7 +260,7 @@ Model Context Protocol (MCP) is a standardized way for AI applications to access
        "ash": {
          "command": "uvx",
          "args": [
-           "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+           "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
            "ash",
            "mcp"
          ],
@@ -278,7 +278,7 @@ Model Context Protocol (MCP) is a standardized way for AI applications to access
        "ash-security": {
          "command": "uvx",
          "args": [
-           "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+           "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
            "ash",
            "mcp"
          ]
@@ -294,7 +294,7 @@ Model Context Protocol (MCP) is a standardized way for AI applications to access
        "ash": {
          "command": "uvx",
          "args": [
-           "--from=git+https://github.com/awslabs/automated-security-helper@v3.0.0",
+           "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.1",
            "ash",
            "mcp"
          ],
@@ -355,16 +355,16 @@ MCP dependencies are included by default in ASH v3. If you're still getting erro
 2. **Check Python version**: Ensure Python 3.10+ is available: `uv python list`
 3. **Test the MCP server**: Try running the server directly:
    ```bash
-   uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.0.0 ash mcp --help
+   uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.4.1 ash mcp --help
    ```
 
 ### How do I test the ASH MCP server?
 ```bash
 # Test MCP server startup
-uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.0.0 ash mcp --debug
+uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.4.1 ash mcp --debug
 
 # Check ASH version
-uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.0.0 ash --version
+uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.4.1 ash --version
 ```
 
 ### How do I monitor MCP server performance?

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -56,13 +56,13 @@ ASH v3 integrates multiple open-source security tools as scanners. Tools like Ba
 
 ```bash
 # Install with pipx (isolated environment)
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
 # Use as normal
 ash --help
 ```
 
-> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.4.0` to stay up to date automatically. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: We also maintain a `v3` floating tag that always points to the latest stable v3.x release. You can use `@v3` instead of `@v3.4.1` to stay up to date automatically. Pin a specific version when you need reproducible builds.
 
 ### Other Installation Methods
 
@@ -74,17 +74,17 @@ ash --help
 ```bash
 # Linux/macOS
 curl -sSf https://astral.sh/uv/install.sh | sh
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 
 # Windows PowerShell
 irm https://astral.sh/uv/install.ps1 | iex
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1 $args }
 ```
 
 #### Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 #### Clone the Repository
@@ -151,7 +151,7 @@ ERROR (2) Exiting due to 122 actionable findings found in ASH scan
 
 ## Configuration
 
-ASH v3 uses a YAML configuration file (`.ash/ash.yaml`) with support for JSON Schema validation:
+ASH v3 uses a YAML configuration file (`.ash/.ash.yaml`) with support for JSON Schema validation:
 
 ```yaml
 # yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json
@@ -180,7 +180,7 @@ Add this to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0
+    rev: v3.4.1
     hooks:
       - id: ash-simple-scan
 ```
@@ -218,7 +218,7 @@ ASH can be run in container mode in any CI/CD environment that supports containe
 <details>
 <summary>How do I exclude files from scanning?</summary>
 
-ASH respects `.gitignore` files. You can also configure ignore paths in your `.ash/ash.yaml` configuration file.
+ASH respects `.gitignore` files. You can also configure ignore paths in your `.ash/.ash.yaml` configuration file.
 </details>
 
 <details>

--- a/docs/content/tutorials/running-ash-in-ci.md
+++ b/docs/content/tutorials/running-ash-in-ci.md
@@ -41,7 +41,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - name: Run ASH scan
         run: ash --mode local
       - name: Upload scan results
@@ -70,7 +70,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - name: Run ASH scan
         run: ash --mode container
       - name: Upload scan results
@@ -143,7 +143,7 @@ jobs:
         with:
           python-version: '3.10'
       - name: Install ASH
-        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+        run: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - name: Run ASH scan
         run: ash --mode local
       - name: Add PR comment
@@ -176,7 +176,7 @@ jobs:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
     - ash --mode local
   artifacts:
     paths:
@@ -194,7 +194,7 @@ ash-scan-container:
     DOCKER_TLS_CERTDIR: "/certs"
   script:
     - apk add --no-cache python3 py3-pip git
-    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+    - pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
     - ash --mode container
   artifacts:
     paths:
@@ -218,7 +218,7 @@ Example using local mode:
 ash-scan:
   image: python:3.10
   script:
-    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+    - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
     - ash --mode local --no-fail-on-findings
   artifacts:
     paths:
@@ -237,7 +237,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
   build:
     commands:
@@ -258,7 +258,7 @@ phases:
     runtime-versions:
       python: 3.10
     commands:
-      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+      - pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 
   pre_build:
     commands:
@@ -288,7 +288,7 @@ pipeline {
     stages {
         stage('Install ASH') {
             steps {
-                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0'
+                sh 'pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1'
             }
         }
         stage('Run ASH Scan') {
@@ -319,7 +319,7 @@ pipeline {
         stage('Install ASH') {
             steps {
                 sh 'apk add --no-cache python3 py3-pip git'
-                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0'
+                sh 'pip3 install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1'
             }
         }
         stage('Run ASH Scan') {
@@ -350,7 +350,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - run:
           name: Run ASH scan
           command: ash --mode local
@@ -377,7 +377,7 @@ jobs:
       - checkout
       - run:
           name: Install ASH
-          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+          command: pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
       - run:
           name: Run ASH scan
           command: ash --mode container
@@ -394,7 +394,7 @@ workflows:
 
 ## Best Practices for CI Integration
 
-> **Tip**: The CI examples in this guide use pinned versions (`@v3.4.0`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
+> **Tip**: The CI examples in this guide use pinned versions (`@v3.4.1`) for reproducibility. You can also use the `v3` floating tag (`@v3`) to always get the latest stable v3.x release, though pinned versions are recommended for CI/CD pipelines.
 
 1. **Fail builds on critical findings**:
    ```bash

--- a/docs/content/tutorials/running-ash-locally.md
+++ b/docs/content/tutorials/running-ash-locally.md
@@ -13,12 +13,12 @@ ASH v3 can run in multiple modes: `local`, `container`, or `precommit`. This gui
 curl -sSf https://astral.sh/uv/install.sh | sh
 
 # Create an alias for ASH
-alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0"
+alias ash="uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1"
 
 # Add this alias to your shell profile (~/.bashrc, ~/.zshrc, etc.)
 ```
 
-> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.4.0` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
+> **Floating tag `v3`**: You can also use `@v3` instead of `@v3.4.1` to always get the latest stable v3.x release. Pin a specific version when you need reproducible builds.
 
 ### Option 2: Using `pipx`
 
@@ -28,13 +28,13 @@ python -m pip install --user pipx
 python -m pipx ensurepath
 
 # Install ASH
-pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pipx install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ### Option 3: Using `pip`
 
 ```bash
-pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.0
+pip install git+https://github.com/awslabs/automated-security-helper.git@v3.4.1
 ```
 
 ### Option 4: Clone the Repository (Legacy Method)
@@ -103,7 +103,7 @@ ASH v3 runs natively on Windows with Python 3.10+:
 irm https://astral.sh/uv/install.ps1 | iex
 
 # Create a function for ASH
-function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.0 $args }
+function ash { uvx git+https://github.com/awslabs/automated-security-helper.git@v3.4.1 $args }
 
 # Use as normal
 ash --help

--- a/docs/content/tutorials/using-ash-with-pre-commit.md
+++ b/docs/content/tutorials/using-ash-with-pre-commit.md
@@ -22,7 +22,7 @@ To configure a git repository to use the `ash` hook, start with the following `p
 ```yaml
 repos:
   - repo: https://github.com/awslabs/automated-security-helper
-    rev: v3.0.0  # update with the latest tagged version in the repository
+    rev: v3.4.1  # update with the latest tagged version in the repository
     hooks:
       - id: ash-simple-scan
 ```

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -1,0 +1,537 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Auto-generate CLI reference documentation from Typer command definitions and MCP tool functions.
+
+Usage:
+    uv run python scripts/generate_cli_docs.py
+    uv run python scripts/generate_cli_docs.py --output docs/content/docs/cli-reference-generated.md
+    python -m scripts.generate_cli_docs --output -  # write to stdout
+"""
+
+import argparse
+import inspect
+import re
+import sys
+import textwrap
+from pathlib import Path
+from typing import Any, get_args, get_origin
+
+
+def _get_type_name(annotation: Any) -> str:
+    """Convert a type annotation to a human-readable string."""
+    if annotation is inspect.Parameter.empty:
+        return "str"
+
+    origin = get_origin(annotation)
+
+    # Handle Optional (Union[X, None])
+    if origin is type(None):
+        return "None"
+
+    # Handle Annotated - extract the base type
+    try:
+        import typing
+        if hasattr(typing, "get_args") and hasattr(typing, "get_origin"):
+            if typing.get_origin(annotation) is typing.Annotated:
+                args = typing.get_args(annotation)
+                if args:
+                    return _get_type_name(args[0])
+    except Exception:
+        pass
+
+    # Handle Union types (Optional[X] = Union[X, None])
+    if origin is type(None):
+        return "None"
+    try:
+        import types as builtin_types
+        if isinstance(annotation, builtin_types.UnionType):
+            inner = [a for a in get_args(annotation) if a is not type(None)]
+            if len(inner) == 1:
+                return _get_type_name(inner[0])
+            return " | ".join(_get_type_name(a) for a in inner)
+    except Exception:
+        pass
+
+    # typing.Union
+    try:
+        import typing
+        if origin is typing.Union:
+            inner = [a for a in get_args(annotation) if a is not type(None)]
+            if len(inner) == 1:
+                return _get_type_name(inner[0])
+            return " | ".join(_get_type_name(a) for a in inner)
+    except Exception:
+        pass
+
+    # Handle List[X]
+    if origin is list:
+        args = get_args(annotation)
+        if args:
+            return f"List[{_get_type_name(args[0])}]"
+        return "List"
+
+    # Handle Optional[X] via typing
+    try:
+        import typing
+        if origin is typing.Optional:
+            args = get_args(annotation)
+            if args:
+                return _get_type_name(args[0])
+    except Exception:
+        pass
+
+    # Enum types
+    import enum
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        values = [e.value for e in annotation]
+        if len(values) <= 6:
+            return f"enum({', '.join(str(v) for v in values)})"
+        return f"enum({', '.join(str(v) for v in values[:4])}, ...)"
+
+    # Basic types
+    if annotation is str:
+        return "str"
+    if annotation is int:
+        return "int"
+    if annotation is float:
+        return "float"
+    if annotation is bool:
+        return "bool"
+    if annotation is Path:
+        return "Path"
+
+    # Fallback to the name
+    if hasattr(annotation, "__name__"):
+        return annotation.__name__
+    return str(annotation).replace("typing.", "")
+
+
+def _format_default(default: Any) -> str:
+    """Format a default value for display."""
+    if default is inspect.Parameter.empty:
+        return "*required*"
+    if default is None:
+        return ""
+    if isinstance(default, bool):
+        return str(default)
+    if isinstance(default, str):
+        if default == "":
+            return '""'
+        return f"`{default}`"
+    if isinstance(default, list):
+        return "[]"
+    # Enum values
+    import enum
+    if isinstance(default, enum.Enum):
+        return f"`{default.value}`"
+    return str(default)
+
+
+def _escape_md(text: str) -> str:
+    """Escape pipe characters for markdown tables."""
+    if not text:
+        return ""
+    return text.replace("|", "\\|").replace("\n", " ")
+
+
+def extract_typer_params(func) -> list[dict]:
+    """
+    Extract parameter metadata from a Typer-decorated function using introspection.
+
+    Returns a list of dicts with keys: flags, type, default, envvar, help, is_argument.
+    """
+    import typing
+
+    sig = inspect.signature(func)
+    params = []
+
+    for name, param in sig.parameters.items():
+        # Skip the typer.Context parameter
+        if name == "ctx":
+            continue
+
+        annotation = param.annotation
+        default = param.default
+
+        # Check if this is an Annotated type
+        if typing.get_origin(annotation) is typing.Annotated:
+            args = typing.get_args(annotation)
+            base_type = args[0]
+            metadata = args[1:]  # Everything after the type is metadata
+
+            # Find the typer.Option or typer.Argument in metadata
+            import typer.models
+            option_info = None
+            for meta in metadata:
+                if isinstance(meta, (typer.models.OptionInfo, typer.models.ArgumentInfo)):
+                    option_info = meta
+                    break
+
+            if option_info is None:
+                continue
+
+            # Extract flag names from param_decls
+            is_argument = isinstance(option_info, typer.models.ArgumentInfo)
+            flags = []
+            if hasattr(option_info, "param_decls") and option_info.param_decls:
+                flags = list(option_info.param_decls)
+            if not flags and not is_argument:
+                # Generate default flag name from parameter name
+                flags = [f"--{name.replace('_', '-')}"]
+
+            # Extract help text
+            help_text = ""
+            if hasattr(option_info, "help") and option_info.help:
+                help_text = option_info.help
+
+            # Extract envvar
+            envvar = ""
+            if hasattr(option_info, "envvar") and option_info.envvar:
+                ev = option_info.envvar
+                if isinstance(ev, (list, tuple)):
+                    envvar = ", ".join(ev)
+                else:
+                    envvar = str(ev)
+
+            # Determine actual default
+            actual_default = default if default is not inspect.Parameter.empty else None
+            if hasattr(option_info, "default") and option_info.default is not None:
+                # typer stores defaults too, but param.default is more reliable
+                pass
+
+            # Resolve type name
+            type_name = _get_type_name(base_type)
+
+            params.append({
+                "flags": flags,
+                "type": type_name,
+                "default": _format_default(actual_default),
+                "envvar": envvar,
+                "help": help_text,
+                "is_argument": is_argument,
+                "param_name": name,
+            })
+        else:
+            # Non-Annotated parameters (simple typer.Option defaults in main.py wrapper)
+            if default is inspect.Parameter.empty:
+                continue
+
+            # These are typically from the mcp wrapper or get-genai-guide
+            type_name = _get_type_name(annotation)
+            flags = [f"--{name.replace('_', '-')}"]
+
+            # Check if default is a typer.Option instance
+            import typer.models
+            if isinstance(default, typer.models.OptionInfo):
+                option_info = default
+                help_text = option_info.help or ""
+                envvar = ""
+                if option_info.envvar:
+                    ev = option_info.envvar
+                    envvar = ", ".join(ev) if isinstance(ev, (list, tuple)) else str(ev)
+                actual_default = option_info.default
+                if option_info.param_decls:
+                    flags = list(option_info.param_decls)
+                params.append({
+                    "flags": flags,
+                    "type": type_name,
+                    "default": _format_default(actual_default),
+                    "envvar": envvar,
+                    "help": help_text,
+                    "is_argument": False,
+                    "param_name": name,
+                })
+            elif isinstance(default, typer.models.ArgumentInfo):
+                help_text = default.help or ""
+                envvar = ""
+                if default.envvar:
+                    ev = default.envvar
+                    envvar = ", ".join(ev) if isinstance(ev, (list, tuple)) else str(ev)
+                actual_default = default.default
+                params.append({
+                    "flags": [],
+                    "type": type_name,
+                    "default": _format_default(actual_default),
+                    "envvar": envvar,
+                    "help": help_text,
+                    "is_argument": True,
+                    "param_name": name,
+                })
+
+    return params
+
+
+def render_command_section(command_name: str, func, description: str = "") -> str:
+    """Render a markdown section for a single CLI command."""
+    params = extract_typer_params(func)
+    if not params:
+        return ""
+
+    lines = []
+    lines.append(f"### `ash {command_name}`")
+    lines.append("")
+
+    # Add description from docstring if available
+    doc = description or (inspect.getdoc(func) or "")
+    if doc:
+        first_para = doc.split("\n\n")[0].strip()
+        if first_para:
+            lines.append(first_para)
+            lines.append("")
+
+    # Separate arguments and options
+    arguments = [p for p in params if p["is_argument"]]
+    options = [p for p in params if not p["is_argument"]]
+
+    if arguments:
+        lines.append("**Arguments:**")
+        lines.append("")
+        lines.append("| Argument | Type | Default | Env Var | Description |")
+        lines.append("|----------|------|---------|---------|-------------|")
+        for p in arguments:
+            arg_name = p["param_name"].upper()
+            lines.append(
+                f"| `{arg_name}` | {p['type']} | {p['default']} | {_escape_md(p['envvar'])} | {_escape_md(p['help'])} |"
+            )
+        lines.append("")
+
+    if options:
+        lines.append("| Flag | Type | Default | Env Var | Description |")
+        lines.append("|------|------|---------|---------|-------------|")
+        for p in options:
+            flag_str = ", ".join(f"`{f}`" for f in p["flags"]) if p["flags"] else f"`--{p['param_name'].replace('_', '-')}`"
+            lines.append(
+                f"| {flag_str} | {p['type']} | {p['default']} | {_escape_md(p['envvar'])} | {_escape_md(p['help'])} |"
+            )
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def extract_mcp_tools() -> list[dict]:
+    """
+    Extract MCP tool definitions from the mcp_server module by introspecting
+    functions decorated with @mcp.tool().
+    """
+    from automated_security_helper.cli import mcp_server
+
+    tools = []
+
+    # Find all functions decorated with @mcp.tool()
+    # The FastMCP server registers tools - we can find them by looking at module-level
+    # async functions that are decorated (they'll be in the mcp server's tool registry,
+    # but we can also find them by scanning the module for known patterns)
+    module = mcp_server
+
+    # Get the mcp instance and its registered tools
+    mcp_instance = module.mcp
+
+    # FastMCP stores tools internally - try to access them
+    # But the simplest approach: scan module for async functions that we know are tools
+    # by checking if they're registered in the mcp._tool_manager or similar
+    tool_functions = []
+
+    for attr_name in dir(module):
+        obj = getattr(module, attr_name)
+        if callable(obj) and inspect.iscoroutinefunction(obj):
+            # Skip private/internal functions
+            if attr_name.startswith("_"):
+                continue
+            # Skip imported helper functions
+            if attr_name.startswith("mcp_"):
+                continue
+            # These are the tool functions registered with @mcp.tool()
+            tool_functions.append((attr_name, obj))
+
+    for tool_name, func in tool_functions:
+        sig = inspect.signature(func)
+        doc = inspect.getdoc(func) or ""
+
+        # Extract description: first paragraph before Args: section
+        description = ""
+        if doc:
+            # Split at Args: or Returns: sections
+            parts = re.split(r"\n\s*(Args|Returns|Example|CRITICAL|IMPORTANT):", doc, maxsplit=1)
+            description = parts[0].strip()
+            # Take only first paragraph
+            description = description.split("\n\n")[0].strip()
+            # Collapse multi-line into single line
+            description = " ".join(description.split())
+
+        # Extract parameters (skip ctx)
+        tool_params = []
+        # Also try to parse Args: section from docstring for per-param descriptions
+        args_descriptions = {}
+        if "Args:" in doc:
+            args_section = doc.split("Args:")[1]
+            # Stop at Returns: or end
+            if "Returns:" in args_section:
+                args_section = args_section.split("Returns:")[0]
+            # Parse indented lines
+            for line in args_section.strip().split("\n"):
+                line = line.strip()
+                if ":" in line and not line.startswith("-"):
+                    param_name, param_desc = line.split(":", 1)
+                    param_name = param_name.strip()
+                    param_desc = param_desc.strip()
+                    args_descriptions[param_name] = param_desc
+
+        for param_name, param in sig.parameters.items():
+            if param_name == "ctx":
+                continue
+            param_type = _get_type_name(param.annotation)
+            param_default = _format_default(param.default)
+            param_desc = args_descriptions.get(param_name, "")
+
+            tool_params.append({
+                "name": param_name,
+                "type": param_type,
+                "default": param_default,
+                "description": param_desc,
+            })
+
+        tools.append({
+            "name": tool_name,
+            "description": description,
+            "params": tool_params,
+        })
+
+    # Sort tools by name for deterministic output
+    tools.sort(key=lambda t: t["name"])
+    return tools
+
+
+def render_mcp_section(tools: list[dict]) -> str:
+    """Render markdown section for MCP tools."""
+    lines = []
+    lines.append("## MCP Tools")
+    lines.append("")
+    lines.append("The ASH MCP server exposes the following tools for integration with AI assistants via the Model Context Protocol.")
+    lines.append("")
+
+    for tool in tools:
+        lines.append(f"### `{tool['name']}`")
+        lines.append("")
+        if tool["description"]:
+            lines.append(tool["description"])
+            lines.append("")
+
+        if tool["params"]:
+            lines.append("| Parameter | Type | Default | Description |")
+            lines.append("|-----------|------|---------|-------------|")
+            for p in tool["params"]:
+                lines.append(
+                    f"| `{p['name']}` | {p['type']} | {p['default']} | {_escape_md(p['description'])} |"
+                )
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_cli_docs() -> str:
+    """Generate the complete CLI reference markdown document."""
+    # Import all the command functions
+    from automated_security_helper.cli.scan import run_ash_scan_cli_command
+    from automated_security_helper.cli.image import build_ash_image_cli_command
+    from automated_security_helper.cli.report import report_command
+    from automated_security_helper.cli.config import config_app
+    from automated_security_helper.cli.inspect import inspect_app
+    from automated_security_helper.cli.main import _mcp_wrapper, get_genai_guide
+
+    # Get config subcommand functions
+    from automated_security_helper.cli.config import (
+        init as config_init,
+        get as config_get,
+        update as config_update,
+        validate_plugin_dependencies as config_validate_deps,
+        lint as config_lint,
+        wizard as config_wizard,
+        validate as config_validate,
+    )
+
+    # Get inspect subcommand functions
+    from automated_security_helper.cli.inspect.inspect_findings_app import findings_command
+    from automated_security_helper.cli.inspect.sarif_fields import analyze_sarif_fields
+
+    sections = []
+
+    # Header
+    sections.append("# CLI Reference (Auto-Generated)")
+    sections.append("")
+    sections.append("This document is auto-generated from the ASH CLI source code using introspection.")
+    sections.append("Do not edit manually. Regenerate with: `uv run python scripts/generate_cli_docs.py`")
+    sections.append("")
+
+    # Main commands
+    sections.append("## Commands")
+    sections.append("")
+
+    # scan command
+    sections.append(render_command_section("scan", run_ash_scan_cli_command,
+        "Runs an ASH scan against the source-dir, outputting results to the output-dir."))
+
+    # build-image command
+    sections.append(render_command_section("build-image", build_ash_image_cli_command,
+        "Builds the ASH container image then runs a scan with it."))
+
+    # report command
+    sections.append(render_command_section("report", report_command))
+
+    # mcp command
+    sections.append(render_command_section("mcp", _mcp_wrapper,
+        "Start the ASH MCP server (Model Context Protocol)."))
+
+    # get-genai-guide command
+    sections.append(render_command_section("get-genai-guide", get_genai_guide))
+
+    # Config subcommands
+    sections.append("## Config Subcommands")
+    sections.append("")
+    sections.append(render_command_section("config init", config_init))
+    sections.append(render_command_section("config get", config_get))
+    sections.append(render_command_section("config update", config_update))
+    sections.append(render_command_section("config validate-plugin-dependencies", config_validate_deps))
+    sections.append(render_command_section("config lint", config_lint))
+    sections.append(render_command_section("config wizard", config_wizard))
+    sections.append(render_command_section("config validate", config_validate))
+
+    # Inspect subcommands
+    sections.append("## Inspect Subcommands")
+    sections.append("")
+    sections.append(render_command_section("inspect findings", findings_command))
+    sections.append(render_command_section("inspect sarif-fields", analyze_sarif_fields))
+
+    # MCP Tools
+    tools = extract_mcp_tools()
+    sections.append(render_mcp_section(tools))
+
+    return "\n".join(sections)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate CLI reference documentation from Typer command definitions."
+    )
+    parser.add_argument(
+        "--output",
+        default="docs/content/docs/cli-reference-generated.md",
+        help="Output file path. Use '-' for stdout. Default: docs/content/docs/cli-reference-generated.md",
+    )
+    args = parser.parse_args()
+
+    content = generate_cli_docs()
+
+    if args.output == "-":
+        sys.stdout.write(content)
+    else:
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(content)
+        print(f"Generated CLI reference docs at: {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/generate_cli_docs.py
+++ b/scripts/generate_cli_docs.py
@@ -39,7 +39,7 @@ def _get_type_name(annotation: Any) -> str:
                 args = typing.get_args(annotation)
                 if args:
                     return _get_type_name(args[0])
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     # Handle Union types (Optional[X] = Union[X, None])
@@ -52,7 +52,7 @@ def _get_type_name(annotation: Any) -> str:
             if len(inner) == 1:
                 return _get_type_name(inner[0])
             return " | ".join(_get_type_name(a) for a in inner)
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     # typing.Union
@@ -63,7 +63,7 @@ def _get_type_name(annotation: Any) -> str:
             if len(inner) == 1:
                 return _get_type_name(inner[0])
             return " | ".join(_get_type_name(a) for a in inner)
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     # Handle List[X]
@@ -80,7 +80,7 @@ def _get_type_name(annotation: Any) -> str:
             args = get_args(annotation)
             if args:
                 return _get_type_name(args[0])
-    except Exception:
+    except Exception:  # nosec B110
         pass
 
     # Enum types

--- a/scripts/verify_docs_freshness.py
+++ b/scripts/verify_docs_freshness.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+CI check: verify documentation stays in sync with source code.
+
+Run with: uv run python scripts/verify_docs_freshness.py
+
+Exit code 0 if all checks pass, exit code 1 with a detailed report if any fail.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Paths (relative to repo root)
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CLI_SCAN_PY = REPO_ROOT / "automated_security_helper" / "cli" / "scan.py"
+MCP_SERVER_PY = REPO_ROOT / "automated_security_helper" / "cli" / "mcp_server.py"
+PYPROJECT_TOML = REPO_ROOT / "pyproject.toml"
+README_MD = REPO_ROOT / "README.md"
+DOCS_DIR = REPO_ROOT / "docs"
+CLI_REFERENCE_MD = DOCS_DIR / "content" / "docs" / "cli-reference.md"
+OUTPUT_FORMATS_MD = DOCS_DIR / "content" / "docs" / "output-formats.md"
+DOCS_INDEX_MD = DOCS_DIR / "content" / "index.md"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def get_version_from_pyproject() -> str:
+    """Extract version from pyproject.toml."""
+    try:
+        import tomllib  # Python 3.11+
+    except ModuleNotFoundError:
+        # Fallback for Python 3.10
+        tomllib = None
+
+    text = read_text(PYPROJECT_TOML)
+
+    if tomllib:
+        import io
+
+        data = tomllib.loads(text)
+        return data["project"]["version"]
+
+    # Regex fallback
+    m = re.search(r'^version\s*=\s*"([^"]+)"', text, re.MULTILINE)
+    if not m:
+        raise RuntimeError("Could not parse version from pyproject.toml")
+    return m.group(1)
+
+
+def collect_md_files() -> list[Path]:
+    """Collect all .md files under docs/ and the repo-root README."""
+    files = list(DOCS_DIR.rglob("*.md"))
+    files.append(README_MD)
+    return files
+
+
+# ---------------------------------------------------------------------------
+# Check 1: CLI flags in docs match source
+# ---------------------------------------------------------------------------
+
+
+def check_cli_flags() -> list[str]:
+    """Parse scan.py for CLI option names and verify they appear in cli-reference.md."""
+    failures: list[str] = []
+    source = read_text(CLI_SCAN_PY)
+    docs = read_text(CLI_REFERENCE_MD)
+
+    # Extract explicit --flag-name strings from typer.Option() calls
+    # Match quoted strings that start with --
+    flag_pattern = re.compile(r'"(--[a-z][a-z0-9-]*)"')
+    flags_in_source: set[str] = set(flag_pattern.findall(source))
+
+    # Also derive flags from Python parameter names (snake_case -> --kebab-case)
+    # Match the parameter name preceding the Annotated[...typer.Option block
+    param_pattern = re.compile(
+        r"^\s+([a-z_][a-z0-9_]*):\s*Annotated\[\s*\n?\s*.*?,\s*\n?\s*typer\.Option\(",
+        re.MULTILINE,
+    )
+    for match in param_pattern.finditer(source):
+        param_name = match.group(1)
+        flag = "--" + param_name.replace("_", "-")
+        flags_in_source.add(flag)
+
+    # Flags that are internal/not user-facing or are short aliases only
+    skip_flags = {"--no-build", "--no-run", "--no-progress", "--no-color"}
+
+    docs_lower = docs.lower()
+    for flag in sorted(flags_in_source):
+        if flag in skip_flags:
+            continue
+        # Check if the flag appears in the docs (case-insensitive)
+        if flag.lower() not in docs_lower:
+            # Also try with backtick wrapping
+            if f"`{flag}`".lower() not in docs_lower:
+                failures.append(f"CLI flag {flag} found in source but missing from cli-reference.md")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 2: Reporter list in docs matches code
+# ---------------------------------------------------------------------------
+
+
+def check_reporters() -> list[str]:
+    """Verify all reporter config fields appear in output-formats.md."""
+    failures: list[str] = []
+
+    from automated_security_helper.config.ash_config import ReporterConfigSegment
+
+    docs = read_text(OUTPUT_FORMATS_MD).lower()
+
+    for field_name, field_info in ReporterConfigSegment.model_fields.items():
+        # Use alias if present, otherwise convert underscores to hyphens
+        alias = None
+        if field_info.alias:
+            alias = field_info.alias
+        display_name = alias if alias else field_name.replace("_", "-")
+
+        if display_name.lower() not in docs:
+            failures.append(
+                f"Reporter '{display_name}' (field: {field_name}) missing from output-formats.md"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 3: Scanner list in docs matches code
+# ---------------------------------------------------------------------------
+
+
+def check_scanners() -> list[str]:
+    """Verify all scanner config fields appear in README.md scanner table."""
+    failures: list[str] = []
+
+    from automated_security_helper.config.ash_config import ScannerConfigSegment
+
+    readme = read_text(README_MD).lower()
+
+    for field_name, field_info in ScannerConfigSegment.model_fields.items():
+        alias = None
+        if field_info.alias:
+            alias = field_info.alias
+        display_name = alias if alias else field_name.replace("_", "-")
+
+        # Check both the alias and the raw field name variants
+        found = (
+            display_name.lower() in readme
+            or field_name.lower().replace("_", "-") in readme
+            or field_name.lower().replace("_", "_") in readme
+        )
+        if not found:
+            failures.append(
+                f"Scanner '{display_name}' (field: {field_name}) missing from README.md"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 4: MCP tool names in docs match code
+# ---------------------------------------------------------------------------
+
+
+def check_mcp_tools() -> list[str]:
+    """Parse mcp_server.py for @mcp.tool() functions and check README."""
+    failures: list[str] = []
+    source = read_text(MCP_SERVER_PY)
+    readme = read_text(README_MD).lower()
+
+    # Find all functions decorated with @mcp.tool()
+    # Pattern: @mcp.tool() followed by async def func_name(
+    tool_pattern = re.compile(
+        r"@mcp\.tool\(\)\s*\n\s*async\s+def\s+([a-z_][a-z0-9_]*)\s*\(",
+        re.MULTILINE,
+    )
+    tool_names = tool_pattern.findall(source)
+
+    for tool_name in tool_names:
+        # Check if the tool name appears in the README (as-is or with underscores)
+        if tool_name.lower() not in readme:
+            # Also try a display form: replace underscores with spaces or other patterns
+            # The README uses names like "scan_directory" which may differ from function names
+            # Check a loose match: any word boundary match
+            alt_name = tool_name.replace("_", " ")
+            if alt_name not in readme and tool_name not in readme:
+                failures.append(
+                    f"MCP tool '{tool_name}' found in mcp_server.py but missing from README.md MCP tools table"
+                )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 5: Version consistency
+# ---------------------------------------------------------------------------
+
+
+def check_version_consistency() -> list[str]:
+    """Verify key docs files reference the current version."""
+    failures: list[str] = []
+    version = get_version_from_pyproject()
+    version_tag = f"@v{version}"
+
+    files_to_check = [
+        (README_MD, "README.md"),
+        (DOCS_INDEX_MD, "docs/content/index.md"),
+    ]
+
+    for path, label in files_to_check:
+        if not path.exists():
+            failures.append(f"File {label} does not exist")
+            continue
+        content = read_text(path)
+        if version_tag not in content:
+            # Check if ANY version tag is present (might just be outdated)
+            old_tags = re.findall(r"@v\d+\.\d+\.\d+", content)
+            if old_tags:
+                outdated = set(old_tags) - {version_tag}
+                if outdated:
+                    failures.append(
+                        f"{label} references outdated version(s) {sorted(outdated)} "
+                        f"instead of {version_tag}"
+                    )
+            else:
+                failures.append(f"{label} does not reference version {version_tag}")
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 6: Config file path consistency
+# ---------------------------------------------------------------------------
+
+
+def check_config_path() -> list[str]:
+    """Flag docs referencing .ash/ash.yaml instead of .ash/.ash.yaml."""
+    failures: list[str] = []
+
+    # Pattern: .ash/ash.yaml NOT preceded by a dot (i.e., not .ash/.ash.yaml)
+    # We look for occurrences of ".ash/ash.yaml" that are NOT ".ash/.ash.yaml"
+    bad_pattern = re.compile(r"(?<!\.)\.ash/ash\.yaml")
+
+    for md_file in collect_md_files():
+        content = read_text(md_file)
+        matches = bad_pattern.findall(content)
+        if matches:
+            rel_path = md_file.relative_to(REPO_ROOT)
+            failures.append(
+                f"{rel_path} references '.ash/ash.yaml' (should be '.ash/.ash.yaml')"
+            )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Check 7: Suppression field name
+# ---------------------------------------------------------------------------
+
+
+def check_suppression_field_name() -> list[str]:
+    """Flag docs using 'file_path:' in suppression context (should be 'path:')."""
+    failures: list[str] = []
+
+    for md_file in collect_md_files():
+        content = read_text(md_file)
+        lines = content.splitlines()
+
+        for i, line in enumerate(lines):
+            # Look for file_path: in a line
+            if "file_path:" not in line:
+                continue
+
+            # Check surrounding context (20 lines before/after) for suppression keywords
+            context_start = max(0, i - 20)
+            context_end = min(len(lines), i + 20)
+            context_block = "\n".join(lines[context_start:context_end]).lower()
+
+            if "suppress" in context_block or "rule_id" in context_block:
+                rel_path = md_file.relative_to(REPO_ROOT)
+                failures.append(
+                    f"{rel_path}:{i + 1} uses 'file_path:' in suppression context "
+                    f"(should be 'path:')"
+                )
+
+    return failures
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> int:
+    checks = [
+        ("CLI flags in docs match source", check_cli_flags),
+        ("Reporter list in docs matches code", check_reporters),
+        ("Scanner list in docs matches code", check_scanners),
+        ("MCP tool names in docs match code", check_mcp_tools),
+        ("Version consistency", check_version_consistency),
+        ("Config file path consistency", check_config_path),
+        ("Suppression field name", check_suppression_field_name),
+    ]
+
+    all_failures: list[tuple[str, list[str]]] = []
+    passed = 0
+    failed = 0
+
+    for name, check_fn in checks:
+        try:
+            failures = check_fn()
+        except Exception as e:
+            failures = [f"Check raised an exception: {e}"]
+
+        if failures:
+            failed += 1
+            all_failures.append((name, failures))
+            print(f"FAIL  {name}")
+            for f in failures:
+                print(f"        - {f}")
+        else:
+            passed += 1
+            print(f"PASS  {name}")
+
+    print()
+    print(f"Results: {passed} passed, {failed} failed, {passed + failed} total")
+
+    if all_failures:
+        print()
+        print("Documentation is out of sync with source code.")
+        print("Fix the issues above and re-run this script.")
+        return 1
+
+    print()
+    print("All documentation freshness checks passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Addresses 80+ documentation issues identified by a 20-agent parallel review. Establishes source-derived doc generation with pre-commit hooks and CI drift detection.

### Bug Fixes (12 files)
- Fix version typo `v3.0,1` → `@v3.4.1` in README
- Update 16 stale version references (v3.4.0, v3.0.0, v3.2.2 → v3.4.1)
- Fix config path `.ash/ash.yaml` → `.ash/.ash.yaml` (3 files)
- Fix suppression field `file_path` → `path` (3 files)
- Update pre-commit `rev: v3.0.0` → `rev: v3.4.1` (5 files)

### New Documentation (10 files)
- `SECURITY.md` — vulnerability disclosure policy
- `.github/ISSUE_TEMPLATE/bug_report.yml` — structured bug report form
- `.github/ISSUE_TEMPLATE/feature_request.yml` — feature request form
- `.github/PULL_REQUEST_TEMPLATE.md` — PR checklist
- `docs/content/docs/concepts.md` — domain model with Mermaid flow diagram
- `docs/content/docs/glossary.md` — 28 term definitions
- `docs/content/docs/supported-languages.md` — scanner coverage matrix
- `docs/content/docs/api-reference.md` — mkdocstrings auto-rendered from docstrings
- `docs/content/docs/cli-reference-generated.md` — auto-generated from Typer introspection

### Source-Derived Automation
- `scripts/generate_cli_docs.py` — introspects Typer commands + MCP tools → markdown
- `scripts/verify_docs_freshness.py` — 7-check CI gate (versions, reporters, scanners, MCP tools, paths, field names)
- Pre-commit hook: `generate-cli-docs` (regenerates on every commit)
- CI lint job: regenerates + `git diff --exit-code` + freshness verifier

### Docstring Coverage (21 files)
- Added docstrings to all 10 scanner config classes and 11 reporter config classes
- These render automatically via mkdocstrings in the API reference page
- Adding a new scanner/reporter plugin now auto-surfaces in generated docs

## What's automated vs manual going forward

| Automated (never manually maintain) | Manual (human-authored, CI-guarded) |
|---|---|
| CLI reference tables | Concepts, glossary, tutorials |
| MCP tools reference | Architecture, troubleshooting |
| Version strings (template system) | Migration guides |
| Scanner/reporter lists | CI integration guides |
| JSON schemas | Suppression workflow docs |

## Test plan

- [x] `uv run python scripts/generate_cli_docs.py` produces consistent output
- [x] All 21 scanner/reporter configs have docstrings
- [ ] `uv run python scripts/verify_docs_freshness.py` passes after docs fixes
- [ ] `mkdocs build` succeeds with all new pages
- [ ] CI lint job passes (schemas + CLI docs + freshness)