### PR TITLE
fix: install CDK dependencies in container mode (#373)

### DIFF
--- a/.ash/.ash_community_plugins.yaml
+++ b/.ash/.ash_community_plugins.yaml
@@ -51,6 +51,11 @@ global_settings:
       line_start: 175
       line_end: 177
       reason: False positive — runtime-generated synthetic credit card numbers from seeded random for test data.
+    - path: scripts/generate_test_docx.py
+      rule_id: PASSPORT
+      line_start: 198
+      line_end: 199
+      reason: Intentional test data — MRZ-format passport strings used to generate sample documents for ferret-scan integration testing.
     - path: tests/integration/cli/test_mcp_file_tracking_integration.py
       rule_id: SECRET-SECRET-KEYWORD
       reason: False positive.

--- a/Dockerfile
+++ b/Dockerfile
@@ -198,7 +198,7 @@ ENV NODE_OPTIONS=--max_old_space_size=512
 # COPY ASH source to /ash instead of / to isolate
 #
 COPY --from=uv-reqs /src/dist/*.whl .
-RUN uv pip install --system *.whl && rm -rf *.whl
+RUN uv pip install --system "$(ls *.whl)[cdk]" && rm -rf *.whl
 
 #
 # Make sure the ash script is executable

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -131,6 +131,28 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
         found = find_executable("node")
         return found is not None
 
+    def get_installation_commands(self, platform: str, arch: str) -> List[List[str]]:
+        """Install CDK dependencies via pip extra.
+
+        The CDK dependencies (aws-cdk-lib, cdk-nag, constructs) are Python packages
+        defined as optional extras in pyproject.toml under [cdk]. This method ensures
+        they are installed when `ash dependencies install` is run.
+        """
+        import sys
+
+        commands = super().get_installation_commands(platform, arch)
+        if not _CDK_AVAILABLE:
+            commands.append(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "automated-security-helper[cdk]",
+                ]
+            )
+        return commands
+
     def scan(
         self,
         target: Path,

--- a/tests/unit/plugin_modules/test_cdk_nag_container_deps.py
+++ b/tests/unit/plugin_modules/test_cdk_nag_container_deps.py
@@ -1,0 +1,98 @@
+"""Regression tests for #373: cdk-nag scanner must install CDK deps in container/local mode.
+
+Before the fix, the Dockerfile installed ASH without the [cdk] optional extra,
+and `ash dependencies install` had no way to install CDK deps because the
+cdk-nag scanner did not override `get_installation_commands()`. This caused
+cdk-nag to be marked as MISSING in container mode.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.core.constants import ASH_WORK_DIR_NAME
+from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+    CdkNagScanner,
+    CdkNagScannerConfig,
+)
+
+AshConfig.model_rebuild()
+CdkNagScannerConfig.model_rebuild()
+CdkNagScanner.model_rebuild()
+
+
+@pytest.fixture
+def scanner_context(tmp_path):
+    """Create a PluginContext for the scanner."""
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    work_dir = output_dir / ASH_WORK_DIR_NAME
+    work_dir.mkdir()
+
+    return PluginContext(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        work_dir=work_dir,
+        config=AshConfig(project_name="test"),
+    )
+
+
+class TestCdkNagInstallationCommands:
+    """get_installation_commands must emit pip install for CDK extra when deps are missing."""
+
+    def test_returns_pip_install_cdk_extra_when_unavailable(self, scanner_context):
+        """When _CDK_AVAILABLE is False, must include pip install automated-security-helper[cdk]."""
+        with patch(
+            "automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner._CDK_AVAILABLE",
+            False,
+        ):
+            scanner = CdkNagScanner(context=scanner_context)
+            commands = scanner.get_installation_commands("linux", "amd64")
+
+            # Should contain exactly one command that installs the [cdk] extra
+            cdk_install_cmds = [
+                cmd for cmd in commands if "automated-security-helper[cdk]" in cmd
+            ]
+            assert len(cdk_install_cmds) == 1, (
+                f"Expected exactly one CDK install command, got: {commands}"
+            )
+
+            # Verify it's a pip install command
+            cmd = cdk_install_cmds[0]
+            assert cmd[0] == sys.executable
+            assert cmd[1] == "-m"
+            assert cmd[2] == "pip"
+            assert cmd[3] == "install"
+
+    def test_no_pip_install_when_cdk_available(self, scanner_context):
+        """When _CDK_AVAILABLE is True, must NOT emit pip install for CDK extra."""
+        with patch(
+            "automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner._CDK_AVAILABLE",
+            True,
+        ):
+            scanner = CdkNagScanner(context=scanner_context)
+            commands = scanner.get_installation_commands("linux", "amd64")
+
+            cdk_install_cmds = [
+                cmd for cmd in commands if "automated-security-helper[cdk]" in cmd
+            ]
+            assert len(cdk_install_cmds) == 0, (
+                f"Should not install CDK extra when already available, got: {commands}"
+            )
+
+    def test_validate_deps_fails_when_cdk_unavailable(self, scanner_context):
+        """validate_plugin_dependencies must return False when CDK is not installed."""
+        with patch(
+            "automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner._CDK_AVAILABLE",
+            False,
+        ):
+            scanner = CdkNagScanner(context=scanner_context)
+            result = scanner.validate_plugin_dependencies()
+            assert result is False
+            assert scanner.dependencies_satisfied is False


### PR DESCRIPTION

*Issue #, if available:* #373

*Description of changes:*
The cdk-nag scanner reported MISSING in container mode because the Dockerfile installed the wheel without the [cdk] optional extra.

Changes:
- Dockerfile: install wheel with [cdk] extra so aws-cdk-lib, cdk-nag, and constructs are available in the container image
- cdk_nag_scanner.py: add get_installation_commands() override so that 'ash dependencies install' can install CDK deps in local mode too

Fixes #373


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
