### PR TITLE
fix(security): add cooldown period to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default: 3
+      semver-major: 7
     commit-message:
       prefix: "ci"
     labels:
@@ -17,6 +20,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default: 3
+      semver-major: 7
     commit-message:
       prefix: "build"
     labels:
@@ -26,6 +32,9 @@ updates:
     directory: "/automated_security_helper/assets"
     schedule:
       interval: "daily"
+    cooldown:
+      default: 3
+      semver-major: 7
     commit-message:
       prefix: "build"
     labels:
@@ -35,6 +44,9 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    cooldown:
+      default: 3
+      semver-major: 7
     commit-message:
       prefix: "build"
     labels:


### PR DESCRIPTION
## Problem

Semgrep rule `dependabot-missing-cooldown` flags all 4 ecosystem entries in `.github/dependabot.yml` — 4 HIGH findings blocking the release workflow.

## Fix

Added `cooldown` configuration to each package ecosystem:
- **default: 3 days** — wait 3 days after a package is published before creating a PR
- **semver-major: 7 days** — wait 7 days for major version bumps

This protects against supply chain attacks where malicious packages are published and quickly consumed by automated dependency bots.