### PR TITLE
ci: add job timeouts and make the Finch setup fail fast instead of hanging

### DIFF
--- a/.github/workflows/ash-create-release.yml
+++ b/.github/workflows/ash-create-release.yml
@@ -15,6 +15,7 @@ jobs:
   create-release-pr:
     name: Bump version and create release PR
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ash-install-methods.yml
+++ b/.github/workflows/ash-install-methods.yml
@@ -22,6 +22,7 @@ jobs:
   validate:
     name: ${{ matrix.method }} (${{ matrix.os }}, py${{ matrix.python-version }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ash-pr-title-check.yml
+++ b/.github/workflows/ash-pr-title-check.yml
@@ -14,6 +14,7 @@ jobs:
   pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ash-repo-docs.yml
+++ b/.github/workflows/ash-repo-docs.yml
@@ -20,6 +20,7 @@ jobs:
     name: Build documentation
     needs: []
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref != 'refs/heads/main')
@@ -47,6 +48,7 @@ jobs:
     name: Deploy documentation
     needs: []
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       #checkov:skip=CKV2_GHA_1:The permissions are not set to write-all at the top-level, or any level
       contents: write

--- a/.github/workflows/ash-tag-on-merge.yml
+++ b/.github/workflows/ash-tag-on-merge.yml
@@ -16,6 +16,7 @@ jobs:
       github.event.pull_request.merged == true &&
       startsWith(github.event.pull_request.title, 'chore(release):')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7

--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -94,7 +94,10 @@ jobs:
   scan-validation:
     name: "scan (${{ matrix.method }}, ${{ matrix.os }})${{ matrix.oci-runner && matrix.oci-runner != 'docker' && format(' [{0}]', matrix.oci-runner) || '' }}${{ matrix.offline && ' [offline]' || '' }}${{ matrix.config-file == 'community' && ' - Community Plugins' || '' }}"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # Container-runtime cells are far slower than docker/python-local and were
+    # being cancelled at exactly 20.3 min by the previous flat 20. Measured:
+    # docker/python-local peak ~5 min, podman/finch on ubuntu-latest reach 20+.
+    timeout-minutes: ${{ (matrix.oci-runner == 'podman' || matrix.oci-runner == 'finch') && 45 || 20 }}
     strategy:
       fail-fast: false
       matrix:
@@ -173,7 +176,10 @@ jobs:
   install-validation:
     name: "${{ matrix.method }} (${{ matrix.os }}, py${{ matrix.python-version }})"
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 20
+    # finch has been observed succeeding at 23 min and hanging past 280; podman is
+    # similarly slow. The other six methods peak under 3 min, so they keep a tight
+    # bound while the container runtimes get enough room to pass legitimately.
+    timeout-minutes: ${{ (matrix.method == 'podman' || matrix.method == 'finch') && 45 || 20 }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -29,6 +29,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7
@@ -51,6 +52,7 @@ jobs:
   unit-test:
     name: "unit-test (${{ matrix.os }}, py${{ matrix.python-version }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     permissions:
       contents: read
       pull-requests: write
@@ -171,6 +173,7 @@ jobs:
   install-validation:
     name: "${{ matrix.method }} (${{ matrix.os }}, py${{ matrix.python-version }})"
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   dependency-review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
       - uses: actions/dependency-review-action@v5

--- a/.github/workflows/run-ash-security-scan.yml
+++ b/.github/workflows/run-ash-security-scan.yml
@@ -108,6 +108,7 @@ jobs:
   ash:
     name: SAST, SCA, and IaC Scan
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       COLUMNS: 140
     steps:

--- a/scripts/setup-finch-linux.sh
+++ b/scripts/setup-finch-linux.sh
@@ -12,6 +12,10 @@
 
 set -euo pipefail
 
+# Keep apt from ever opening a config prompt. Without this a package that wants
+# to discuss a modified conffile will block forever on a runner with no tty.
+export DEBIAN_FRONTEND=noninteractive
+
 ARCH=$(dpkg --print-architecture)
 
 echo "=== Removing Docker Engine (conflicts with Finch containerd) ==="
@@ -32,7 +36,40 @@ systemctl start containerd
 systemctl start finch-buildkit
 systemctl start finch
 
+# Docker was removed above, so if any of these units is dead there is no runtime
+# left to fall back on and the image build that follows blocks instead of
+# failing. Confirm each unit is actually active, with a bound, and dump its logs
+# if not.
+echo "=== Waiting for Finch services to report active ==="
+for unit in containerd finch-buildkit finch; do
+    for _ in $(seq 1 30); do
+        if systemctl is-active --quiet "$unit"; then break; fi
+        sleep 2
+    done
+    if ! systemctl is-active --quiet "$unit"; then
+        echo "ERROR: ${unit} did not become active within 60s" >&2
+        systemctl status "$unit" --no-pager --lines=40 >&2 || true
+        journalctl -u "$unit" --no-pager --lines=60 >&2 || true
+        exit 1
+    fi
+    echo "  ${unit}: active"
+done
+
 echo "=== Verifying Finch installation ==="
 finch --version
+
+# `finch --version` only proves the binary is on PATH; it passes even when
+# buildkit and containerd are unreachable. Probe the daemon so a broken runtime
+# surfaces here in under a minute rather than wedging `ash build-image` until the
+# job timeout. Both probes are bounded, so this step can never be the thing that
+# hangs.
+echo "=== Verifying the Finch daemon responds ==="
+if ! timeout 60 sh -c 'finch info >/dev/null 2>&1 || finch images >/dev/null 2>&1'; then
+    echo "ERROR: Finch did not answer a daemon query within 60s." >&2
+    echo "buildkit or containerd is installed but not usable; refusing to continue." >&2
+    systemctl status containerd finch-buildkit finch --no-pager --lines=40 >&2 || true
+    journalctl -u finch-buildkit --no-pager --lines=60 >&2 || true
+    exit 1
+fi
 
 echo "=== Finch setup complete ==="


### PR DESCRIPTION
## The problem

Six jobs were stuck at once — **every one of them `finch (ubuntu-latest, py3.12)`**:

| run | stuck for |
| --- | --- |
| 32271612038 | 280.4 min |
| 32271650061 | 279.2 min |
| 32271942534 | 276.5 min |
| 32272231018 | 273.8 min |
| 32272276688 | 273.3 min |
| 32274366832 | 236.8 min |

~24 runner-hours, six occupied runners. All six have been cancelled (four were stale merge-queue runs for already-merged PRs, one a merged dependabot PR, one superseded by a newer run).

Nothing stopped them because **`scan-validation` was the only job in the repo with `timeout-minutes`**. Everything else inherited GitHub's 360-minute default.

## Two findings, not one

**1. Most jobs had no bound at all.** 12 of 13 jobs across 9 workflows.

**2. The one existing bound is too tight and is actively cancelling work.** Four jobs show conclusion `cancelled` at precisely **20.3 min** — `scan (bash|python-container, ubuntu-latest) [finch|podman]`. Those surface as failures in the checks rollup, so part of the container-cell red on this repo is the repo's own timeout rather than the code under test. And because the cap truncates them, their true duration isn't observable.

Corroborating: finch is wildly variable — **6.6 min** in one run, **23 min succeeding** in another, **280+ min** hung. A flat 20 would have killed the 23-minute pass.

## Timeouts added

Sized from measured maxima across several runs, and scaled per matrix cell rather than one number for everything:

| workflow | job | timeout |
| --- | --- | --- |
| ash-unified-ci | lint | 15 |
| ash-unified-ci | unit-test | 20 |
| ash-unified-ci | scan-validation | **podman/finch → 45, else 20** |
| ash-unified-ci | install-validation | **podman/finch → 45, else 20** |
| ash-install-methods | validate | 20 |
| ash-repo-docs | build-docs / deploy-docs | 20 / 15 |
| ash-create-release | create-release-pr | 15 |
| ash-tag-on-merge | tag-and-release | 15 |
| ash-pr-title-check | pr-title | 10 |
| dependency-review | dependency-review | 15 |
| run-ash-security-scan | ash | 30 |

Basis: docker/python-local scan cells peak ~5 min, the six non-container install methods peak under 3 min, `unit-test` 3.4 min, `lint` 0.4 min. The 280-minute hang is still bounded — at 45 min instead of 360 — while a legitimate 23-minute finch pass survives.

`ash-repo-scan.yml`'s `ash` job is deliberately untouched: it calls a **reusable workflow**, where `timeout-minutes` is not a permitted key. Adding it there would break the workflow.

## Why the Finch job hangs

`scripts/setup-finch-linux.sh` **removes Docker Engine**, so once it runs there's no fallback runtime. It then starts `containerd`, `finch-buildkit` and `finch` and verifies with `finch --version` — which only proves the binary is on PATH and passes even when both daemons are unreachable. The `ash build-image --oci-runner finch --force` that follows blocks rather than failing.

1. **Poll each unit for up to 60s**, dumping `systemctl status` + `journalctl` if it never goes active.
2. **Bounded daemon probe** after the version check — `finch info` with a `finch images` fallback, wrapped in `timeout 60`. A broken runtime surfaces in under a minute, and this step can never itself hang. (Both subcommands are tried because the repo has no precedent for either; `timeout` bounds both regardless.)
3. **`export DEBIAN_FRONTEND=noninteractive`**, so a package wanting to discuss a modified conffile can't block on a tty-less runner.

## Verified

- All 9 workflows parse as YAML.
- `bash -n` and **shellcheck** clean on the script.
- No timeout on the reusable-workflow call.
- Additive apart from the two timeout lines that became expressions.

## Scope

This bounds the damage and makes the failure legible; it does **not** fix whatever is wrong with Finch on Ubuntu. Right now the logs are unreachable because GitHub withholds them until the run completes and the run never completes. Once a wedged job dies at 45 min with journal output attached, the root cause becomes diagnosable.