### PR TITLE
fix: MCP Server, config validation and cli

### DIFF
--- a/automated_security_helper/base/scanner_plugin.py
+++ b/automated_security_helper/base/scanner_plugin.py
@@ -17,8 +17,9 @@ from typing import Annotated, Any, Generic, List, Literal, Optional, TypeVar
 from abc import abstractmethod
 
 # Pattern for valid CLI flag keys: one or two leading dashes followed by
-# a letter, then alphanumerics/underscores/hyphens.
-_VALID_FLAG_KEY_PATTERN = re.compile(r"^-{1,2}[A-Za-z][A-Za-z0-9_\-]*$")
+# a letter, then alphanumerics/underscores/hyphens. Optionally followed by
+# '=' and a value (e.g., --exclude="path1,path2" or --skip-path=".venv/").
+_VALID_FLAG_KEY_PATTERN = re.compile(r"^-{1,2}[A-Za-z][A-Za-z0-9_\-]*(=.*)?$")
 from pathlib import Path
 
 

--- a/automated_security_helper/cli/mcp_server.py
+++ b/automated_security_helper/cli/mcp_server.py
@@ -647,6 +647,10 @@ async def get_scan_results(
         if scanners or severities:
             results = _apply_content_filters(results, scanners, severities)
 
+        # When actionable_only is requested, extract a flat findings list for easy consumption
+        if actionable_only:
+            results = _add_findings_list(results)
+
         # Apply response size filter based on parameter
         if filter_level == "full":
             # Return full results for backward compatibility
@@ -773,18 +777,58 @@ def _filter_minimal(results: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _get_finding_severity(result: Dict[str, Any]) -> str:
+    """
+    Determine the severity of a SARIF finding.
+
+    Checks explicit issue_severity in properties first, then falls back to
+    mapping the SARIF level to a severity string.
+
+    Args:
+        result: A single SARIF result dict
+
+    Returns:
+        Uppercase severity string (CRITICAL, HIGH, MEDIUM, LOW, INFO)
+    """
+    # SARIF level -> severity mapping
+    _SARIF_LEVEL_TO_SEVERITY = {
+        "error": "CRITICAL",
+        "warning": "MEDIUM",
+        "note": "LOW",
+        "none": "INFO",
+    }
+
+    # Check explicit issue_severity in properties first
+    props = result.get("properties", {}) or {}
+    issue_severity = (props.get("issue_severity") or "").upper()
+    if issue_severity in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
+        return issue_severity
+
+    # Fall back to SARIF level mapping
+    level = (result.get("level") or "note").lower()
+    return _SARIF_LEVEL_TO_SEVERITY.get(level, "LOW")
+
+
+def _is_finding_suppressed(result: Dict[str, Any]) -> bool:
+    """Check if a SARIF finding is suppressed."""
+    suppressions = result.get("suppressions")
+    return bool(suppressions and len(suppressions) > 0)
+
+
 def _filter_actionable_only(results: Dict[str, Any]) -> Dict[str, Any]:
     """
-    Filter results to exclude suppressed findings.
+    Filter results to exclude suppressed findings and return only actionable findings.
 
     This removes findings that have been marked as false positives or accepted risks,
-    returning only actionable findings that require attention.
+    returning only actionable findings that require attention. The SARIF results are
+    filtered to contain only non-suppressed findings.
 
     Args:
         results: The full scan results
 
     Returns:
-        Filtered results with suppressed findings excluded
+        Filtered results with suppressed findings excluded and SARIF results
+        containing only actionable findings
     """
     import copy
 
@@ -801,10 +845,7 @@ def _filter_actionable_only(results: Dict[str, Any]) -> Dict[str, Any]:
                     run["results"] = [
                         result
                         for result in run["results"]
-                        if not (
-                            result.get("suppressions")
-                            and len(result.get("suppressions", [])) > 0
-                        )
+                        if not _is_finding_suppressed(result)
                     ]
 
     # Update summary stats to reflect only actionable findings
@@ -839,11 +880,75 @@ def _filter_actionable_only(results: Dict[str, Any]) -> Dict[str, Any]:
     return filtered_results
 
 
+def _add_findings_list(results: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Extract a flat list of actionable findings from SARIF results and add it
+    to the top level of the response for easy consumption.
+
+    This provides a clear, focused list of findings that require attention,
+    rather than requiring consumers to navigate the nested SARIF structure.
+
+    Args:
+        results: The filtered scan results (after actionable_only and severity filters)
+
+    Returns:
+        Results with an added top-level 'findings' list
+    """
+    findings_list = []
+
+    # Extract findings from SARIF runs
+    sarif = results.get("raw_results", {}).get("sarif", {})
+    if "runs" in sarif:
+        for run in sarif["runs"]:
+            for result in run.get("results", []):
+                props = result.get("properties", {}) or {}
+                locations = result.get("locations", [])
+
+                # Extract location info
+                file_path = None
+                line_start = None
+                line_end = None
+                if locations:
+                    phys_loc = (
+                        locations[0].get("physicalLocation", {}) if locations else {}
+                    )
+                    artifact_loc = phys_loc.get("artifactLocation", {})
+                    file_path = artifact_loc.get("uri")
+                    region = phys_loc.get("region", {})
+                    line_start = region.get("startLine")
+                    line_end = region.get("endLine")
+
+                finding = {
+                    "rule_id": result.get("ruleId"),
+                    "severity": _get_finding_severity(result),
+                    "message": (
+                        result.get("message", {}).get("text")
+                        or result.get("message", {}).get("markdown")
+                    ),
+                    "scanner": props.get("scanner_name"),
+                    "file_path": file_path,
+                    "line_start": line_start,
+                    "line_end": line_end,
+                }
+
+                # Only include non-None values
+                finding = {k: v for k, v in finding.items() if v is not None}
+                findings_list.append(finding)
+
+    results["findings"] = findings_list
+    results["findings_count"] = len(findings_list)
+
+    return results
+
+
 def _apply_content_filters(
     results: Dict[str, Any], scanners: str = None, severities: str = None
 ) -> Dict[str, Any]:
     """
     Filter results by scanner names and/or severity levels.
+
+    This filters both the metadata (severity_counts, scanner_results) AND the actual
+    SARIF findings to only include results matching the specified criteria.
 
     Args:
         results: The full scan results
@@ -865,6 +970,30 @@ def _apply_content_filters(
 
     # Create a deep copy to avoid modifying the original
     filtered_results = copy.deepcopy(results)
+
+    # Filter SARIF findings by scanner and/or severity
+    if "raw_results" in filtered_results and "sarif" in filtered_results["raw_results"]:
+        sarif = filtered_results["raw_results"]["sarif"]
+        if "runs" in sarif:
+            for run in sarif["runs"]:
+                if "results" in run and run["results"]:
+                    filtered_sarif_results = []
+                    for result in run["results"]:
+                        # Filter by scanner name if specified
+                        if scanner_list:
+                            props = result.get("properties", {}) or {}
+                            result_scanner = (props.get("scanner_name") or "").lower()
+                            if result_scanner and result_scanner not in scanner_list:
+                                continue
+
+                        # Filter by severity if specified
+                        if severity_list:
+                            finding_severity = _get_finding_severity(result).lower()
+                            if finding_severity not in severity_list:
+                                continue
+
+                        filtered_sarif_results.append(result)
+                    run["results"] = filtered_sarif_results
 
     # Filter scanner_reports
     if "scanner_reports" in filtered_results and scanner_list:
@@ -955,6 +1084,16 @@ def _apply_content_filters(
                 "suppressed",
             ]:
                 filtered_summary_stats[key] = 0
+        # Recalculate actionable based on filtered severity counts if it existed
+        if "actionable" in filtered_summary_stats:
+            severity_keys = ["critical", "high", "medium", "low", "info"]
+            new_actionable = sum(
+                filtered_summary_stats.get(k, 0) for k in severity_keys
+            )
+            filtered_summary_stats["actionable"] = new_actionable
+            filtered_summary_stats["total"] = (
+                new_actionable + filtered_summary_stats.get("suppressed", 0)
+            )
         filtered_results["summary_stats"] = filtered_summary_stats
 
     # Add filter metadata

--- a/automated_security_helper/cli/scan.py
+++ b/automated_security_helper/cli/scan.py
@@ -339,7 +339,10 @@ def run_ash_scan_cli_command(
     if source_dir is None:
         source_dir = Path.cwd().as_posix()
     if output_dir is None:
-        output_dir = Path.cwd().joinpath(".ash", "ash_output").as_posix()
+        # Default output_dir is relative to source_dir, not CWD.
+        # This ensures that when --source-dir points to a different project,
+        # the output (and config resolution) happens in the correct location.
+        output_dir = Path(source_dir).joinpath(".ash", "ash_output").as_posix()
 
     if Path(source_dir).absolute().as_posix() == Path(output_dir).absolute().as_posix():
         output_dir = Path(output_dir).joinpath(".ash", "ash_output")

--- a/automated_security_helper/config/config_linter.py
+++ b/automated_security_helper/config/config_linter.py
@@ -45,6 +45,7 @@ class LintCategory(str, Enum):
     SUPPRESSION_LINE_RANGE = "suppression-line-range"
     SUPPRESSION_EXPIRED = "suppression-expired"
     SUPPRESSION_UNUSED = "suppression-unused"
+    IGNORE_PATH_ISSUE = "ignore-path-issue"
     SYNTAX_ERROR = "syntax-error"
 
 
@@ -118,6 +119,7 @@ class ConfigLinter:
         config_path: Path,
         output_dir: Optional[Path] = None,
         check_unused: bool = False,
+        source_dir: Optional[Path] = None,
     ) -> LintResult:
         """Lint a configuration file and return all issues found.
 
@@ -125,6 +127,8 @@ class ConfigLinter:
             config_path: Path to the configuration file
             output_dir: Path to the ASH output directory (for unused suppressions check)
             check_unused: Whether to check for unused suppressions
+            source_dir: Path to the source directory (for resolving ignore_path patterns).
+                        If None, inferred from config_path location.
 
         Returns:
             LintResult with all issues found
@@ -149,6 +153,9 @@ class ConfigLinter:
 
         # Run suppression-specific lint checks
         cls._check_suppression_issues(config_data, result)
+
+        # Run ignore_path and suppression path checks
+        cls._check_ignore_path_issues(config_path, config_data, result, source_dir)
 
         # Check for unused suppressions if requested
         if check_unused:
@@ -624,6 +631,113 @@ class ConfigLinter:
                             path=path_prefix,
                         )
                     )
+
+    @classmethod
+    def _check_ignore_path_issues(
+        cls,
+        config_path: Path,
+        config_data: Dict[str, Any],
+        result: LintResult,
+        source_dir: Optional[Path] = None,
+    ) -> None:
+        """Check ignore_paths and suppression paths for common issues.
+
+        Detects:
+        - Paths that point to existing directories but lack a '**' glob suffix,
+          which means they won't match any files inside the directory.
+        - Only warns when the path actually exists as a directory in the repo
+          (avoids false positives for virtual environments that may not be initialized).
+        """
+        # Determine the project root for resolving relative paths
+        if source_dir is not None:
+            project_root = source_dir.resolve()
+        else:
+            config_parent = config_path.resolve().parent
+            # If config is in .ash/, go up one level to project root
+            if config_parent.name == ".ash":
+                project_root = config_parent.parent
+            else:
+                project_root = config_parent
+
+        global_settings = config_data.get("global_settings", {})
+        if not isinstance(global_settings, dict):
+            return
+
+        # Check ignore_paths
+        ignore_paths = global_settings.get("ignore_paths", [])
+        if isinstance(ignore_paths, list):
+            for i, entry in enumerate(ignore_paths):
+                if not isinstance(entry, dict):
+                    continue
+                path_pattern = entry.get("path", "")
+                if path_pattern:
+                    cls._check_single_path_pattern(
+                        path_pattern=path_pattern,
+                        path_prefix=f"global_settings.ignore_paths[{i}].path",
+                        project_root=project_root,
+                        result=result,
+                    )
+
+        # Check suppression paths
+        suppressions = global_settings.get("suppressions", [])
+        if isinstance(suppressions, list):
+            for i, entry in enumerate(suppressions):
+                if not isinstance(entry, dict):
+                    continue
+                path_pattern = entry.get("path", "")
+                if path_pattern:
+                    cls._check_single_path_pattern(
+                        path_pattern=path_pattern,
+                        path_prefix=f"global_settings.suppressions[{i}].path",
+                        project_root=project_root,
+                        result=result,
+                    )
+
+    @classmethod
+    def _check_single_path_pattern(
+        cls,
+        path_pattern: str,
+        path_prefix: str,
+        project_root: Path,
+        result: LintResult,
+    ) -> None:
+        """Check a single path pattern for directory-without-glob issues.
+
+        A path like 'tests/test_data' or 'tests/test_data/' that points to an
+        existing directory will silently fail to match any files inside it.
+        The user likely intended 'tests/test_data/**'.
+        """
+        # Skip patterns that already contain glob characters that would match files
+        # Patterns with ** already handle recursive matching
+        if "**" in path_pattern:
+            return
+
+        # Strip trailing slash for directory check
+        clean_path = path_pattern.rstrip("/")
+
+        # Skip patterns with wildcards in the filename portion (e.g., "src/*.py")
+        # These are valid file-matching patterns
+        basename = Path(clean_path).name
+        if "*" in basename or "?" in basename or "[" in basename:
+            return
+
+        # Check if this path resolves to an existing directory
+        # We strip leading **/ patterns that won't exist as literal paths
+        candidate = project_root / clean_path
+        if candidate.is_dir():
+            # The path exists as a directory — warn that it needs /**
+            result.issues.append(
+                LintIssue(
+                    severity=LintSeverity.WARNING,
+                    category=LintCategory.IGNORE_PATH_ISSUE,
+                    message=(
+                        f"Path '{path_pattern}' points to a directory but lacks a '**' glob suffix. "
+                        f"This pattern will not match files inside the directory. "
+                        f"Use '{clean_path}/**' to ignore all files recursively."
+                    ),
+                    path=path_prefix,
+                )
+            )
 
     @classmethod
     def _check_unused_suppressions(

--- a/automated_security_helper/config/config_validator.py
+++ b/automated_security_helper/config/config_validator.py
@@ -5,7 +5,7 @@
 
 import json
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import yaml
 
@@ -62,11 +62,15 @@ class ConfigValidator:
     }
 
     @classmethod
-    def validate_config_file(cls, config_path: Path) -> Tuple[bool, List[str]]:
+    def validate_config_file(
+        cls, config_path: Path, source_dir: Optional[Path] = None
+    ) -> Tuple[bool, List[str]]:
         """Validate a configuration file and return validation results.
 
         Args:
             config_path: Path to the configuration file
+            source_dir: Path to the source directory (for resolving ignore_path patterns).
+                        If None, inferred from config_path location.
 
         Returns:
             Tuple of (is_valid, list_of_errors)
@@ -162,6 +166,10 @@ class ConfigValidator:
                                     f"this should not be in user configs"
                                 )
 
+            # Validate ignore_paths and suppression paths for directory-without-glob issues
+            warnings = cls._check_path_patterns(config_path, config_data, source_dir)
+            errors.extend(warnings)
+
             return len(errors) == 0, errors
 
         except yaml.YAMLError as e:
@@ -173,6 +181,94 @@ class ConfigValidator:
         except Exception as e:
             errors.append(f"Unexpected error during validation: {str(e)}")
             return False, errors
+
+    @classmethod
+    def _check_path_patterns(
+        cls,
+        config_path: Path,
+        config_data: dict,
+        source_dir: Optional[Path] = None,
+    ) -> List[str]:
+        """Check ignore_paths and suppression paths for directory-without-glob issues.
+
+        Returns a list of warning messages for paths that point to existing directories
+        but lack a '**' glob suffix (meaning they won't match files inside).
+        Only warns when the path actually exists as a directory in the repo.
+        """
+        warnings = []
+
+        # Determine the project root for resolving relative paths
+        if source_dir is not None:
+            project_root = source_dir.resolve()
+        else:
+            config_parent = config_path.resolve().parent
+            if config_parent.name == ".ash":
+                project_root = config_parent.parent
+            else:
+                project_root = config_parent
+
+        global_settings = config_data.get("global_settings", {})
+        if not isinstance(global_settings, dict):
+            return warnings
+
+        # Check ignore_paths
+        ignore_paths = global_settings.get("ignore_paths", [])
+        if isinstance(ignore_paths, list):
+            for entry in ignore_paths:
+                if not isinstance(entry, dict):
+                    continue
+                path_pattern = entry.get("path", "")
+                warning = cls._check_single_path(path_pattern, project_root)
+                if warning:
+                    warnings.append(warning)
+
+        # Check suppression paths
+        suppressions = global_settings.get("suppressions", [])
+        if isinstance(suppressions, list):
+            for entry in suppressions:
+                if not isinstance(entry, dict):
+                    continue
+                path_pattern = entry.get("path", "")
+                warning = cls._check_single_path(path_pattern, project_root)
+                if warning:
+                    warnings.append(warning)
+
+        return warnings
+
+    @classmethod
+    def _check_single_path(cls, path_pattern: str, project_root: Path) -> Optional[str]:
+        """Check a single path pattern for directory-without-glob issues.
+
+        Returns a warning message if the path points to an existing directory
+        without a '**' glob suffix, or None if the path is fine.
+        """
+        if not path_pattern:
+            return None
+
+        # Skip patterns that already contain ** (recursive glob)
+        if "**" in path_pattern:
+            return None
+
+        # Strip trailing slash for directory check
+        clean_path = path_pattern.rstrip("/")
+
+        # Skip patterns with wildcards in the filename portion
+        from pathlib import PurePosixPath
+
+        basename = PurePosixPath(clean_path).name
+        if "*" in basename or "?" in basename or "[" in basename:
+            return None
+
+        # Check if this path resolves to an existing directory
+        candidate = project_root / clean_path
+        if candidate.is_dir():
+            return (
+                f"Path '{path_pattern}' points to a directory but lacks a '**' glob suffix — "
+                f"it will not match files inside the directory. "
+                f"Use '{clean_path}/**' to ignore all files recursively."
+            )
+
+        return None
 
     @classmethod
     def validate_and_raise(cls, config_path: Path) -> None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
@@ -82,6 +82,24 @@ PURL_TYPE_TO_GITLAB: dict[str, tuple[str, str]] = {
     "rpm": ("yum", ""),
 }
 
+# Default lockfile/manifest names per ecosystem, used as a last-resort fallback
+# for the metadata-level ``input_file:path`` when Syft doesn't report a location.
+_DEFAULT_LOCKFILES: dict[str, str] = {
+    "npm": "package-lock.json",
+    "pypi": "requirements.txt",
+    "gem": "Gemfile.lock",
+    "golang": "go.sum",
+    "maven": "pom.xml",
+    "cargo": "Cargo.lock",
+    "composer": "composer.lock",
+    "nuget": "packages.lock.json",
+    "pub": "pubspec.lock",
+    "cocoapods": "Podfile.lock",
+    "hex": "mix.lock",
+    "python": "requirements.txt",
+    "go-module": "go.sum",
+}
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -312,6 +330,53 @@ class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig])
             self.config = GitLabCycloneDXReporterConfig()
         return super().model_post_init(context)
 
+    def _resolve_dominant_type(
+        self,
+        components: list[dict],
+        options: GitLabCycloneDXReporterConfigOptions,
+    ) -> str | None:
+        """Determine the dominant ecosystem type across all components.
+
+        Uses config override if set, otherwise counts PURL types and
+        syft:package:type values to find the most common one.
+        """
+        if options.package_manager_override:
+            # Find the matching type key for the override
+            for purl_type, (pm, _) in PURL_TYPE_TO_GITLAB.items():
+                if pm == options.package_manager_override:
+                    return purl_type
+            for syft_type, (pm, _) in SYFT_TYPE_TO_GITLAB.items():
+                if pm == options.package_manager_override:
+                    return syft_type
+
+        from collections import Counter
+
+        types: Counter[str] = Counter()
+        for component in components:
+            # Try syft:package:type first
+            syft_type = _get_component_property(component, "syft:package:type")
+            if syft_type and syft_type in SYFT_TYPE_TO_GITLAB:
+                types[syft_type] += 1
+                continue
+            # Fallback to PURL type
+            purl_type = _extract_purl_type(component.get("purl"))
+            if purl_type and purl_type in PURL_TYPE_TO_GITLAB:
+                types[purl_type] += 1
+
+        return types.most_common(1)[0][0] if types else None
+
+    def _dominant_input_file(self, components: list[dict]) -> str | None:
+        """Find the most common input file path across components."""
+        from collections import Counter
+
+        files: Counter[str] = Counter()
+        for component in components:
+            raw_path = _get_component_property(component, "syft:location:0:path")
+            normalized = _normalize_input_file_path(raw_path)
+            if normalized:
+                files[normalized] += 1
+        return files.most_common(1)[0][0] if files else None
+
     def report(self, model: "AshAggregatedResults") -> str | None:
         """Enrich CycloneDX with GitLab properties and serialize."""
 
@@ -342,8 +407,54 @@ class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig])
             {"name": "gitlab:meta:schema_version", "value": GITLAB_SCHEMA_VERSION}
         )
 
