### PR TITLE
fix(docs): restore working star history charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,4 +483,4 @@ This library is licensed under the Apache 2.0 License. See the [LICENSE](LICENSE
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/automated-security-helper&type=Date)](https://www.star-history.com/#awslabs/automated-security-helper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/automated-security-helper&type=Date)](https://star-history.dera.page/#awslabs/automated-security-helper&Date)

--- a/README.md.template
+++ b/README.md.template
@@ -483,4 +483,4 @@ This library is licensed under the Apache 2.0 License. See the [LICENSE](LICENSE
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/automated-security-helper&type=Date)](https://www.star-history.com/#awslabs/automated-security-helper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/automated-security-helper&type=Date)](https://star-history.dera.page/#awslabs/automated-security-helper&Date)

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -12,7 +12,7 @@ ASH (Automated Security Helper) is a security scanning tool designed to help you
 - It leverages lightweight, open-source tools for flexibility and portability
 - ASH v3 has been completely rewritten in Python with significant improvements to usability and functionality
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/automated-security-helper&type=Date)](https://www.star-history.com/#awslabs/automated-security-helper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/automated-security-helper&type=Date)](https://star-history.dera.page/#awslabs/automated-security-helper&Date)
 
 ## Key Features in ASH v3
 

--- a/docs/content/index.md.template
+++ b/docs/content/index.md.template
@@ -12,7 +12,7 @@ ASH (Automated Security Helper) is a security scanning tool designed to help you
 - It leverages lightweight, open-source tools for flexibility and portability
 - ASH v3 has been completely rewritten in Python with significant improvements to usability and functionality
 
-[![Star History Chart](https://api.star-history.com/svg?repos=awslabs/automated-security-helper&type=Date)](https://www.star-history.com/#awslabs/automated-security-helper&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=awslabs/automated-security-helper&type=Date)](https://star-history.dera.page/#awslabs/automated-security-helper&Date)
 
 ## Key Features in ASH v3
 


### PR DESCRIPTION
The star history chart in the README and docs is currently broken because it depends on the GitHub stargazer API, which has imposed restrictions that prevent the chart from loading. This patch points the chart at an alternative provider that uses the same domain for both the API and frontend and requires no API token, so the chart renders correctly again. Updates both the generated documentation and the corresponding templates.