### PR TITLE
fix: handle None output_dir in inspect findings command

### DIFF
--- a/automated_security_helper/cli/inspect/inspect_findings_app.py
+++ b/automated_security_helper/cli/inspect/inspect_findings_app.py
@@ -75,7 +75,9 @@ class SuppressDialog(ModalScreen[bool]):
             yield Label(f"File: {self.finding.get('file', 'N/A')}")
             yield Label(f"Line: {self.finding.get('line', 'N/A')}")
             yield Label("Reason (required):")
-            yield Input(placeholder="Why is this finding suppressed?", id="reason_input")
+            yield Input(
+                placeholder="Why is this finding suppressed?", id="reason_input"
+            )
             yield Label("Expiration date (optional, YYYY-MM-DD):")
             yield Input(placeholder="e.g. 2025-12-31", id="expiration_input")
             with HorizontalGroup(classes="button-row"):
@@ -103,8 +105,12 @@ class SuppressDialog(ModalScreen[bool]):
                     path=self.finding.get("file") or "*",
                     reason=reason,
                     expiration=expiration,
-                    line_start=int(self.finding["line"]) if self.finding.get("line") else None,
-                    line_end=int(self.finding["line"]) if self.finding.get("line") else None,
+                    line_start=int(self.finding["line"])
+                    if self.finding.get("line")
+                    else None,
+                    line_end=int(self.finding["line"])
+                    if self.finding.get("line")
+                    else None,
                 )
                 add_suppression_to_config(self.config_path, suppression)
                 self.dismiss(True)
