### PR TITLE
fix(ci): disable coverage gate in release smoke test

### DIFF
--- a/.github/actions/run-scan-test/action.yml
+++ b/.github/actions/run-scan-test/action.yml
@@ -262,7 +262,7 @@ runs:
       uses: actions/upload-artifact@v7
       if: success() || failure()
       with:
-        name: ash_output-${{ inputs.os }}-${{ inputs.method }}-${{ inputs.config-file }}
+        name: ash_output-${{ inputs.os }}-${{ inputs.method }}-${{ inputs.config-file }}${{ inputs.oci-runner && format('-{0}', inputs.oci-runner) || '' }}${{ inputs.offline == 'true' && '-offline' || '' }}
         path: .ash/ash_output
         retention-days: 7
         if-no-files-found: warn

--- a/.github/workflows/ash-create-release.yml
+++ b/.github/workflows/ash-create-release.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           uv run ash --help
           uv run ash config validate
-          uv run python -m pytest tests/unit/cli/test_config_init.py -x -q --no-header
+          uv run python -m pytest tests/unit/cli/test_config_init.py -x -q --no-header --no-cov
 
       - name: Create release PR
         if: steps.bump.outputs.bumped == 'true'


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The smoke test only runs a single test file as a sanity check. Because pytest.ini globally enables --cov with fail_under=80, this single file triggers a coverage failure (31% vs 80% required). Adding --no-cov skips the coverage gate for this targeted smoke test.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
