### PR TITLE
fix(gitlab-cyclonedx): emit minimal empty SBOM when no components found

### DIFF
--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
@@ -377,13 +377,48 @@ class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig])
                 files[normalized] += 1
         return files.most_common(1)[0][0] if files else None
 
-    def report(self, model: "AshAggregatedResults") -> str | None:
-        """Enrich CycloneDX with GitLab properties and serialize."""
+    def _build_minimal_empty_sbom(self) -> dict:
+        """Build a minimal valid GitLab-flavored CycloneDX document.
 
-        # Guard: nothing to enrich if there's no CycloneDX data
+        Used when no components are detected (e.g., infrastructure-only repos).
+        Always emitting an artifact ensures GitLab pipelines that require the
+        ``gl-dependency-scanning-report.cdx.json`` artifact don't fail when a
+        repo legitimately has no software dependencies.
+
+        The minimal document includes the CycloneDX envelope and the GitLab
+        schema version metadata property required by GitLab's parser.
+        """
+        return {
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.4",
+            "version": 1,
+            "metadata": {
+                "properties": [
+                    {
+                        "name": "gitlab:meta:schema_version",
+                        "value": GITLAB_SCHEMA_VERSION,
+                    }
+                ],
+            },
+            "components": [],
+        }
+
+    def report(self, model: "AshAggregatedResults") -> str | None:
+        """Enrich CycloneDX with GitLab properties and serialize.
+
+        When no CycloneDX data or components are present, emit a minimal valid
+        GitLab-compatible CycloneDX document instead of skipping. This ensures
+        downstream GitLab pipelines that require the artifact to exist (e.g.,
+        for policy validation) don't fail on repos with no dependencies.
+        """
+
+        # Guard: emit a minimal empty SBOM when no CycloneDX data is present
         if not model.cyclonedx:
-            ASH_LOGGER.debug("gitlab-cyclonedx: No CycloneDX model present, skipping.")
-            return None
+            ASH_LOGGER.debug(
+                "gitlab-cyclonedx: No CycloneDX model present, "
+                "emitting minimal empty SBOM."
+            )
+            return json.dumps(self._build_minimal_empty_sbom(), separators=(",", ":"))
 
         # Serialize to dict for manipulation
         doc = model.cyclonedx.model_dump(
@@ -396,9 +431,10 @@ class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig])
         components = doc.get("components")
         if not components:
             ASH_LOGGER.debug(
-                "gitlab-cyclonedx: CycloneDX model has no components, skipping."
+                "gitlab-cyclonedx: CycloneDX model has no components, "
+                "emitting minimal empty SBOM."
             )
-            return None
+            return json.dumps(self._build_minimal_empty_sbom(), separators=(",", ":"))
 
         # --- Inject metadata-level schema version property ---
         metadata = doc.setdefault("metadata", {})

--- a/tests/unit/reporters/test_gitlab_cyclonedx_reporter.py
+++ b/tests/unit/reporters/test_gitlab_cyclonedx_reporter.py
@@ -87,10 +87,50 @@ def test_components_have_input_file_path(reporter, model):
     assert paths[0]["value"] == "yarn.lock"
 
 
-def test_returns_none_when_no_components(reporter):
+def test_emits_minimal_empty_sbom_when_no_components(reporter):
+    """When the model has no CycloneDX data, emit a minimal valid SBOM
+    rather than skipping. This ensures GitLab pipelines that require the
+    artifact to exist don't fail on repos with no dependencies.
+    """
     model = AshAggregatedResults()
+    # Force-clear cyclonedx to simulate a scan that produced no SBOM
+    model.cyclonedx = None
     result = reporter.report(model)
-    assert result is None
+    assert result is not None
+    doc = json.loads(result)
+    assert doc["bomFormat"] == "CycloneDX"
+    assert doc["specVersion"] == "1.4"
+    assert doc["version"] == 1
+    assert doc["components"] == []
+    schema_props = [
+        p
+        for p in doc["metadata"]["properties"]
+        if p["name"] == "gitlab:meta:schema_version"
+    ]
+    assert len(schema_props) == 1
+    assert schema_props[0]["value"] == "1"
+
+
+def test_emits_minimal_empty_sbom_when_components_list_empty(reporter):
+    """When CycloneDX is present but contains no components, still emit
+    a minimal valid SBOM. This is the common case for infrastructure-only
+    or no-code repos where Syft finds no packages.
+    """
+    model = AshAggregatedResults()  # default CycloneDXReport() has no components
+    result = reporter.report(model)
+    assert result is not None
+    doc = json.loads(result)
+    assert doc["bomFormat"] == "CycloneDX"
+    assert doc["specVersion"] == "1.4"
+    assert doc["version"] == 1
+    assert doc["components"] == []
+    schema_props = [
+        p
+        for p in doc["metadata"]["properties"]
+        if p["name"] == "gitlab:meta:schema_version"
+    ]
+    assert len(schema_props) == 1
+    assert schema_props[0]["value"] == "1"
 
 
 def test_extract_purl_type():


### PR DESCRIPTION
## Summary

Fixes #342

When ASH is run against a repository with no recognizable packages (e.g., infrastructure-only repos), Syft produces no components. The GitLab CycloneDX reporter previously returned `None` and wrote no file, which broke GitLab pipelines that require `gl-dependency-scanning-report.cdx.json` to exist for policy validation.

## Changes

- **`gitlab_cyclonedx_reporter.py`**: Added `_build_minimal_empty_sbom()` helper that returns a minimal valid CycloneDX document containing the envelope (`bomFormat`, `specVersion`, `version`), an empty `components` list, and the required `gitlab:meta:schema_version` metadata property. Both early-return paths (no `model.cyclonedx` and empty `components`) now emit this document instead of returning `None`. This matches the behavior of the generic CycloneDX reporter, which already emits a minimal valid document in this case.
- **`test_gitlab_cyclonedx_reporter.py`**: Replaced `test_returns_none_when_no_components` with two new tests covering both empty paths (no CycloneDX model and empty components list), asserting the minimal SBOM structure and required schema version property.

## Testing

- All 120 reporter unit tests pass
- Pre-commit hooks (ruff, ruff-format, ASH self-scan) pass

## Impact

GitLab pipelines that require the `gl-dependency-scanning-report.cdx.json` artifact for policy validation will no longer fail on repos with no software dependencies (e.g., infrastructure-only repos).