### PR TITLE
fix(scanners): do not embed literal quotes in checkov/bandit exclusion args

### DIFF
--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py
@@ -325,7 +325,7 @@ class BanditScanner(ScannerPluginBase[BanditScannerConfig]):
             bandit_excludes.append(str(Path("**").joinpath(item.path, "**")))
 
         self.args.extra_args.append(
-            ToolExtraArg(key=f'--exclude="{",".join(bandit_excludes)}"', value=None)
+            ToolExtraArg(key=f"--exclude={','.join(bandit_excludes)}", value=None)
         )
 
         return super()._process_config_options()

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
@@ -280,7 +280,7 @@ class CheckovScanner(ScannerPluginBase[CheckovScannerConfig]):
 
         for item in KNOWN_IGNORE_PATHS:
             self.args.extra_args.append(
-                ToolExtraArg(key=f'--skip-path="{item}"', value=None)
+                ToolExtraArg(key=f"--skip-path={item}", value=None)
             )
 
         for item in self.config.options.skip_path:
@@ -289,7 +289,7 @@ class CheckovScanner(ScannerPluginBase[CheckovScannerConfig]):
             )
             self.args.extra_args.append(
                 ToolExtraArg(
-                    key=f'--skip-path="{item.path}"',
+                    key=f"--skip-path={item.path}",
                     value=None,
                 )
             )

--- a/tests/integration/scanners/test_bandit_scanner.py
+++ b/tests/integration/scanners/test_bandit_scanner.py
@@ -104,7 +104,9 @@ def test_process_config_options_exclusions(test_plugin_context):
 
     # Check that exclusion arguments were added
     exclusion_args = [arg.key for arg in scanner.args.extra_args]
-    # The exclusion args are now in the format '--exclude="tests/*"'
+    # The exclusion args are in the format '--exclude=tests/*' (no embedded
+    # quotes — quoting values here would pass '"' as part of the argv since
+    # ASH invokes scanners via subprocess without a shell).
     assert any("--exclude=" in arg and "tests/*" in arg for arg in exclusion_args)
 
 

--- a/tests/unit/plugin_modules/ash_builtin/test_bandit_scanner_exclude_quoting.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_bandit_scanner_exclude_quoting.py
@@ -1,0 +1,100 @@
+"""Regression tests for the shape of the bandit ``--exclude=`` argv token."""
+
+from pathlib import Path
+
+from automated_security_helper.core.constants import KNOWN_IGNORE_PATHS
+from automated_security_helper.models.core import IgnorePathWithReason
+from automated_security_helper.plugin_modules.ash_builtin.scanners.bandit_scanner import (
+    BanditScanner,
+    BanditScannerConfig,
+    BanditScannerConfigOptions,
+)
+
+
+def test_process_config_options_exclude_argument_contains_no_literal_quotes(
+    test_plugin_context,
+):
+    """No emitted ``--exclude=`` argv token contains a literal ``"`` character.
+
+    Quote characters embedded in the value are passed verbatim into the
+    child process argv (``subprocess`` runs with ``shell=False``) and
+    become part of the exclusion pattern bandit sees.
+    """
+    scanner = BanditScanner(
+        context=test_plugin_context,
+        config=BanditScannerConfig(
+            options=BanditScannerConfigOptions(
+                excluded_paths=[
+                    IgnorePathWithReason(path="cdk.out", reason="CDK synth output"),
+                    IgnorePathWithReason(path=".venv", reason="Python virtualenv"),
+                ]
+            )
+        ),
+    )
+    scanner._process_config_options()
+
+    exclude_keys = [
+        arg.key for arg in scanner.args.extra_args if arg.key.startswith("--exclude=")
+    ]
+    assert exclude_keys, (
+        f"Expected at least one --exclude= token, got none. "
+        f"All extra_args keys: {[a.key for a in scanner.args.extra_args]!r}"
+    )
+
+    offending = [key for key in exclude_keys if '"' in key]
+    assert not offending, (
+        f"--exclude tokens contain literal '\"' characters: {offending!r}"
+    )
+
+
+def test_process_config_options_exclude_argument_value_is_well_formed(
+    test_plugin_context,
+):
+    """The ``--exclude=`` value is the comma-join of the expected glob entries."""
+    user_paths = ["tests", "docs"]
+    scanner = BanditScanner(
+        context=test_plugin_context,
+        config=BanditScannerConfig(
+            options=BanditScannerConfigOptions(
+                excluded_paths=[
+                    IgnorePathWithReason(path=p, reason="value-preservation test")
+                    for p in user_paths
+                ]
+            )
+        ),
+    )
+    scanner._process_config_options()
+
+    exclude_tokens = [
+        arg.key for arg in scanner.args.extra_args if arg.key.startswith("--exclude=")
+    ]
+    assert exclude_tokens, "Expected at least one --exclude= token"
+
+    # Mirror the source-code construction so the test stays correct under
+    # any future Path-normalization changes: each KNOWN_IGNORE_PATHS item
+    # contributes "{item}/**" plus "**/{item}/**", and each user
+    # excluded_paths entry contributes "**/{path}/**".
+    expected_entries: list[str] = []
+    for item in KNOWN_IGNORE_PATHS:
+        expected_entries.append(str(Path(item).joinpath("**")))
+        expected_entries.append(str(Path("**").joinpath(item, "**")))
+    for p in user_paths:
+        expected_entries.append(str(Path("**").joinpath(p, "**")))
+
+    for token in exclude_tokens:
+        value = token[len("--exclude=") :]
+        actual_entries = value.split(",")
+        assert actual_entries == expected_entries, (
+            f"--exclude= value did not match expected entries.\n"
+            f"  token:    {token!r}\n"
+            f"  actual:   {actual_entries!r}\n"
+            f"  expected: {expected_entries!r}"
+        )
+
+    # All --exclude= tokens (multiple if _process_config_options is invoked
+    # more than once) must carry the same value.
+    distinct_values = {token[len("--exclude=") :] for token in exclude_tokens}
+    assert len(distinct_values) == 1, (
+        f"Expected all --exclude= tokens to carry the same value; got "
+        f"{len(distinct_values)} distinct values: {distinct_values!r}"
+    )