-        # --- Inject per-component properties ---
+        # --- Inject metadata-level dependency_scanning source properties ---
+        # GitLab's CycloneDX parser resolves the report-level source from
+        # metadata.properties ONLY. Without these, the parser returns nil for
+        # the source and fires "Required GitLab CycloneDX properties are missing".
         options = self.config.options
+        dominant_type = self._resolve_dominant_type(components, options)
+        if dominant_type:
+            pm, lang = (None, None)
+            if dominant_type in PURL_TYPE_TO_GITLAB:
+                pm, lang = PURL_TYPE_TO_GITLAB[dominant_type]
+            elif dominant_type in SYFT_TYPE_TO_GITLAB:
+                pm, lang = SYFT_TYPE_TO_GITLAB[dominant_type]
+
+            input_file = (
+                options.input_file_path_override
+                or self._dominant_input_file(components)
+                or _DEFAULT_LOCKFILES.get(dominant_type)
+            )
+
+            metadata_props.append(
+                {
+                    "name": "gitlab:dependency_scanning:category",
+                    "value": options.category,
+                }
+            )
+            if options.package_manager_override or pm:
+                metadata_props.append(
+                    {
+                        "name": "gitlab:dependency_scanning:package_manager:name",
+                        "value": options.package_manager_override or pm,
+                    }
+                )
+            if options.language_override or lang:
+                metadata_props.append(
+                    {
+                        "name": "gitlab:dependency_scanning:language:name",
+                        "value": options.language_override or lang,
+                    }
+                )
+            if input_file:
+                metadata_props.append(
+                    {
+                        "name": "gitlab:dependency_scanning:input_file:path",
+                        "value": input_file,
+                    }
+                )
+
+        # --- Inject per-component properties ---
         enriched_count = 0
 
         for component in components:

