### PR TITLE
test(runtime-patch): replace hardcoded /tmp paths flagged by bandit B108

### DIFF
--- a/tests/unit/config/test_runtime_patch.py
+++ b/tests/unit/config/test_runtime_patch.py
@@ -60,11 +60,11 @@ class TestAllowedPaths:
             {
                 "op": "add",
                 "path": "/external_reports_to_include/-",
-                "value": "/tmp/report.sarif",
+                "value": "/work/report.sarif",
             }
         ]
         result = apply_runtime_patch(base, ops, allowlist=allowlist)
-        assert "/tmp/report.sarif" in result.external_reports_to_include
+        assert "/work/report.sarif" in result.external_reports_to_include
 
     def test_allowed_glob_segment_match(self) -> None:
         base = _base_config()
@@ -293,12 +293,12 @@ class TestAtomicMultiOp:
             {
                 "op": "add",
                 "path": "/external_reports_to_include/-",
-                "value": "/tmp/r.sarif",
+                "value": "/work/r.sarif",
             },
         ]
         result = apply_runtime_patch(base, ops, allowlist=allowlist)
         assert result.project_name == "renamed"
-        assert "/tmp/r.sarif" in result.external_reports_to_include
+        assert "/work/r.sarif" in result.external_reports_to_include
 
 
 class TestDefaults:
@@ -375,7 +375,7 @@ class TestRecursiveValuePattern:
             {
                 "op": "replace",
                 "path": "/external_reports_to_include",
-                "value": ["/tmp/a.sarif", "DROP TABLE users", "/tmp/b.sarif"],
+                "value": ["/work/a.sarif", "DROP TABLE users", "/work/b.sarif"],
             }
         ]
         with pytest.raises(RuntimePatchDeniedError) as excinfo:
@@ -414,12 +414,12 @@ class TestRecursiveValuePattern:
             {
                 "op": "replace",
                 "path": "/external_reports_to_include",
-                "value": ["/tmp/a.sarif", "/tmp/b.sarif"],
+                "value": ["/work/a.sarif", "/work/b.sarif"],
             }
         ]
         # Should apply cleanly.
         result = apply_runtime_patch(base, ops, allowlist=allowlist)
-        assert result.external_reports_to_include == ["/tmp/a.sarif", "/tmp/b.sarif"]
+        assert result.external_reports_to_include == ["/work/a.sarif", "/work/b.sarif"]
 
     def test_value_key_missing_distinguished_from_explicit_null(self) -> None:
         """#72 regression: an op with no `value` key must be treated as


### PR DESCRIPTION
## What

Replaces the hardcoded `/tmp/...` literals in `tests/unit/config/test_runtime_patch.py` with `/work/...` equivalents. Seven lines, test-data only, no product code.

## Why

ASH's own self-scan fails on this branch. bandit reports **B108 — "Probable insecure usage of temp file/directory"** ten times in this file, all at MEDIUM. The repo's global severity threshold is MEDIUM, so all ten are actionable and `ash` exits 2:

```
│ bandit │ 0 │ 0 │ 0 │ 10 │ 17 │ 0 │ 32.4s │ 10 │ FAILED │ MED (g) │
=== Actionable findings detected! ===
ERROR (2) Exiting due to 10 actionable findings found in ASH scan
```

That is what turns `scan (python-local, *)` red on the default config. The Community Plugins variant of the same job passes, which is why the failure looked platform-shaped rather than config-shaped.

The flagged values are inert: `apply_runtime_patch` writes them into `external_reports_to_include` and the assertions read them back out. No file is created, opened, or deleted, so the rule is a false positive here — but the pattern is still worth removing rather than suppressing.

## Approach

`/work` is what main already switched to for the same class of finding in #312 (`test: use /work/src instead of /tmp/src in SARIF fixtures`). Reusing that keeps the literals meaningful as fake in-container paths and avoids scattering `# nosec B108` annotations.

## Verification

- `tests/unit/config/test_runtime_patch.py` — 30 passed
- Full unit suite — 2719 passed, 0 failed (identical to the pre-change count on this branch)
- `ash --mode local --build-target ci` — exit **0**, was exit 2
- bandit **10 MEDIUM → 0**, actionable **10 → 0**, FAILED → PASSED
- bandit LOW unchanged at 17, confirming nothing else was suppressed or dropped

## Notes

Based on `pr/mcp-streamable-http` (#335), where the file lives. #336 inherits the same ten findings as a descendant and is cleared once this lands and #336 is updated onto it.

#338 has two findings of the same rule in a different file, on a sibling branch. Since neither file exists on the other's branch, that fix ships separately.