--- a/tests/unit/plugin_modules/ash_builtin/test_checkov_scanner_skip_path_quoting.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_checkov_scanner_skip_path_quoting.py
@@ -1,0 +1,95 @@
+"""Regression tests for the shape of checkov ``--skip-path=`` argv tokens."""
+
+import pytest
+
+from automated_security_helper.core.constants import KNOWN_IGNORE_PATHS
+from automated_security_helper.models.core import IgnorePathWithReason
+from automated_security_helper.plugin_modules.ash_builtin.scanners.checkov_scanner import (
+    CheckovScanner,
+    CheckovScannerConfig,
+    CheckovScannerConfigOptions,
+)
+
+
+def test_process_config_options_skip_path_arguments_contain_no_literal_quotes(
+    test_plugin_context,
+):
+    """No emitted ``--skip-path=`` argv token contains a literal ``"`` character.
+
+    Quote characters embedded in the value are passed verbatim into the
+    child process argv (``subprocess`` runs with ``shell=False``), and
+    checkov compiles each ``--skip-path`` value as a regex, so a literal
+    ``"`` would prevent the pattern from matching any real path.
+    """
+    scanner = CheckovScanner(
+        context=test_plugin_context,
+        config=CheckovScannerConfig(
+            options=CheckovScannerConfigOptions(
+                skip_path=[
+                    IgnorePathWithReason(path="cdk.out", reason="CDK synth output"),
+                    IgnorePathWithReason(path=".venv", reason="Python virtualenv"),
+                ]
+            )
+        ),
+    )
+    scanner._process_config_options()
+
+    skip_path_keys = [
+        arg.key for arg in scanner.args.extra_args if arg.key.startswith("--skip-path=")
+    ]
+    assert len(skip_path_keys) >= 2, (
+        f"Expected at least two --skip-path= tokens (KNOWN_IGNORE_PATHS + "
+        f"user entries), got {skip_path_keys!r}"
+    )
+
+    offending = [key for key in skip_path_keys if '"' in key]
+    assert not offending, (
+        f"--skip-path tokens contain literal '\"' characters: {offending!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "user_path",
+    [
+        "cdk.out",
+        ".venv",
+        "node_modules",
+        "tests/integration",
+        "my-dir/sub_dir.123",
+    ],
+)
+def test_process_config_options_skip_path_values_are_verbatim(
+    test_plugin_context, user_path
+):
+    """Each user ``skip_path`` entry is emitted verbatim as ``--skip-path={path}``."""
+    scanner = CheckovScanner(
+        context=test_plugin_context,
+        config=CheckovScannerConfig(
+            options=CheckovScannerConfigOptions(
+                skip_path=[
+                    IgnorePathWithReason(path=user_path, reason="value-preservation test"),
+                ]
+            )
+        ),
+    )
+    scanner._process_config_options()
+
+    skip_path_keys = [
+        arg.key for arg in scanner.args.extra_args if arg.key.startswith("--skip-path=")
+    ]
+
+    expected_token = f"--skip-path={user_path}"
+    assert expected_token in skip_path_keys, (
+        f"Expected exact token {expected_token!r} among emitted --skip-path "
+        f"tokens, but got {skip_path_keys!r}"
+    )
+
+    # _process_config_options is called twice during the scanner lifecycle
+    # (once at model_post_init, once explicitly above), so the count of
+    # --skip-path= tokens must be a multiple of len(KNOWN_IGNORE_PATHS) + 1.
+    per_invocation_count = len(KNOWN_IGNORE_PATHS) + 1
+    assert len(skip_path_keys) % per_invocation_count == 0, (
+        f"Expected len(skip_path_keys)={len(skip_path_keys)} to be a multiple "
+        f"of len(KNOWN_IGNORE_PATHS) + 1 = {per_invocation_count}; "
+        f"keys={skip_path_keys!r}"
+    )


