### PR TITLE
fix: correct dependabot cooldown property names

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default: 3
-      semver-major: 7
+      default-days: 7
     commit-message:
       prefix: "ci"
     labels:
@@ -21,8 +20,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default: 3
-      semver-major: 7
+      default-days: 7
     commit-message:
       prefix: "build"
     labels:
@@ -33,8 +31,7 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default: 3
-      semver-major: 7
+      default-days: 7
     commit-message:
       prefix: "build"
     labels:
@@ -45,8 +42,8 @@ updates:
     schedule:
       interval: "daily"
     cooldown:
-      default: 3
-      semver-major: 7
+      default-days: 7
+      semver-major-days: 7
     commit-message:
       prefix: "build"
     labels:


### PR DESCRIPTION
The cooldown schema requires `default-days` and `semver-major-days` (with `-days` suffix), not `default` and `semver-major`.

Fixes the GitHub schema validation error:
```
The property '#/updates/0/cooldown' contains additional properties ["default", "semver-major"] outside of the schema when none are allowed
```