### PR TITLE
perf(tests): run the unit suite on all cores instead of pinning -n 1

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,23 @@ python_classes = Test*
 python_functions = test_*
 
 # Configure test discovery and execution
+#
+# `-n auto` runs the suite across every available CPU. It replaced `-n 1`, which
+# had been in place since the v3 release with no recorded reason and served no
+# purpose: xdist gives each worker its own process, so cwd, environment and
+# module-level singletons are already isolated per worker. That is why the eight
+# test modules that call os.chdir/monkeypatch.chdir are safe in parallel, and no
+# test binds a socket or port, which is the one pattern that genuinely breaks.
+#
+# Verified before changing: five consecutive full-suite runs at 192 workers, all
+# 2700 passed / 0 failed, plus a 4-worker run (matching a GitHub standard runner)
+# also 2700 passed. pytest-cov combines per-worker data correctly, so the
+# fail_under=80 gate in .coveragerc still applies.
+#
+# Note on `auto`: psutil is not a dependency, so xdist falls back to
+# os.cpu_count() and `auto` means all *logical* CPUs. If psutil ever arrives as a
+# transitive dependency, `auto` starts meaning physical cores instead and the
+# worker count on hyperthreaded runners halves; switch to `-n logical` then.
 addopts =
     --verbose
     --cov=automated_security_helper
@@ -13,7 +30,7 @@ addopts =
     --cov-report=html:test-results/coverage_html
     --junit-xml=test-results/pytest.junit.xml
     --durations=10
-    -n 1
+    -n auto
     --cov-config=.coveragerc
 
 # Configure markers for test categorization


### PR DESCRIPTION
## What

One line in `pytest.ini`: `-n 1` → `-n auto`, plus a comment recording why it's safe.

## Why `-n 1` isn't needed

It arrived with the v3 release squash (#117) with no dedicated commit or rationale, and it is **not** an isolation mechanism. xdist gives every worker its own **process**, so cwd, environment variables and module-level singletons are already isolated per worker. That's why the eight test modules calling `os.chdir`/`monkeypatch.chdir` are safe in parallel.

The one pattern that genuinely breaks under parallelism is binding a socket or port. `git grep` finds **zero** tests doing that.

## Measured before changing anything

| workers | result | wall time |
| --- | --- | --- |
| `-n 1` (today) | 2700 passed | 115.6s |
| `-n 4` (a standard GitHub runner) | 2700 passed | 62.8s |
| `-n auto` (192 here) | 2700 passed | 37.9s |

- **Five consecutive** full-suite runs at 192 workers: 2700 passed, 0 failed, 0 errors each (36.3s / 36.7s / 42.8s / 39.0s / 37.9s).
- The in-flight MCP branch **#335**, which adds streamable-HTTP transport tests, is also clean at 192 workers — 2737 passed.
- `pytest-cov` combines per-worker data correctly, so the `fail_under = 80` gate in `.coveragerc` still applies. Verified via a plain `uv run pytest` — the exact command CI uses — with no ini parse error.

## Expected CI effect

`unit-test` is 18 jobs averaging 2.8 min, about **50 of the ~246 runner-minutes** in a full `ASH - Unified CI` run. On a 4-vCPU standard runner this should be roughly **1.8×** faster, so ~50 → ~28 runner-minutes. Free — no larger runners involved.

## Note on `auto`

`psutil` is not a dependency, so xdist falls back to `os.cpu_count()` and `auto` means all *logical* CPUs — 4 on a standard runner. If `psutil` ever arrives as a transitive dependency, `auto` starts meaning *physical* cores and the worker count halves on hyperthreaded runners. `-n logical` is the switch if that happens; this is recorded as a comment in `pytest.ini` so it isn't rediscovered the hard way.

## Interaction with #416

#416 is the runner-sizing experiment. Its arm A is meant to be the `-n 1` baseline but invokes plain `uv run pytest`, so if this PR lands first, arm A silently becomes `-n auto` and A-vs-B collapses. Either land #416 first, or change its arm A to pass `-n 1` explicitly.