### PR DESCRIPTION
*Issue #, 349*

*Description of changes:*

The built-in `checkov` and `bandit` scanner plugins construct their `--skip-path` / `--exclude` CLI arguments as single-string tokens with literal double-quote characters wrapped around the value. ASH invokes scanners via `subprocess` with the default `shell=False`, so the `"` characters end up inside the argv value rather than being interpreted as shell quoting. The downstream tools then treat the quotes as part of the pattern — checkov compiles a regex that requires a literal `"` character in the file path, so no real path matches and exclusions silently fail.

The failure is silent: scanners exit 0, no warning is emitted, and the only observable symptom is that path exclusions don't appear to take effect. Both built-in `KNOWN_IGNORE_PATHS` and any user-configured `skip_path` / `excluded_paths` entries are affected.

Affected versions: Tested v3.2.1 and v3.5.2, although likely present in older versions.

See the linked issue for the full reproducer.

*Fix*

Remove the embedded quotes from the three affected f-strings. The values are passed as argv via `subprocess`, so no shell-level quoting is needed — the argument delimiter is the argv boundary.

- `automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py`:
  two occurrences (the `KNOWN_IGNORE_PATHS` loop and the user `skip_path` loop).
- `automated_security_helper/plugin_modules/ash_builtin/scanners/bandit_scanner.py`:
  one occurrence (the single `--exclude` token).

*Tests*

Two new unit-test files under `tests/unit/plugin_modules/ash_builtin/`:

- `test_checkov_scanner_skip_path_quoting.py`:
  - `test_process_config_options_skip_path_arguments_contain_no_literal_quotes`  — asserts no emitted `--skip-path=` `ToolExtraArg.key` contains a literal `"` character.
  - `test_process_config_options_skip_path_values_are_verbatim` — parametrized over five filesystem-safe paths; asserts each emitted token equals exactly `--skip-path={path}`.

- `test_bandit_scanner_exclude_quoting.py`:
  - `test_process_config_options_exclude_argument_contains_no_literal_quotes` — asserts no emitted `--exclude=` `ToolExtraArg.key` contains a literal `"` character.
  - `test_process_config_options_exclude_argument_value_is_well_formed` — asserts the comma-joined `--exclude=` value splits into the expected list of glob entries (mirroring the source-code `Path(...).joinpath(...)` construction so the test stays correct under any future Path-normalization changes).

Also updated a stale comment in `tests/integration/scanners/test_bandit_scanner.py::test_process_config_options_exclusions`
that documented the buggy quoted form as if it were intentional. The assertion itself is quote-agnostic and is unchanged.

*Verification*

- New regression tests fail on the unfixed code and pass after the fix.
- Full unit + scanner integration suite (`uv run pytest --run-integration tests/unit/ tests/integration/scanners/ -v --no-cov`) shows the same pre-existing 5 failures as before the fix (unrelated env / mock signature drift); zero new failures.
- `uv run ruff check` and `uv run ruff format --check` clean on all five touched files.
- End-to-end: installed locally via `uv tool install --from . automated-security-helper --force`, ran against a project with a
  `cdk.out/` directory and `scanners.checkov.options.skip_path: "cdk.out"`. Verified scan properly excluded cdk.out.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.