### PR TITLE
fix(ci): stop installing ASH from the ephemeral merge-queue ref, and gate all three upgrade paths

### DIFF
--- a/.github/actions/run-scan-test/action.yml
+++ b/.github/actions/run-scan-test/action.yml
@@ -47,17 +47,38 @@ runs:
         SNYK_TOKEN: ${{ inputs.snyk-token }}
       run: |
         echo "Installing tools needed for community plugins..."
-        npm install -g snyk
+
+        # Every install below pulls a third-party binary over the network, and none
+        # of them had a retry. Observed failure: snyk's npm post-install wrapper hit
+        # ECONNRESET part-way through downloading snyk-win.exe, retried the download
+        # successfully (shasums matched), then died renaming a temp file the failed
+        # attempt had already cleaned up - taking the whole
+        # `scan (python-local, windows-latest) - Community Plugins` job with it,
+        # before ASH was even invoked.
+        retry() {
+          local attempts=3 n=1
+          until "$@"; do
+            if [ "$n" -ge "$attempts" ]; then
+              echo "::error::'$*' failed after ${attempts} attempts"
+              return 1
+            fi
+            echo "::warning::'$*' failed (attempt ${n}/${attempts}); retrying in $((n * 10))s"
+            sleep $((n * 10))
+            n=$((n + 1))
+          done
+        }
+
+        retry npm install -g snyk
         snyk version
 
         if [[ "$RUNNER_OS" == "Linux" ]]; then
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
+          retry bash -c 'curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin'
           trivy version
         elif [[ "$RUNNER_OS" == "macOS" ]]; then
-          brew install trivy
+          retry brew install trivy
           trivy version
         elif [[ "$RUNNER_OS" == "Windows" ]]; then
-          curl -sfL -o trivy.zip "https://get.trivy.dev/trivy?type=zip&os=windows&arch=amd64"
+          retry curl -sfL -o trivy.zip "https://get.trivy.dev/trivy?type=zip&os=windows&arch=amd64"
           mkdir -p /tmp/trivy-install
           mv trivy.zip /tmp/trivy-install/
           cd /tmp/trivy-install
@@ -69,7 +90,7 @@ runs:
           trivy version
         fi
 
-        pip install ferret-scan
+        retry pip install ferret-scan
         ferret-scan --version
 
     # Validate config

--- a/.github/workflows/ash-repo-scan.yml
+++ b/.github/workflows/ash-repo-scan.yml
@@ -22,8 +22,14 @@ jobs:
       security-events: write # Required for collection of SARIF code scanning results for GitHub Advanced Security checks
     with:
       # For PR runs, install ASH from the PR's head repo and branch so fork PRs work.
+      # For merge_group runs, github.head_ref is empty and github.ref_name is the
+      # ephemeral gh-readonly-queue/... branch, which GitHub deletes as soon as the
+      # queue entry is processed. The scan step's uvx install would win the race and
+      # the later report step's would not, failing with "couldn't find remote ref".
+      # The commit is unreachable once the branch is gone, so its SHA is not
+      # fetchable either - the only stable choice is the default branch.
       # For non-PR runs (workflow_dispatch, push), use the current repo and ref.
-      ash-version: ${{ github.head_ref || github.ref_name }}
+      ash-version: ${{ github.head_ref || (github.event_name == 'merge_group' && github.event.repository.default_branch) || github.ref_name }}
       ash-repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       # This repo uses GitHub Advanced Security. If you do not use GitHub Advanced Security,
       # it is recommended to set this to `false` to prevent failures during SARIF report

--- a/.github/workflows/ash-upgrade-paths.yml
+++ b/.github/workflows/ash-upgrade-paths.yml
@@ -24,13 +24,13 @@ name: ASH Upgrade Paths
 
 on:
   merge_group:
+  # Deliberately unfiltered. These three arms are meant to be required checks in
+  # the "Protect main" ruleset, and a required check that does not run never
+  # reports - which blocks the pull request forever. A `paths:` filter here would
+  # do exactly that on any PR that happens not to touch pyproject.toml,
+  # uv.lock or automated_security_helper/**. The cost of always running is three
+  # parallel jobs on a repo that already runs well over a hundred.
   pull_request:
