### PR TITLE
test(scanners): replace hardcoded /tmp paths flagged by bandit B108

### DIFF
--- a/tests/unit/base/test_scanner_template_method.py
+++ b/tests/unit/base/test_scanner_template_method.py
@@ -618,11 +618,11 @@ class TestInjectInvocationHelper:
         final_args = [
             "checkov",
             "-d",
-            "/tmp/src",
+            "/work/src",
             "--output",
             "sarif",
             "--output-file-path",
-            "/tmp/out",
+            "/work/out",
         ]
         target = plugin_context.source_dir
         scanner._inject_invocation(report, final_args, target)
@@ -630,5 +630,5 @@ class TestInjectInvocationHelper:
         inv = report.runs[0].invocations[0]
         # Hardcoded legacy expectation (matches ``" ".join(final_args)``
         # that the pre-migration per-scanner _post_scan emitted).
-        expected = "checkov -d /tmp/src --output sarif --output-file-path /tmp/out"
+        expected = "checkov -d /work/src --output sarif --output-file-path /work/out"
         assert inv.commandLine == expected


### PR DESCRIPTION
## What

Replaces the hardcoded `/tmp/...` literals in `tests/unit/base/test_scanner_template_method.py` with `/work/...` equivalents. Three lines, test-data only, no product code.

## Why

ASH's own self-scan fails on this branch. bandit reports **B108 — "Probable insecure usage of temp file/directory"** twice in the `_inject_invocation` test, both at MEDIUM. The repo's global severity threshold is MEDIUM, so both are actionable and `ash` exits 2:

```
│ bandit │ 0 │ 0 │ 0 │ 2 │ 18 │ 0 │ 2 │ FAILED │ MED (g) │
```

That is what turns `scan (python-local, *)` red on the default config, while the Community Plugins variant of the same job passes.

The flagged paths are a synthetic argv list (`final_args`) plus the expected joined command line. `_inject_invocation` only string-joins them onto the SARIF `Invocation`, so nothing touches the filesystem — a false positive, but the pattern is still better removed than suppressed.

## Approach

`/work` is what main already switched to for the same class of finding in #312 (`test: use /work/src instead of /tmp/src in SARIF fixtures`). The `expected` string is updated in lockstep so it still equals `" ".join(final_args)` — that equality is the whole point of the test, so the two must move together.

## Verification

- `tests/unit/base/test_scanner_template_method.py` — 19 passed
- Full unit suite — 2726 passed, 0 failed (identical to the pre-change count on this branch)
- `ash --mode local --build-target ci` — exit **0**, was exit 2
- bandit **2 MEDIUM → 0**, actionable **2 → 0**, FAILED → PASSED
- bandit LOW unchanged at 18, confirming nothing else was suppressed or dropped

## Notes

Based on `pr/scanner-template-method` (#338), where the file lives.

#335 has ten findings of the same rule in a different file, on a sibling branch, fixed in its own PR. Neither file exists on the other's branch, so a single combined PR was not possible.