### PR TITLE
fix(checkov): resolve the config file against source_dir, not process cwd

### DIFF
--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/checkov_scanner.py
@@ -248,12 +248,33 @@ class CheckovScanner(ScannerPluginBase[CheckovScannerConfig]):
             if item is not None
         ]
 
+        # Resolve config candidates against source_dir, not the process working
+        # directory, and hand checkov an absolute path.
+        #
+        # The subprocess runs with cwd=context.source_dir (see
+        # PluginBase._run_subprocess), so probing with a bare Path(...).exists()
+        # asked a different question than the one checkov would answer: it tested
+        # the directory ASH happens to be invoked from. When that directory was
+        # ASH's own checkout, the probe matched ASH's ".ash/.checkov.yaml" and
+        # passed it through get_shortest_name, which relativises against the
+        # process cwd. checkov then could not open it, wrote no SARIF, and the
+        # scanner reported ERROR with zero findings.
+        #
+        # This used to line up by accident: the pre-decomposition run_ash_scan
+        # chdir'd the whole process into source_dir, so process cwd and subprocess
+        # cwd were the same directory. Resolving explicitly keeps the behaviour
+        # correct without a global chdir, which also matters for scanning several
+        # projects in one process.
+        source_dir = Path(self.context.source_dir)
         for conf_path in possible_config_paths:
-            if Path(conf_path).exists():
+            candidate = Path(conf_path)
+            if not candidate.is_absolute():
+                candidate = source_dir / candidate
+            if candidate.exists():
                 self.args.extra_args.append(
                     ToolExtraArg(
                         key="--config-file",
-                        value=get_shortest_name(input=conf_path),
+                        value=candidate.resolve().as_posix(),
                     )
                 )
                 break

--- a/tests/unit/plugin_modules/ash_builtin/test_checkov_config_discovery.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_checkov_config_discovery.py
@@ -1,0 +1,122 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: checkov config discovery must key off source_dir, not process cwd.
+
+checkov's subprocess runs with cwd=context.source_dir (PluginBase._run_subprocess
+defaults working_dir to it). The config probe previously used a bare
+Path(".ash/.checkov.yaml").exists(), which tests whatever directory ASH was invoked
+from, and then passed the match through get_shortest_name, which relativises against
+that same process cwd. So the probe and the consumer disagreed about the base
+directory.
+
+When ASH was invoked from its own checkout, the probe matched ASH's committed
+.ash/.checkov.yaml and handed checkov a path it could not open. checkov exited
+without writing results_sarif.sarif, the scanner raised FileNotFoundError, and every
+scan reported checkov as ERROR with zero findings.
+
+This lined up by accident before run_ash_scan was decomposed: that version chdir'd
+the whole process into source_dir, so process cwd and subprocess cwd were the same
+directory. Restoring the global chdir is not the fix - it destabilised 107 tests
+across the CWD-sensitive suites, because the decomposition deliberately removed
+process-wide cwd dependence (see tests/unit/test_cwd_defaults_fix.py). Resolving the
+probe explicitly is, and it is also what scanning several projects in one process
+requires.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.base.plugin_context import PluginContext
+
+PluginContext.model_rebuild()
+
+from automated_security_helper.plugin_modules.ash_builtin.scanners.checkov_scanner import (  # noqa: E402
+    CheckovScanner,
+    CheckovScannerConfig,
+    CheckovScannerConfigOptions,
+)
+
+
+def _scanner(source_dir: Path, output_dir: Path, **opts) -> CheckovScanner:
+    ctx = PluginContext(
+        source_dir=source_dir, output_dir=output_dir, config=AshConfig()
+    )
+    return CheckovScanner(
+        context=ctx,
+        config=CheckovScannerConfig(options=CheckovScannerConfigOptions(**opts)),
+    )
+
+
+def _config_args(scanner: CheckovScanner) -> list[str]:
+    return [
+        ea.value for ea in scanner.args.extra_args if ea.key == "--config-file"
+    ]
+
+
+@pytest.fixture
+def dirs(tmp_path):
+    src = tmp_path / "target"
+    (src / ".ash").mkdir(parents=True)
+    out = tmp_path / "out"
+    out.mkdir()
+    return src, out
+
+
+class TestConfigResolvedAgainstSourceDir:
+    def test_finds_config_in_source_dir(self, dirs):
+        src, out = dirs
+        cfg = src / ".ash" / ".checkov.yaml"
+        cfg.write_text("skip-check:\n  - CKV_AWS_18\n")
+
+        args = _config_args(_scanner(src, out))
+        assert args, "config in source_dir was not discovered"
+        assert Path(args[0]) == cfg.resolve(), args
+
+    def test_config_arg_is_absolute(self, dirs):
+        """The subprocess cwd is source_dir; a cwd-relative arg is ambiguous."""
+        src, out = dirs
+        (src / ".ash" / ".checkov.yaml").write_text("skip-check: []\n")
+
+        args = _config_args(_scanner(src, out))
+        assert args and Path(args[0]).is_absolute(), args
+
+    def test_ignores_config_that_only_exists_in_process_cwd(self, dirs, monkeypatch):
+        """A config next to ASH's own checkout must not leak into a scan of elsewhere.
+
+        This is the exact failure: the probe found a file relative to the process
+        working directory that checkov, running from source_dir, could not open.
+        """
+        src, out = dirs
+        elsewhere = out / "cwd-with-config"
+        (elsewhere / ".ash").mkdir(parents=True)
+        (elsewhere / ".ash" / ".checkov.yaml").write_text("skip-check: []\n")
+        monkeypatch.chdir(elsewhere)
+
+        assert _config_args(_scanner(src, out)) == [], (
+            "picked up a config from the process working directory; checkov runs "
+            "from source_dir and cannot open it"
+        )
+
+    def test_no_config_anywhere_adds_no_arg(self, dirs, monkeypatch):
+        src, out = dirs
+        monkeypatch.chdir(out)
+        assert _config_args(_scanner(src, out)) == []
+
+    def test_explicit_relative_config_file_resolves_against_source_dir(self, dirs):
+        src, out = dirs
+        cfg = src / "custom.yaml"
+        cfg.write_text("skip-check: []\n")
+
+        args = _config_args(_scanner(src, out, config_file="custom.yaml"))
+        assert args and Path(args[0]) == cfg.resolve(), args
+
+    def test_explicit_absolute_config_file_is_used_as_given(self, dirs):
+        src, out = dirs
+        cfg = out / "abs.yaml"
+        cfg.write_text("skip-check: []\n")
+
+        args = _config_args(_scanner(src, out, config_file=str(cfg)))
+        assert args and Path(args[0]) == cfg.resolve(), args