--- a/automated_security_helper/utils/get_scan_set.py
+++ b/automated_security_helper/utils/get_scan_set.py
@@ -88,9 +88,14 @@ def _collect_ignorefiles_and_all_files(
     if root_gitignore.is_file():
         try:
             root_ignore_parser.parse_rule_file(root_gitignore, base_dir=root_path)
-        except Exception:
-            # If parsing fails, proceed without pruning
-            pass
+        except (OSError, ValueError, TypeError, IndexError, re.error):
+            # If the root .gitignore can't be parsed (malformed patterns,
+            # encoding issues, etc.), proceed without directory pruning.
+            # All files will still be filtered by the full ignore spec later.
+            debug_echo(
+                f"Could not parse root .gitignore for directory pruning: {root_gitignore}",
+                debug=debug,
+            )
 
     for root, dirs, files in os.walk(path):
         # Prune directories that are ignored by the root .gitignore.
@@ -105,10 +110,10 @@ def _collect_ignorefiles_and_all_files(
             try:
                 if root_ignore_parser.match(dir_path / "placeholder"):
                     dirs_to_remove.append(d)
-                    debug_echo(
-                        f"Skipping ignored directory: {dir_path}", debug=debug
-                    )
-            except Exception:
+                    debug_echo(f"Skipping ignored directory: {dir_path}", debug=debug)
+            except (ValueError, TypeError, IndexError, re.error):
+                # If matching fails for a specific directory (e.g. due to a
+                # malformed pattern), skip pruning for that directory only.
                 pass
         for d in dirs_to_remove:
             dirs.remove(d)
@@ -187,12 +192,16 @@ def get_ash_ignorespec(
             # or:     "######### START CONTENTS: ${SOURCE_DIR}/.gitignore #########"
             # or:     "######### START CONTENTS: ASH_INCLUSIONS #########"
             try:
-                content_path = stripped.split("START CONTENTS:")[1].strip().rstrip("#").strip()
+                content_path = (
+                    stripped.split("START CONTENTS:")[1].strip().rstrip("#").strip()
+                )
                 if content_path == "ASH_INCLUSIONS":
                     current_base_path = "/"
                 elif "${SOURCE_DIR}" in content_path:
                     # Extract the directory containing the .gitignore/.ignore file
-                    relative_path = content_path.replace("${SOURCE_DIR}", "").lstrip("/")
+                    relative_path = content_path.replace("${SOURCE_DIR}", "").lstrip(
+                        "/"
+                    )
                     # Get the parent directory of the ignore file
                     parent_dir = str(Path(relative_path).parent)
                     if parent_dir == ".":
@@ -238,7 +247,9 @@ def get_files_not_matching_spec(
     return included
 
 
-def get_changed_files(base_ref: str = "origin/main", cwd: Optional[Path] = None) -> Optional[List[Path]]:
+def get_changed_files(
+    base_ref: str = "origin/main", cwd: Optional[Path] = None
+) -> Optional[List[Path]]:
     """Return files changed between *base_ref* and HEAD using ``git diff``.
 
     Falls back to ``None`` (meaning "scan everything") when:
@@ -255,9 +266,7 @@ def get_changed_files(base_ref: str = "origin/main", cwd: Optional[Path] = None)
         or ``None`` if the diff could not be computed.
     """
     if not re.match(r"^[a-zA-Z0-9._/~^@{}\-]+$", base_ref):
-        ASH_LOGGER.warning(
-            f"Invalid base_ref '{base_ref}'; falling back to full scan"
-        )
+        ASH_LOGGER.warning(f"Invalid base_ref '{base_ref}'; falling back to full scan")
         return None
 
     try:
@@ -269,9 +278,7 @@ def get_changed_files(base_ref: str = "origin/main", cwd: Optional[Path] = None)
             cwd=cwd,
         )
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        ASH_LOGGER.warning(
-            "git not available or timed out; falling back to full scan"
-        )
+        ASH_LOGGER.warning("git not available or timed out; falling back to full scan")
         return None
 
     if result.returncode != 0:
@@ -382,14 +389,19 @@ def scan_set(
 
     if not ashignore_content:
         ashignore_content = get_ash_ignorespec_lines(
-            source, ignorefile, debug=debug,
+            source,
+            ignorefile,
+            debug=debug,
             _discovered_ignore_files=discovered_ignores,
         )
 
     if not ashscanset_list:
         spec = get_ash_ignorespec(ashignore_content, debug=debug)
         ashscanset_list = get_files_not_matching_spec(
-            source, spec, debug=debug, _all_files=all_files,
+            source,
+            spec,
+            debug=debug,
+            _all_files=all_files,
         )
 
     if output:

--- a/automated_security_helper/utils/get_scan_set.py
+++ b/automated_security_helper/utils/get_scan_set.py
@@ -66,6 +66,11 @@ def _collect_ignorefiles_and_all_files(
 ) -> tuple[List[str], List[str]]:
     """Walk the directory tree once to collect ignore files and all file paths.
 
+    Respects .gitignore hierarchy: if a directory is ignored by a parent
+    .gitignore, its contents (including nested .gitignore files) are skipped.
+    This prevents rules like ``*`` inside ``.venv/.gitignore`` from being
+    applied globally and accidentally ignoring all project files.
+
     Returns a tuple of (ignore_file_paths, all_file_paths).
     """
     if extra_ignorefiles is None:
@@ -75,7 +80,39 @@ def _collect_ignorefiles_and_all_files(
     ignore_files: List[str] = []
     all_files: List[str] = []
 
-    for root, _dirs, files in os.walk(path):
+    # Build an initial ignore spec from the root .gitignore (if it exists)
+    # so we can skip walking into ignored directories.
+    root_ignore_parser = IgnoreParser()
+    root_path = Path(path)
+    root_gitignore = root_path / ".gitignore"
+    if root_gitignore.is_file():
+        try:
+            root_ignore_parser.parse_rule_file(root_gitignore, base_dir=root_path)
+        except Exception:
+            # If parsing fails, proceed without pruning
+            pass
+
+    for root, dirs, files in os.walk(path):
+        # Prune directories that are ignored by the root .gitignore.
+        # This prevents descending into .venv/, node_modules/, etc.
+        # and picking up their internal .gitignore files.
+        dirs_to_remove = []
+        for d in dirs:
+            dir_path = Path(root) / d
+            # igittigitt.match expects a Path; directories need trailing separator
+            # to match directory-specific patterns. We check both the dir path
+            # and a fake file inside it.
+            try:
+                if root_ignore_parser.match(dir_path / "placeholder"):
+                    dirs_to_remove.append(d)
+                    debug_echo(
+                        f"Skipping ignored directory: {dir_path}", debug=debug
+                    )
+            except Exception:
+                pass
+        for d in dirs_to_remove:
+            dirs.remove(d)
+
         for f in files:
             full_path = os.path.join(root, f)
             if f in _ignore_names:
@@ -132,10 +169,46 @@ def get_ash_ignorespec(
 ) -> IgnoreParser:
     debug_echo("Generating spec from collected ignorespec lines", debug=debug)
     parser = IgnoreParser()
+
+    # Track the current base directory from section markers.
+    # Lines like "######### START CONTENTS: ${SOURCE_DIR}/.ruff_cache/.gitignore #########"
+    # indicate that subsequent rules should be scoped to that directory.
+    current_base_path = "/"
+
     for line in lines:
         stripped = line.strip()
-        if stripped and not stripped.startswith("#"):
-            parser.add_rule(stripped, base_path="/")
+        if not stripped:
+            continue
+
+        # Detect section markers to determine the base path for rules
+        if stripped.startswith("#########") and "START CONTENTS:" in stripped:
+            # Extract the path from the marker
+            # Format: "######### START CONTENTS: ${SOURCE_DIR}/subdir/.gitignore #########"
+            # or:     "######### START CONTENTS: ${SOURCE_DIR}/.gitignore #########"
+            # or:     "######### START CONTENTS: ASH_INCLUSIONS #########"
+            try:
+                content_path = stripped.split("START CONTENTS:")[1].strip().rstrip("#").strip()
+                if content_path == "ASH_INCLUSIONS":
+                    current_base_path = "/"
+                elif "${SOURCE_DIR}" in content_path:
+                    # Extract the directory containing the .gitignore/.ignore file
+                    relative_path = content_path.replace("${SOURCE_DIR}", "").lstrip("/")
+                    # Get the parent directory of the ignore file
+                    parent_dir = str(Path(relative_path).parent)
+                    if parent_dir == ".":
+                        current_base_path = "/"
+                    else:
+                        current_base_path = "/" + parent_dir
+                else:
+                    current_base_path = "/"
+            except (IndexError, ValueError):
+                current_base_path = "/"
+            continue
+
+        if stripped.startswith("#"):
+            continue
+
+        parser.add_rule(stripped, base_path=current_base_path)
     return parser
 
 

--- a/tests/unit/config/test_ignore_path_validation.py
+++ b/tests/unit/config/test_ignore_path_validation.py
@@ -10,7 +10,6 @@ Covers two bugs:
 
 import pytest
 import yaml
-from pathlib import Path
 
 from automated_security_helper.config.config_linter import (
     ConfigLinter,
@@ -146,7 +145,9 @@ def config_with_suppression_dir_path(project_with_dirs):
 class TestIgnorePathLinting:
     """Tests for ignore_path validation in the config linter."""
 
-    def test_warns_on_directory_without_glob(self, config_with_dir_ignore_path, project_with_dirs):
+    def test_warns_on_directory_without_glob(
+        self, config_with_dir_ignore_path, project_with_dirs
+    ):
         """A path pointing to an existing directory without ** should produce a warning."""
         result = ConfigLinter.lint(config_with_dir_ignore_path)
 
@@ -158,7 +159,9 @@ class TestIgnorePathLinting:
         assert "tests/test_data" in ignore_path_issues[0].message
         assert "/**" in ignore_path_issues[0].message
 
-    def test_warns_on_directory_with_trailing_slash(self, config_with_trailing_slash_ignore_path):
+    def test_warns_on_directory_with_trailing_slash(
+        self, config_with_trailing_slash_ignore_path
+    ):
         """A path with trailing slash pointing to an existing directory should also warn."""
         result = ConfigLinter.lint(config_with_trailing_slash_ignore_path)
 
@@ -178,7 +181,9 @@ class TestIgnorePathLinting:
         ]
         assert len(ignore_path_issues) == 0
 
-    def test_no_warning_for_nonexistent_directory(self, config_with_nonexistent_dir_path):
+    def test_no_warning_for_nonexistent_directory(
+        self, config_with_nonexistent_dir_path
+    ):
         """Paths that don't exist as directories should not produce warnings.
 
         This handles the case of virtual environments that haven't been initialized,
@@ -191,7 +196,9 @@ class TestIgnorePathLinting:
         ]
         assert len(ignore_path_issues) == 0
 
-    def test_warns_on_suppression_directory_path(self, config_with_suppression_dir_path):
+    def test_warns_on_suppression_directory_path(
+        self, config_with_suppression_dir_path
+    ):
         """Suppression paths pointing to existing directories without ** should also warn."""
         result = ConfigLinter.lint(config_with_suppression_dir_path)
 
@@ -227,14 +234,20 @@ class TestIgnorePathLinting:
         # Without source_dir, 'lib' won't resolve (config_dir has no 'lib')
         result_no_source = ConfigLinter.lint(config_path)
         issues_no_source = [
-            i for i in result_no_source.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+            i
+            for i in result_no_source.issues
+            if i.category == LintCategory.IGNORE_PATH_ISSUE
         ]
-        assert len(issues_no_source) == 0  # No warning because dir doesn't exist relative to config
+        assert (
+            len(issues_no_source) == 0
+        )  # No warning because dir doesn't exist relative to config
 
         # With source_dir, 'lib' resolves to an existing directory
         result_with_source = ConfigLinter.lint(config_path, source_dir=source_dir)
         issues_with_source = [
-            i for i in result_with_source.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+            i
+            for i in result_with_source.issues
+            if i.category == LintCategory.IGNORE_PATH_ISSUE
         ]
         assert len(issues_with_source) == 1
         assert "lib" in issues_with_source[0].message
@@ -274,9 +287,13 @@ class TestIgnorePathLinting:
 class TestIgnorePathValidation:
     """Tests for ignore_path validation in the config validator (ash config validate)."""
 
-    def test_validate_warns_on_directory_without_glob(self, config_with_dir_ignore_path):
+    def test_validate_warns_on_directory_without_glob(
+        self, config_with_dir_ignore_path
+    ):
         """ash config validate should flag directory paths without **."""
-        is_valid, errors = ConfigValidator.validate_config_file(config_with_dir_ignore_path)
+        is_valid, errors = ConfigValidator.validate_config_file(
+            config_with_dir_ignore_path
+        )
 
         # Should not be valid because of the path warning
         assert not is_valid
@@ -284,22 +301,32 @@ class TestIgnorePathValidation:
 
     def test_validate_passes_with_valid_paths(self, config_with_valid_ignore_paths):
         """ash config validate should pass with properly formed paths."""
-        is_valid, errors = ConfigValidator.validate_config_file(config_with_valid_ignore_paths)
+        is_valid, errors = ConfigValidator.validate_config_file(
+            config_with_valid_ignore_paths
+        )
 
         # Should be valid (no path-related errors)
         path_errors = [e for e in errors if "directory" in e.lower() and "/**" in e]
         assert len(path_errors) == 0
 
-    def test_validate_no_warning_for_nonexistent_path(self, config_with_nonexistent_dir_path):
+    def test_validate_no_warning_for_nonexistent_path(
+        self, config_with_nonexistent_dir_path
+    ):
         """ash config validate should not warn about paths that don't exist as directories."""
-        is_valid, errors = ConfigValidator.validate_config_file(config_with_nonexistent_dir_path)
+        is_valid, errors = ConfigValidator.validate_config_file(
+            config_with_nonexistent_dir_path
+        )
 
         path_errors = [e for e in errors if "directory" in e.lower() and "/**" in e]
         assert len(path_errors) == 0
 
-    def test_validate_warns_on_suppression_directory_path(self, config_with_suppression_dir_path):
+    def test_validate_warns_on_suppression_directory_path(
+        self, config_with_suppression_dir_path
+    ):
         """ash config validate should also flag suppression paths pointing to directories."""
-        is_valid, errors = ConfigValidator.validate_config_file(config_with_suppression_dir_path)
+        is_valid, errors = ConfigValidator.validate_config_file(
+            config_with_suppression_dir_path
+        )
 
         assert not is_valid
         assert any("docs" in e and "/**" in e for e in errors)

--- a/tests/unit/config/test_ignore_path_validation.py
+++ b/tests/unit/config/test_ignore_path_validation.py
@@ -1,0 +1,448 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ignore_path and suppression path validation in config linter and validator.
+
+Covers two bugs:
+1. Invalid ignore_paths pass validation silently (no error from `ash config validate`)
+2. Folder paths without `**` are silently ignored (should warn to add `/**`)
+"""
+
+import pytest
+import yaml
+from pathlib import Path
+
+from automated_security_helper.config.config_linter import (
+    ConfigLinter,
+    LintCategory,
+    LintSeverity,
+)
+from automated_security_helper.config.config_validator import ConfigValidator
+
+
+@pytest.fixture
+def project_with_dirs(tmp_path):
+    """Create a project structure with directories for testing path validation."""
+    # Create project structure
+    (tmp_path / "src").mkdir()
+    (tmp_path / "src" / "app.py").write_text("print('hello')")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_data").mkdir()
+    (tmp_path / "tests" / "test_data" / "sample.json").write_text("{}")
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("# Guide")
+    (tmp_path / ".ash").mkdir()
+    return tmp_path
+
+
+@pytest.fixture
+def config_with_dir_ignore_path(project_with_dirs):
+    """Config with ignore_path pointing to a directory without **."""
+    config_path = project_with_dirs / ".ash" / ".ash.yaml"
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "ignore_paths": [
+                {
+                    "path": "tests/test_data",
+                    "reason": "Test data only",
+                },
+            ],
+        },
+    }
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+@pytest.fixture
+def config_with_trailing_slash_ignore_path(project_with_dirs):
+    """Config with ignore_path pointing to a directory with trailing slash but no **."""
+    config_path = project_with_dirs / ".ash" / ".ash.yaml"
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "ignore_paths": [
+                {
+                    "path": "tests/test_data/",
+                    "reason": "Test data only",
+                },
+            ],
+        },
+    }
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+@pytest.fixture
+def config_with_valid_ignore_paths(project_with_dirs):
+    """Config with properly formed ignore_paths using **."""
+    config_path = project_with_dirs / ".ash" / ".ash.yaml"
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "ignore_paths": [
+                {
+                    "path": "tests/test_data/**",
+                    "reason": "Test data only",
+                },
+                {
+                    "path": "**/.venv/**",
+                    "reason": "Virtual environment",
+                },
+                {
+                    "path": "src/*.py",
+                    "reason": "Source files with wildcard",
+                },
+            ],
+        },
+    }
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+@pytest.fixture
+def config_with_nonexistent_dir_path(project_with_dirs):
+    """Config with ignore_path pointing to a non-existent directory (e.g., uninitialized venv)."""
+    config_path = project_with_dirs / ".ash" / ".ash.yaml"
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "ignore_paths": [
+                {
+                    "path": ".venv",
+                    "reason": "Virtual environment (not initialized)",
+                },
+                {
+                    "path": "node_modules",
+                    "reason": "Node modules (not installed)",
+                },
+            ],
+        },
+    }
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+@pytest.fixture
+def config_with_suppression_dir_path(project_with_dirs):
+    """Config with suppression path pointing to a directory without **."""
+    config_path = project_with_dirs / ".ash" / ".ash.yaml"
+    config_data = {
+        "project_name": "test-project",
+        "global_settings": {
+            "suppressions": [
+                {
+                    "path": "docs",
+                    "rule_id": "SECRET-*",
+                    "reason": "Documentation examples",
+                },
+            ],
+        },
+    }
+    config_path.write_text(yaml.dump(config_data))
+    return config_path
+
+
+class TestIgnorePathLinting:
+    """Tests for ignore_path validation in the config linter."""
+
+    def test_warns_on_directory_without_glob(self, config_with_dir_ignore_path, project_with_dirs):
+        """A path pointing to an existing directory without ** should produce a warning."""
+        result = ConfigLinter.lint(config_with_dir_ignore_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 1
+        assert ignore_path_issues[0].severity == LintSeverity.WARNING
+        assert "tests/test_data" in ignore_path_issues[0].message
+        assert "/**" in ignore_path_issues[0].message
+
+    def test_warns_on_directory_with_trailing_slash(self, config_with_trailing_slash_ignore_path):
+        """A path with trailing slash pointing to an existing directory should also warn."""
+        result = ConfigLinter.lint(config_with_trailing_slash_ignore_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 1
+        assert ignore_path_issues[0].severity == LintSeverity.WARNING
+        assert "tests/test_data" in ignore_path_issues[0].message
+
+    def test_no_warning_for_valid_glob_paths(self, config_with_valid_ignore_paths):
+        """Paths with ** or file wildcards should not produce warnings."""
+        result = ConfigLinter.lint(config_with_valid_ignore_paths)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_no_warning_for_nonexistent_directory(self, config_with_nonexistent_dir_path):
+        """Paths that don't exist as directories should not produce warnings.
+
+        This handles the case of virtual environments that haven't been initialized,
+        or node_modules that haven't been installed.
+        """
+        result = ConfigLinter.lint(config_with_nonexistent_dir_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_warns_on_suppression_directory_path(self, config_with_suppression_dir_path):
+        """Suppression paths pointing to existing directories without ** should also warn."""
+        result = ConfigLinter.lint(config_with_suppression_dir_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 1
+        assert "docs" in ignore_path_issues[0].message
+        assert "/**" in ignore_path_issues[0].message
+
+    def test_respects_source_dir_parameter(self, tmp_path):
+        """The source_dir parameter should be used for resolving paths."""
+        # Create a separate source directory with a 'lib' folder
+        source_dir = tmp_path / "source"
+        source_dir.mkdir()
+        (source_dir / "lib").mkdir()
+        (source_dir / "lib" / "utils.py").write_text("pass")
+
+        # Config is in a different location
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        config_path = config_dir / "config.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "lib", "reason": "Library folder"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        # Without source_dir, 'lib' won't resolve (config_dir has no 'lib')
+        result_no_source = ConfigLinter.lint(config_path)
+        issues_no_source = [
+            i for i in result_no_source.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(issues_no_source) == 0  # No warning because dir doesn't exist relative to config
+
+        # With source_dir, 'lib' resolves to an existing directory
+        result_with_source = ConfigLinter.lint(config_path, source_dir=source_dir)
+        issues_with_source = [
+            i for i in result_with_source.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(issues_with_source) == 1
+        assert "lib" in issues_with_source[0].message
+
+    def test_multiple_issues_reported(self, project_with_dirs):
+        """Multiple directory paths without ** should each produce a warning."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "tests/test_data", "reason": "Test data"},
+                    {"path": "docs", "reason": "Documentation"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 2
+
+    def test_path_prefix_in_issue(self, config_with_dir_ignore_path):
+        """The issue should include the correct config path prefix for identification."""
+        result = ConfigLinter.lint(config_with_dir_ignore_path)
+
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 1
+        assert "global_settings.ignore_paths[0].path" in ignore_path_issues[0].path
+
+
+class TestIgnorePathValidation:
+    """Tests for ignore_path validation in the config validator (ash config validate)."""
+
+    def test_validate_warns_on_directory_without_glob(self, config_with_dir_ignore_path):
+        """ash config validate should flag directory paths without **."""
+        is_valid, errors = ConfigValidator.validate_config_file(config_with_dir_ignore_path)
+
+        # Should not be valid because of the path warning
+        assert not is_valid
+        assert any("tests/test_data" in e and "/**" in e for e in errors)
+
+    def test_validate_passes_with_valid_paths(self, config_with_valid_ignore_paths):
+        """ash config validate should pass with properly formed paths."""
+        is_valid, errors = ConfigValidator.validate_config_file(config_with_valid_ignore_paths)
+
+        # Should be valid (no path-related errors)
+        path_errors = [e for e in errors if "directory" in e.lower() and "/**" in e]
+        assert len(path_errors) == 0
+
+    def test_validate_no_warning_for_nonexistent_path(self, config_with_nonexistent_dir_path):
+        """ash config validate should not warn about paths that don't exist as directories."""
+        is_valid, errors = ConfigValidator.validate_config_file(config_with_nonexistent_dir_path)
+
+        path_errors = [e for e in errors if "directory" in e.lower() and "/**" in e]
+        assert len(path_errors) == 0
+
+    def test_validate_warns_on_suppression_directory_path(self, config_with_suppression_dir_path):
+        """ash config validate should also flag suppression paths pointing to directories."""
+        is_valid, errors = ConfigValidator.validate_config_file(config_with_suppression_dir_path)
+
+        assert not is_valid
+        assert any("docs" in e and "/**" in e for e in errors)
+
+    def test_validate_with_source_dir(self, tmp_path):
+        """ash config validate should accept source_dir for path resolution."""
+        # Create source with a directory
+        source_dir = tmp_path / "project"
+        source_dir.mkdir()
+        (source_dir / "vendor").mkdir()
+        (source_dir / ".ash").mkdir()
+
+        config_path = source_dir / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "vendor", "reason": "Third-party code"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        is_valid, errors = ConfigValidator.validate_config_file(
+            config_path, source_dir=source_dir
+        )
+
+        assert not is_valid
+        path_errors = [e for e in errors if "vendor" in e and "/**" in e]
+        assert len(path_errors) == 1
+
+
+class TestEdgeCases:
+    """Edge cases for path validation."""
+
+    def test_path_with_glob_in_middle(self, project_with_dirs):
+        """Paths like 'src/*/test.py' should not trigger the warning."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "src/*/test.py", "reason": "Test files"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_path_with_question_mark_glob(self, project_with_dirs):
+        """Paths with ? glob should not trigger the warning."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "src/app?.py", "reason": "App files"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_exact_file_path_no_warning(self, project_with_dirs):
+        """An exact file path should not trigger the warning even if it exists."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "src/app.py", "reason": "Specific file"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_empty_ignore_paths_no_crash(self, project_with_dirs):
+        """Empty ignore_paths list should not cause issues."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_no_global_settings_no_crash(self, project_with_dirs):
+        """Config without global_settings should not crash."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        assert len(ignore_path_issues) == 0
+
+    def test_mixed_valid_and_invalid_paths(self, project_with_dirs):
+        """Only directory paths without ** should be flagged, valid ones should pass."""
+        config_path = project_with_dirs / ".ash" / ".ash.yaml"
+        config_data = {
+            "project_name": "test-project",
+            "global_settings": {
+                "ignore_paths": [
+                    {"path": "tests/test_data/**", "reason": "Valid - has **"},
+                    {"path": "docs", "reason": "Invalid - directory without **"},
+                    {"path": "src/app.py", "reason": "Valid - specific file"},
+                    {"path": "nonexistent_dir", "reason": "Valid - doesn't exist"},
+                ],
+            },
+        }
+        config_path.write_text(yaml.dump(config_data))
+
+        result = ConfigLinter.lint(config_path)
+        ignore_path_issues = [
+            i for i in result.issues if i.category == LintCategory.IGNORE_PATH_ISSUE
+        ]
+        # Only 'docs' should be flagged (exists as directory, no **)
+        assert len(ignore_path_issues) == 1
+        assert "docs" in ignore_path_issues[0].message

--- a/tests/unit/reporters/test_gitlab_cyclonedx_metadata_properties.py
+++ b/tests/unit/reporters/test_gitlab_cyclonedx_metadata_properties.py
@@ -1,0 +1,262 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for gitlab-cyclonedx reporter metadata-level properties.
+
+Validates that the reporter produces output matching GitLab's requirements:
+- gitlab:meta:schema_version at metadata.properties
+- gitlab:dependency_scanning:{category,package_manager:name,language:name,input_file:path}
+  at metadata.properties (required for GitLab to resolve a report-level source)
+- Per-component enrichment still present
+
+Without metadata-level dependency_scanning properties, GitLab fires:
+"Required GitLab CycloneDX properties are missing"
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.plugin_modules.ash_builtin.reporters.gitlab_cyclonedx_reporter import (
+    GitLabCycloneDXReporter,
+    GitLabCycloneDXReporterConfig,
+    GitLabCycloneDXReporterConfigOptions,
+    GITLAB_SCHEMA_VERSION,
+)
+from automated_security_helper.config.ash_config import AshConfig  # noqa: F401
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.base.plugin_context import PluginContext
+
+AshAggregatedResults.model_rebuild()
+
+
+@pytest.fixture
+def model():
+    fixture_path = Path("tests/test_data/outputs/ash_aggregated_results.json")
+    with open(fixture_path) as f:
+        raw = json.load(f)
+    return AshAggregatedResults.model_validate(raw)
+
+
+@pytest.fixture
+def reporter(tmp_path):
+    ctx = PluginContext(source_dir=Path("."), output_dir=tmp_path)
+    return GitLabCycloneDXReporter(context=ctx, config=GitLabCycloneDXReporterConfig())
+
+
+@pytest.fixture
+def report_doc(reporter, model):
+    """Parse the reporter output into a dict for assertions."""
+    result = reporter.report(model)
+    assert result is not None
+    return json.loads(result)
+
+
+class TestMetadataLevelProperties:
+    """Validate that metadata.properties contains all required GitLab properties."""
+
+    def test_schema_version_present(self, report_doc):
+        """gitlab:meta:schema_version must be at metadata.properties."""
+        meta_props = report_doc["metadata"]["properties"]
+        schema_props = [
+            p for p in meta_props if p["name"] == "gitlab:meta:schema_version"
+        ]
+        assert len(schema_props) == 1
+        assert schema_props[0]["value"] == GITLAB_SCHEMA_VERSION
+
+    def test_dependency_scanning_category_present(self, report_doc):
+        """gitlab:dependency_scanning:category must be at metadata.properties."""
+        meta_props = report_doc["metadata"]["properties"]
+        cat_props = [
+            p for p in meta_props if p["name"] == "gitlab:dependency_scanning:category"
+        ]
+        assert len(cat_props) == 1
+        assert cat_props[0]["value"] == "production"
+
+    def test_dependency_scanning_package_manager_present(self, report_doc):
+        """gitlab:dependency_scanning:package_manager:name must be at metadata.properties."""
+        meta_props = report_doc["metadata"]["properties"]
+        pm_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:package_manager:name"
+        ]
+        assert len(pm_props) == 1
+        # The fixture is npm-dominant
+        assert pm_props[0]["value"] == "npm"
+
+    def test_dependency_scanning_language_present(self, report_doc):
+        """gitlab:dependency_scanning:language:name must be at metadata.properties."""
+        meta_props = report_doc["metadata"]["properties"]
+        lang_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:language:name"
+        ]
+        assert len(lang_props) == 1
+        assert lang_props[0]["value"] == "JavaScript"
+
+    def test_dependency_scanning_input_file_path_present(self, report_doc):
+        """gitlab:dependency_scanning:input_file:path must be at metadata.properties.
+
+        This is the critical property — without it, GitLab's parser returns nil
+        for the source and fires the 'Required properties are missing' error.
+        """
+        meta_props = report_doc["metadata"]["properties"]
+        path_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:input_file:path"
+        ]
+        assert len(path_props) == 1
+        # Should be a non-empty string (the dominant input file or fallback)
+        assert path_props[0]["value"]
+        assert len(path_props[0]["value"]) > 0
+
+    def test_all_required_properties_present_together(self, report_doc):
+        """All 5 required properties must be present for GitLab to accept the report."""
+        meta_props = report_doc["metadata"]["properties"]
+        prop_names = {p["name"] for p in meta_props}
+
+        required = {
+            "gitlab:meta:schema_version",
+            "gitlab:dependency_scanning:category",
+            "gitlab:dependency_scanning:package_manager:name",
+            "gitlab:dependency_scanning:language:name",
+            "gitlab:dependency_scanning:input_file:path",
+        }
+        missing = required - prop_names
+        assert not missing, f"Missing required metadata properties: {missing}"
+
+
+class TestMetadataWithConfigOverrides:
+    """Validate that config overrides are reflected in metadata properties."""
+
+    def test_package_manager_override_in_metadata(self, tmp_path, model):
+        """Config override for package_manager should appear in metadata."""
+        ctx = PluginContext(source_dir=Path("."), output_dir=tmp_path)
+        config = GitLabCycloneDXReporterConfig(
+            options=GitLabCycloneDXReporterConfigOptions(
+                package_manager_override="yarn",
+                language_override="TypeScript",
+            )
+        )
+        reporter = GitLabCycloneDXReporter(context=ctx, config=config)
+        result = reporter.report(model)
+        doc = json.loads(result)
+
+        meta_props = doc["metadata"]["properties"]
+        pm_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:package_manager:name"
+        ]
+        lang_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:language:name"
+        ]
+        assert pm_props[0]["value"] == "yarn"
+        assert lang_props[0]["value"] == "TypeScript"
+
+    def test_input_file_path_override_in_metadata(self, tmp_path, model):
+        """Config override for input_file_path should appear in metadata."""
+        ctx = PluginContext(source_dir=Path("."), output_dir=tmp_path)
+        config = GitLabCycloneDXReporterConfig(
+            options=GitLabCycloneDXReporterConfigOptions(
+                input_file_path_override="custom/package-lock.json",
+            )
+        )
+        reporter = GitLabCycloneDXReporter(context=ctx, config=config)
+        result = reporter.report(model)
+        doc = json.loads(result)
+
+        meta_props = doc["metadata"]["properties"]
+        path_props = [
+            p
+            for p in meta_props
+            if p["name"] == "gitlab:dependency_scanning:input_file:path"
+        ]
+        assert path_props[0]["value"] == "custom/package-lock.json"
+
+    def test_category_override_in_metadata(self, tmp_path, model):
+        """Config override for category should appear in metadata."""
+        ctx = PluginContext(source_dir=Path("."), output_dir=tmp_path)
+        config = GitLabCycloneDXReporterConfig(
+            options=GitLabCycloneDXReporterConfigOptions(
+                category="development",
+            )
+        )
+        reporter = GitLabCycloneDXReporter(context=ctx, config=config)
+        result = reporter.report(model)
+        doc = json.loads(result)
+
+        meta_props = doc["metadata"]["properties"]
+        cat_props = [
+            p for p in meta_props if p["name"] == "gitlab:dependency_scanning:category"
+        ]
+        assert cat_props[0]["value"] == "development"
+
+
+class TestPerComponentEnrichmentStillPresent:
+    """Verify per-component properties are still injected alongside metadata."""
+
+    def test_components_still_have_category(self, report_doc):
+        """Per-component category should still be present."""
+        for component in report_doc["components"][:5]:
+            cats = [
+                p
+                for p in component.get("properties", [])
+                if p["name"] == "gitlab:dependency_scanning:category"
+            ]
+            assert len(cats) >= 1, f"Component {component.get('name')} missing category"
+
+    def test_components_still_have_package_manager(self, report_doc):
+        """Per-component package_manager should still be present for components with PURLs."""
+        components_with_purl = [c for c in report_doc["components"] if c.get("purl")]
+        assert len(components_with_purl) > 0
+
+        for component in components_with_purl[:5]:
+            pms = [
+                p
+                for p in component.get("properties", [])
+                if p["name"] == "gitlab:dependency_scanning:package_manager:name"
+            ]
+            assert len(pms) >= 1, (
+                f"Component {component.get('name')} missing package_manager"
+            )
+
+
+class TestOutputFormat:
+    """Validate the overall output format is valid CycloneDX-like JSON."""
+
+    def test_output_is_valid_json(self, reporter, model):
+        """Output must be parseable JSON."""
+        result = reporter.report(model)
+        doc = json.loads(result)
+        assert isinstance(doc, dict)
+
+    def test_output_has_bom_format(self, report_doc):
+        """Output should retain the CycloneDX bomFormat field."""
+        assert report_doc.get("bomFormat") == "CycloneDX"
+
+    def test_output_has_spec_version(self, report_doc):
+        """Output should retain the CycloneDX specVersion field."""
+        assert report_doc.get("specVersion") in ("1.4", "1.5", "1.6")
+
+    def test_output_has_components(self, report_doc):
+        """Output should have a non-empty components array."""
+        assert len(report_doc.get("components", [])) > 0
+
+    def test_output_has_metadata(self, report_doc):
+        """Output should have metadata with properties."""
+        assert "metadata" in report_doc
+        assert "properties" in report_doc["metadata"]
+        assert len(report_doc["metadata"]["properties"]) >= 5  # at least the 5 required
+
+    def test_compact_json_output(self, reporter, model):
+        """Output should use compact JSON (no extra whitespace)."""
+        result = reporter.report(model)
+        # Compact JSON uses separators=(",", ":") — no spaces after , or :
+        assert ", " not in result[:200]  # Check first 200 chars for spaces after comma

--- a/tests/unit/test_scan_set_ignored_dirs.py
+++ b/tests/unit/test_scan_set_ignored_dirs.py
@@ -1,0 +1,187 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for scan_set behavior with nested .gitignore files in ignored directories.
+
+Covers the bug where .gitignore files inside ignored directories (e.g., .venv/)
+containing '*' would cause the entire project to have 0 scannable files.
+"""
+
+import pytest
+from pathlib import Path
+
+from automated_security_helper.utils.get_scan_set import (
+    _collect_ignorefiles_and_all_files,
+    scan_set,
+)
+
+
+@pytest.fixture
+def project_with_venv_gitignore(tmp_path):
+    """Create a project that reproduces the 0-files bug.
+
+    Structure:
+        project/
+        ├── .gitignore          (ignores .venv/, .ruff_cache/, etc.)
+        ├── app.py
+        ├── config.yaml
+        ├── templates/
+        │   └── deploy.yml
+        ├── .venv/
+        │   └── .gitignore      (contains just '*')
+        ├── .ruff_cache/
+        │   └── .gitignore      (contains just '*')
+        └── .pytest_cache/
+            └── .gitignore      (contains just '*')
+    """
+    project = tmp_path / "project"
+    project.mkdir()
+
+    # Root .gitignore - ignores .venv, .ruff_cache, .pytest_cache
+    (project / ".gitignore").write_text(
+        ".venv/\n"
+        "venv/\n"
+        ".ruff_cache/\n"
+        ".pytest_cache/\n"
+        "htmlcov/\n"
+        "__pycache__/\n"
+        "*.pyc\n"
+        ".ash/\n"
+    )
+
+    # Project files that should be found
+    (project / "app.py").write_text("print('hello')")
+    (project / "config.yaml").write_text("key: value")
+    templates = project / "templates"
+    templates.mkdir()
+    (templates / "deploy.yml").write_text("stages: [build]")
+
+    # .venv with a .gitignore that contains '*' (standard venv pattern)
+    venv = project / ".venv"
+    venv.mkdir()
+    (venv / ".gitignore").write_text("*\n")
+    (venv / "pyvenv.cfg").write_text("home = /usr/bin")
+    lib = venv / "lib"
+    lib.mkdir()
+    (lib / "site.py").write_text("pass")
+
+    # .ruff_cache with a .gitignore that contains '*'
+    ruff = project / ".ruff_cache"
+    ruff.mkdir()
+    (ruff / ".gitignore").write_text("# Automatically created by ruff.\n*\n")
+    (ruff / "cache.bin").write_text("binary")
+
+    # .pytest_cache with a .gitignore that contains '*'
+    pytest_cache = project / ".pytest_cache"
+    pytest_cache.mkdir()
+    (pytest_cache / ".gitignore").write_text("# Created by pytest automatically.\n*\n")
+    (pytest_cache / "v" / "cache").mkdir(parents=True)
+
+    return project
+
+
+class TestScanSetIgnoredDirectories:
+    """Tests that .gitignore files inside ignored directories don't pollute the global spec."""
+
+    def test_venv_gitignore_does_not_cause_zero_files(self, project_with_venv_gitignore):
+        """The '*' rule in .venv/.gitignore should NOT cause 0 files to be found."""
+        result = scan_set(source=str(project_with_venv_gitignore))
+
+        # Should find at least app.py, config.yaml, deploy.yml
+        assert len(result) >= 3, f"Expected at least 3 files, got {len(result)}: {result}"
+
+        # Verify specific files are included
+        filenames = [Path(f).name for f in result]
+        assert "app.py" in filenames
+        assert "config.yaml" in filenames
+        assert "deploy.yml" in filenames
+
+    def test_ignored_dir_gitignore_not_collected(self, project_with_venv_gitignore):
+        """_collect_ignorefiles_and_all_files should NOT collect .gitignore from ignored dirs."""
+        ignore_files, all_files = _collect_ignorefiles_and_all_files(
+            str(project_with_venv_gitignore)
+        )
+
+        # Should only find the root .gitignore, not the ones in .venv/, .ruff_cache/, etc.
+        ignore_basenames = [Path(f).parent.name for f in ignore_files]
+        assert "project" in ignore_basenames or any(
+            f.endswith("project/.gitignore") or f == str(project_with_venv_gitignore / ".gitignore")
+            for f in ignore_files
+        )
+
+        # Should NOT contain .venv/.gitignore
+        venv_ignores = [f for f in ignore_files if ".venv" in f]
+        assert len(venv_ignores) == 0, f"Found .venv/.gitignore that should be skipped: {venv_ignores}"
+
+        # Should NOT contain .ruff_cache/.gitignore
+        ruff_ignores = [f for f in ignore_files if ".ruff_cache" in f]
+        assert len(ruff_ignores) == 0, f"Found .ruff_cache/.gitignore that should be skipped: {ruff_ignores}"
+
+    def test_ignored_dir_files_not_in_all_files(self, project_with_venv_gitignore):
+        """Files inside ignored directories should not be collected at all."""
+        _ignore_files, all_files = _collect_ignorefiles_and_all_files(
+            str(project_with_venv_gitignore)
+        )
+
+        # Should NOT contain files from .venv/
+        venv_files = [f for f in all_files if ".venv" in f]
+        assert len(venv_files) == 0, f"Found .venv files that should be skipped: {venv_files}"
+
+    def test_scan_set_excludes_venv_files(self, project_with_venv_gitignore):
+        """scan_set should not include files from .venv/ in the result."""
+        result = scan_set(source=str(project_with_venv_gitignore))
+
+        venv_files = [f for f in result if ".venv" in f]
+        assert len(venv_files) == 0, f"Found .venv files in scan set: {venv_files}"
+
+    def test_scan_set_excludes_ruff_cache_files(self, project_with_venv_gitignore):
+        """scan_set should not include files from .ruff_cache/ in the result."""
+        result = scan_set(source=str(project_with_venv_gitignore))
+
+        ruff_files = [f for f in result if ".ruff_cache" in f]
+        assert len(ruff_files) == 0, f"Found .ruff_cache files in scan set: {ruff_files}"
+
+    def test_non_ignored_subdirs_still_walked(self, project_with_venv_gitignore):
+        """Directories NOT in .gitignore should still be walked normally."""
+        result = scan_set(source=str(project_with_venv_gitignore))
+
+        # templates/ is not ignored, so deploy.yml should be found
+        template_files = [f for f in result if "templates" in f]
+        assert len(template_files) >= 1
+
+    def test_no_root_gitignore_still_works(self, tmp_path):
+        """If there's no root .gitignore, all directories should be walked."""
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "app.py").write_text("pass")
+        sub = project / "subdir"
+        sub.mkdir()
+        (sub / "lib.py").write_text("pass")
+
+        result = scan_set(source=str(project))
+
+        assert len(result) == 2
+
+
+class TestExcludeKeyValidation:
+    """Tests that the --exclude=value pattern is accepted by the flag key validator."""
+
+    def test_exclude_equals_pattern_is_valid(self):
+        """The --exclude='...' pattern should pass the key validation regex."""
+        import re
+        pattern = re.compile(r"^-{1,2}[A-Za-z][A-Za-z0-9_\-]*(=.*)?$")
+
+        # These should all be valid
+        assert pattern.match("--exclude=\".venv/**\"")
+        assert pattern.match("--skip-path=\".venv/\"")
+        assert pattern.match("--config=p/ci")
+        assert pattern.match("--format")
+        assert pattern.match("-f")
+        assert pattern.match("--no-rewrite-rule-ids")
+
+        # These should still be invalid (injection attempts)
+        assert not pattern.match("; rm -rf /")
+        assert not pattern.match("| cat /etc/passwd")
+        assert not pattern.match("--")
+        assert not pattern.match("-")
+        assert not pattern.match("")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

fix(config): Validate ignore_paths/suppression paths for directory-without-glob patterns
fix(scan): Resolve scan set returning 0 files and --exclude arg being silently dropped
fix(cli): Default output-dir relative to source-dir instead of CWD
fix(mcp): Return flat findings list when actionable_only is requested

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