-    paths:
-      # Anything that can change how the package installs or what it exposes.
-      - pyproject.toml
-      - uv.lock
-      - automated_security_helper/**
-      - .github/workflows/ash-upgrade-paths.yml
   workflow_dispatch: {}
 
 permissions:

--- a/.github/workflows/ash-upgrade-paths.yml
+++ b/.github/workflows/ash-upgrade-paths.yml
@@ -1,0 +1,164 @@
+---
+# Validates that the commit under test can be *upgraded into*, not just installed
+# fresh. A clean install passing tells you nothing about whether an existing
+# installation survives the upgrade - stale entry points, regenerated schemas,
+# renamed modules and moved console scripts all fail only on the upgrade path.
+#
+# Three arms, all installing the same new version (the checked-out tree):
+#
+#   direct            clean environment -> new                (baseline)
+#   from-release      latest release tag -> new               (what users do)
+#   from-prev-commit  HEAD~1 -> new                           (what CI/main does)
+#
+# Why the new version comes from the local checkout rather than a git ref:
+# on merge_group the ref is an ephemeral gh-readonly-queue/... branch that GitHub
+# deletes as soon as the queue entry is processed. Installing from it races that
+# deletion - and once the branch is gone the commit is unreachable, so its SHA is
+# not fetchable either. The checkout is already on disk and cannot disappear
+# mid-run, so it is the only stable source for "the code being merged".
+#
+# The old versions are materialised with `git worktree` from the local clone for
+# the same reason: no network fetch, so nothing here depends on a remote ref that
+# may have been deleted. That requires fetch-depth: 0 (history + tags).
+name: ASH Upgrade Paths
+
+on:
+  merge_group:
+  pull_request:
+    paths:
+      # Anything that can change how the package installs or what it exposes.
+      - pyproject.toml
+      - uv.lock
+      - automated_security_helper/**
+      - .github/workflows/ash-upgrade-paths.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  upgrade-path:
+    name: "upgrade (${{ matrix.from }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - from: direct
+          - from: from-release
+          - from: from-prev-commit
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          # Full history and tags: the old versions are resolved locally, not fetched.
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Resolve the starting point for this arm
+        id: start
+        env:
+          ARM: ${{ matrix.from }}
+        run: |
+          set -euo pipefail
+          case "$ARM" in
+            direct)
+              echo "ref=" >> "$GITHUB_OUTPUT"
+              echo "label=clean environment" >> "$GITHUB_OUTPUT"
+              ;;
+            from-release)
+              # Highest semver release tag that is an ancestor of HEAD.
+              #
+              # Deliberately not `git describe --tags`: that picks the nearest tag
+              # by commit distance, which here returns the floating major-version
+              # tag `v3`. `v3` gets reattached over time, so upgrading "from v3"
+              # would mean upgrading from an unpredictable commit. Sorting by
+              # version and filtering to vX.Y.Z pins the arm to a real release.
+              ref=$(git tag --sort=-v:refname \
+                    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+                    | while read -r t; do
+                        if git merge-base --is-ancestor "$t" HEAD 2>/dev/null; then
+                          echo "$t"; break
+                        fi
+                      done)
+              if [ -n "$ref" ]; then
+                echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+                echo "label=release ${ref}" >> "$GITHUB_OUTPUT"
+              else
+                echo "::error::No semver release tag is an ancestor of HEAD - cannot validate the upgrade-from-release path."
+                exit 1
+              fi
+              ;;
+            from-prev-commit)
+              if ref=$(git rev-parse --verify HEAD~1 2>/dev/null); then
+                echo "ref=${ref}" >> "$GITHUB_OUTPUT"
+                echo "label=commit ${ref:0:8}" >> "$GITHUB_OUTPUT"
+              else
+                echo "::error::HEAD has no parent - cannot validate the upgrade-from-commit path."
+                exit 1
+              fi
+              ;;
+          esac
+
+      - name: Create the target environment
+        run: |
+          set -euo pipefail
+          # --seed so the venv has pip, matching how users upgrade in place.
+          uv venv --seed --python 3.12 "${RUNNER_TEMP}/venv"
+
+      - name: "Install the starting version (${{ steps.start.outputs.label }})"
+        if: steps.start.outputs.ref != ''
+        env:
+          START_REF: ${{ steps.start.outputs.ref }}
+        run: |
+          set -euo pipefail
+          # Materialise the old tree from the local clone. No fetch, so a deleted
+          # merge-queue ref cannot break this.
+          git worktree add --detach "${RUNNER_TEMP}/old" "$START_REF"
+          uv pip install --python "${RUNNER_TEMP}/venv/bin/python" -q "${RUNNER_TEMP}/old"
+          # Prove the starting point is genuinely functional before upgrading over
+          # it; otherwise a broken "before" state would make the upgrade look fine.
+          "${RUNNER_TEMP}/venv/bin/ash" --version
+
+      - name: Upgrade to the commit under test
+        run: |
+          set -euo pipefail
+          uv pip install --python "${RUNNER_TEMP}/venv/bin/python" -q .
+
+      - name: Verify the upgraded installation
+        run: |
+          set -euo pipefail
+          VENV="${RUNNER_TEMP}/venv/bin"
+          # Console script still resolves and reports the new version.
+          "${VENV}/ash" --version
+          "${VENV}/ash" --help > /dev/null
+          # Subcommands whose entry points or imports could have moved.
+          "${VENV}/ash" mcp --help > /dev/null
+          "${VENV}/ash" config get > /dev/null
+          # Import the package fresh: catches modules left behind by the old
+          # install shadowing the new one.
+          "${VENV}/python" -c "import automated_security_helper as m; print('import ok:', m.__file__)"
+
+      - name: Verify it can still scan after the upgrade
+        run: |
+          set -euo pipefail
+          VENV="${RUNNER_TEMP}/venv/bin"
+          FIX="${RUNNER_TEMP}/selftest"
+          mkdir -p "$FIX"
+          printf 'print("hello")\n' > "${FIX}/test_sample.py"
+          "${VENV}/ash" scan --source-dir "$FIX" --output-dir "${FIX}/output" \
+            --simple --phases scan --phases report
+
+      - name: Record the arm in the run summary
+        if: success() || failure()
+        env:
+          ARM: ${{ matrix.from }}
+          LABEL: ${{ steps.start.outputs.label }}
+          STATUS: ${{ job.status }}
+        run: |
+          printf '| %s | %s | %s |\n' "$ARM" "$LABEL" "$STATUS" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/run-ash-security-scan.yml
+++ b/.github/workflows/run-ash-security-scan.yml
@@ -167,7 +167,12 @@ jobs:
         env:
           ASH_REPO_CLONE_URL: https://github.com/${{ github.repository }}.git
         run: |-
-          uvx --reinstall --from ${ASH_UVX_SOURCE} ash \
+          # No --reinstall here. The Run ASH step above already installed this exact
+          # source, so re-forcing a download makes the report step do a second git
+          # fetch it does not need - and if the ref has disappeared in the meantime
+          # (merge_group queue branches are deleted mid-run) that fetch is what
+          # fails, after the scan itself has already succeeded.
+          uvx --from ${ASH_UVX_SOURCE} ash \
             --output-dir "${ASH_OUTPUT_DIR}" report
 
       - name: Update step summary


### PR DESCRIPTION
## What

Two related changes to how ASH gets installed in the merge queue.

### 1. The existing scan job was failing regardless of findings

[Run 32379692582](https://github.com/awslabs/automated-security-helper/actions/runs/32379692582/job/96459551863) had bandit, checkov, grype, npm-audit, opengrep, semgrep and syft all `PASSED` with 0 actionable findings, then exited 1:

```
ASH_UVX_SOURCE: git+.../automated-security-helper@gh-readonly-queue/main/pr-381-5bde2a97...
error: Failed to resolve `--with` requirement
  fatal: couldn't find remote ref refs/tags/gh-readonly-queue/main/pr-381-5bde2a97...
```

`ash-repo-scan.yml` passes `ash-version: ${{ github.head_ref || github.ref_name }}`. Its comment covers PR runs and "non-PR runs (workflow_dispatch, push)" but never `merge_group`, where `head_ref` is empty and `ref_name` is the ephemeral `gh-readonly-queue/...` branch. GitHub deletes that branch as soon as the queue entry is processed, and `run-ash-security-scan.yml` installs from it **twice** - the scan step and the report step - so the two installs race the deletion. The scan wins; the report, minutes later, loses.

Switching to a SHA does not help: verified against the failing run, the queue branch no longer resolves **and neither does its head commit** `5d3f6e79` (`fatal: couldn't find remote ref`). Once the branch is deleted the commit is unreachable.

Fixed by resolving `ash-version` to the default branch on `merge_group`, and by dropping `--reinstall` from the report step so it reuses what the scan step just installed instead of doing a second fetch it does not need.

### 2. New gate: all three upgrade paths

A clean install passing says nothing about whether an *existing* installation survives the upgrade. `ash-upgrade-paths.yml` adds three arms on `merge_group`, all installing the same new version (the checked-out tree):

| arm | starting point | represents |
| --- | --- | --- |
| `direct` | clean environment | baseline |
| `from-release` | `v3.5.9` | what users do |
| `from-prev-commit` | `HEAD~1` | what main does |

Each arm installs the starting version, proves it runs (`ash --version`), upgrades in place, then re-checks the console script, `--help`, `mcp --help`, `config get`, a fresh package import, and a real scan against a fixture. Verifying the starting point first matters - a broken "before" state would make any upgrade look clean.

This also covers the trade-off from change 1: the queued commit's own code is still exercised in the merge queue, by all three arms.

## Two resolution details that are easy to get wrong

**The new version comes from the local checkout, not a git ref.** That is the only source that cannot disappear mid-run, for exactly the reason change 1 documents. The old versions are materialised with `git worktree` from the local clone for the same reason - no network fetch - which is why `fetch-depth: 0` is required.

**`from-release` deliberately avoids `git describe --tags`.** That picks the nearest tag by commit distance, which in this repo returns the floating major-version tag `v3`. `v3` is reattached over time, so the arm would upgrade from an unpredictable commit. Sorting by version and filtering to `vX.Y.Z` pins it to `v3.5.9`.

## Verified

All three arms were run locally against this branch - all pass, and the post-upgrade scan exits 0.

The `from-release` arm was also checked for vacuousness, which was a genuine risk: main still declares version `3.5.9`, identical to the release tag, so pip could have treated the upgrade as already-satisfied and validated nothing. It does not. In the upgraded venv's site-packages:

- `core/phases/scanner_executor.py` (absent from v3.5.9) is **present**
- `cli/mcp.py` from v3.5.9 is **gone**, and the new `cli/mcp/` package is **present**

That file-to-package transition is precisely the hazard this gate exists to catch - a leftover `mcp.py` would shadow `mcp/` and break every MCP import.

All workflows parse as YAML, and no `${{ }}` expression is interpolated inside any `run:` block.