### PR DESCRIPTION
Stacked on #334.

## Problem

checkov reports status `ERROR` with zero findings on any scan whose target has no IaC files, and the `scan` job fails in CI. On `main` the same target returns `PASSED`.

## Cause

The config probe and the process that consumes it disagreed about which directory they meant.

checkov's subprocess runs with `cwd=context.source_dir` — `PluginBase._run_subprocess` defaults `working_dir` to it. The probe used a bare `Path(".ash/.checkov.yaml").exists()`, which tests whatever directory ASH was invoked from, then passed any match through `get_shortest_name`, which relativises against that same process cwd.

Invoked from ASH's own checkout, the probe matched ASH's committed `.ash/.checkov.yaml` and handed checkov a relative path it could not open from `source_dir`. checkov exited without writing `results_sarif.sarif`, `scan()` raised `FileNotFoundError`, and the scanner was marked `ERROR`.

This lined up by accident until `run_ash_scan` was decomposed: the previous implementation `chdir`'d the whole process into `source_dir`, so process cwd and subprocess cwd were the same directory. `main` is correct only incidentally.

## Fix

Candidates resolve against `source_dir` and are passed absolute. A relative `options.config_file` resolves against `source_dir`; an absolute one is used as given.

## Alternative considered and rejected

Restoring `os.chdir(source_dir)` in `_run_local_mode`. It restores parity with `main` and it does fix checkov — verified. But measured against the suite it took **2677 passed / 0 failed to 107 failed and 23 errors** across the cwd-sensitive files, because the decomposition deliberately removed process-wide cwd dependence (`tests/unit/test_cwd_defaults_fix.py` exists for that reason) and dropped the `patch("os.chdir")` guards those tests needed. A process-wide chdir also cannot express per-project scoping, which multi-project scanning will need. Resolving the path explicitly fixes the cause rather than re-establishing the coincidence.

## Verification

- Target with no IaC files: checkov `ERROR` to `PASSED`, no errors recorded.
- Target with its own `.ash/.checkov.yaml` containing `skip-check: [CKV_AWS_18]`: **6 findings, `CKV_AWS_18` absent**. Same target with the config removed: **7 findings, `CKV_AWS_18` present**. Exactly the one rule the config skips, so the per-target config is genuinely honoured rather than silently ignored.
- Full scan across all default scanners: **zero scanners in ERROR**, down from 9.
- Unit suite 2683 passed / 0 failed. Schema and docs-freshness gates clean.

## Tests

Six regression tests in `tests/unit/plugin_modules/ash_builtin/test_checkov_config_discovery.py`, including that a config present only in the process working directory is *not* picked up. Reinstating the old probe fails 4 of the 6.