@@ -986,7 +992,31 @@ def findings_command(
     """Interactively explore security findings."""
     # Try to load the model from the output directory
     try:
-        report_file_actual = Path(output_dir).joinpath(report_file)
+        # Resolve cwd-based default at call time (not import time).
+        if output_dir is None:
+            output_dir = Path.cwd().joinpath(".ash", "ash_output")
+
+        output_dir_path = Path(output_dir)
+
+        # Search multiple candidate paths for the report file
+        candidate_paths = [
+            output_dir_path.joinpath(".ash", "ash_output", report_file),
+            output_dir_path.joinpath("ash_output", report_file),
+            output_dir_path.joinpath(report_file),
+        ]
+
+        report_file_actual = None
+        for candidate in candidate_paths:
+            if candidate.exists():
+                report_file_actual = candidate
+                break
+
+        if report_file_actual is None:
+            typer.echo(
+                "No model or report file available. Please run a scan first or provide a report file."
+            )
+            return
+
         model = AshAggregatedResults.load_model(Path(report_file_actual))
         if model is None:
             typer.echo(

--- a/tests/unit/cli/inspect/test_inspect_findings_app.py
+++ b/tests/unit/cli/inspect/test_inspect_findings_app.py
@@ -6,7 +6,7 @@ Textual rendering internals are not tested.
 """
 
 import pytest
-from unittest.mock import MagicMock, patch, mock_open
+from unittest.mock import MagicMock, patch
 from pathlib import Path
 
 from automated_security_helper.cli.inspect.inspect_findings_app import (
@@ -569,7 +569,7 @@ class TestFindingDetailScreen:
             "line": 1,
             "message": "test",
         }
-        screen = FindingDetailScreen(finding)
+        screen = FindingDetailScreen(finding)  # noqa: F841
         # Compose would use file_ext = "yaml" for .yml files
         # We verify the logic by checking the path suffix handling
         snippet_path = Path(finding["file"])
@@ -587,7 +587,7 @@ class TestFindingDetailScreen:
             "line": 1,
             "message": "test",
         }
-        screen = FindingDetailScreen(finding)
+        screen = FindingDetailScreen(finding)  # noqa: F841
         snippet_path = Path(finding["file"])
         file_ext = (
             snippet_path.suffix.lstrip(".")
@@ -785,42 +785,98 @@ class TestExtractFindings:
 
 
 class TestFindingsCommand:
-    @patch("automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults")
+    @patch(
+        "automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults"
+    )
     @patch("typer.secho")
     def test_command_handles_load_error(self, mock_secho, mock_model_cls):
-        from automated_security_helper.cli.inspect.inspect_findings_app import findings_command
+        from automated_security_helper.cli.inspect.inspect_findings_app import (
+            findings_command,
+        )
 
         mock_model_cls.load_model.side_effect = FileNotFoundError("not found")
 
-        # Call through typer callback simulation
-        findings_command(output_dir=Path("/nonexistent"), report_file="report.json")
+        # Use a temp directory with a real file so candidate path check passes
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.json"
+            report_path.write_text("{}")
+            findings_command(output_dir=Path(tmpdir), report_file="report.json")
+
         mock_secho.assert_called_once()
         call_args = mock_secho.call_args
         assert "Error loading model or report" in call_args[0][0]
 
-    @patch("automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults")
+    @patch(
+        "automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults"
+    )
     @patch("typer.echo")
     def test_command_handles_none_model(self, mock_echo, mock_model_cls):
-        from automated_security_helper.cli.inspect.inspect_findings_app import findings_command
+        from automated_security_helper.cli.inspect.inspect_findings_app import (
+            findings_command,
+        )
 
         mock_model_cls.load_model.return_value = None
 
-        findings_command(output_dir=Path("/tmp"), report_file="report.json")  # nosec B108
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.json"
+            report_path.write_text("{}")
+            findings_command(output_dir=Path(tmpdir), report_file="report.json")
+
         mock_echo.assert_called_once()
         assert "No model" in mock_echo.call_args[0][0]
 
-    @patch("automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults")
-    @patch("automated_security_helper.cli.inspect.inspect_findings_app.extract_findings")
+    @patch(
+        "automated_security_helper.cli.inspect.inspect_findings_app.AshAggregatedResults"
+    )
+    @patch(
+        "automated_security_helper.cli.inspect.inspect_findings_app.extract_findings"
+    )
     @patch("typer.echo")
     def test_command_handles_no_findings(self, mock_echo, mock_extract, mock_model_cls):
-        from automated_security_helper.cli.inspect.inspect_findings_app import findings_command
+        from automated_security_helper.cli.inspect.inspect_findings_app import (
+            findings_command,
+        )
 
         mock_model_cls.load_model.return_value = MagicMock()
         mock_extract.return_value = []
 
-        findings_command(output_dir=Path("/tmp"), report_file="report.json")  # nosec B108
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            report_path = Path(tmpdir) / "report.json"
+            report_path.write_text("{}")
+            findings_command(output_dir=Path(tmpdir), report_file="report.json")
+
         mock_echo.assert_called_once()
         assert "No findings" in mock_echo.call_args[0][0]
+
+    @patch("typer.echo")
+    def test_command_handles_none_output_dir(self, mock_echo):
+        """Test that findings_command handles None output_dir gracefully."""
+        from automated_security_helper.cli.inspect.inspect_findings_app import (
+            findings_command,
+        )
+
+        import tempfile
+        import os
+
+        # Run from a temp directory with no .ash/ash_output
+        with tempfile.TemporaryDirectory() as tmpdir:
+            original_cwd = os.getcwd()
+            try:
+                os.chdir(tmpdir)
+                findings_command(
+                    output_dir=None, report_file="ash_aggregated_results.json"
+                )
+            finally:
+                os.chdir(original_cwd)
+
+        mock_echo.assert_called_once()
+        assert "No model" in mock_echo.call_args[0][0]
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -122,7 +122,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "attrs", specifier = ">=23.1.0,<27.0.0" },
-    { name = "aws-cdk-lib", marker = "extra == 'cdk'", specifier = ">=2.150.0,<2.249" },
+    { name = "aws-cdk-lib", marker = "extra == 'cdk'", specifier = ">=2.253.0,<2.254" },
     { name = "boto3", specifier = ">=1.34.0,<1.44" },
     { name = "cattrs", specifier = ">=22.1.0,<27.0.0" },
     { name = "cdk-nag", marker = "extra == 'cdk'", specifier = ">=2.28.0,<3.0.0" },
@@ -143,7 +143,7 @@ requires-dist = [
     { name = "python-multipart", specifier = ">=0.0.22,<0.1" },
     { name = "requests", specifier = ">=2.28.0,<3.0.0" },
     { name = "rich", specifier = ">=13.5.3,<16" },
-    { name = "textual", specifier = ">=3.2.0,<9" },
+    { name = "textual", specifier = ">=8.2.5,<9" },
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
     { name = "typer", specifier = ">=0.16.0,<0.26" },
     { name = "uv", specifier = ">=0.9.21,<0.12" },
@@ -153,13 +153,13 @@ provides-extras = ["cdk"]
 [package.metadata.requires-dev]
 dev = [
     { name = "commitizen", specifier = ">=4.13.10" },
-    { name = "hatchling", specifier = ">=1.27.0" },
+    { name = "hatchling", specifier = ">=1.29.0" },
     { name = "lazydocs", specifier = ">=0.4.8,<1.0.0" },
     { name = "mcp", specifier = ">=1.23.3" },
     { name = "mkdocs", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-autorefs", specifier = ">=1.4.1,<2.0.0" },
     { name = "mkdocs-awesome-nav", specifier = ">=3.1.2,<4.0.0" },
-    { name = "mkdocs-material", specifier = ">=9.6.11,<10.0.0" },
+    { name = "mkdocs-material", specifier = ">=9.7.6,<10.0.0" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2.1,<2.0.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.29.1,<1.0.0" },
     { name = "mypy", specifier = ">=1.15.0,<2.0.0" },
@@ -167,7 +167,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=0.26.0,<2.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.0,<7.0.0" },
-    { name = "pytest-mock", specifier = ">=3.14.0,<4.0.0" },
+    { name = "pytest-mock", specifier = ">=3.15.1,<4.0.0" },
     { name = "pytest-xdist", specifier = ">=3.7.0,<4.0.0" },
     { name = "ruff", specifier = ">=0.11.2,<1.0.0" },
     { name = "toml", specifier = ">=0.10.2" },
@@ -219,7 +219,7 @@ wheels = [
 
 [[package]]
 name = "aws-cdk-lib"
-version = "2.248.0"
+version = "2.253.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aws-cdk-asset-awscli-v1" },
@@ -230,9 +230,9 @@ dependencies = [
     { name = "publication" },
     { name = "typeguard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/42/a8250f31763adb21acb90088b99f7f37c3b8d09c3fd94dc631c0e69d9463/aws_cdk_lib-2.248.0.tar.gz", hash = "sha256:a00c73bfa6865ef62d700d6f97dd4124979ccfe69dc1ef70f2526aa49c52bbc8", size = 48734274, upload-time = "2026-04-03T07:35:05.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7a/58/f4104842e277f000396f9f9e12588eb83615a1212fb3ee1668bb5dd1f97a/aws_cdk_lib-2.253.1.tar.gz", hash = "sha256:df03363cdaef4d2d7bac368b2d5d2bf4209921d21096cd5f8e5889347fee4793", size = 49586746, upload-time = "2026-05-08T16:05:27.185Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/0b/41b0979581668c709b01a7d26f9c2716031f2b0c53ad5a01341160c631b0/aws_cdk_lib-2.248.0-py3-none-any.whl", hash = "sha256:e89db288365371e6b42aaae8b45ad2064615dfbe87e95741a2f2bb7ec1f33dad", size = 49395398, upload-time = "2026-04-03T07:34:25.671Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7c/1e7964f0f267301bb5026fed45369961f7311073412bcd36e09fbe4df0de/aws_cdk_lib-2.253.1-py3-none-any.whl", hash = "sha256:03a6f5080978f9e3576f490d06fbd1f41f159280d34dbca50721de4a19694136", size = 50271288, upload-time = "2026-05-08T16:04:41.956Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When --output-dir is not provided, findings_command crashed with TypeError because Path(None) is invalid. Add the standard null-check defaulting to .ash/ash_output relative to CWD, and search multiple candidate paths for the report file, matching the pattern used in report.py and scan.py.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
