### PR TITLE
fix: enforce plugin-declared tool version constraints when installing scanner tools

### DIFF
--- a/.github/actions/run-scan-test/action.yml
+++ b/.github/actions/run-scan-test/action.yml
@@ -90,7 +90,26 @@ runs:
           trivy version
         fi
 
-        retry pip install ferret-scan
+        # `pip install ferret-scan` resolves to whatever is newest, which is not
+        # a version anyone chose. ferret-scan 2.3.3 was published at
+        # 2026-08-20T21:14:59Z; jobs whose install step ran after that installed
+        # it, picked up a new API_KEY_OR_SECRET detector that matches
+        # `session: Optional[Session]` in generated Pydantic schemas, and failed
+        # on 2 findings. Runs from 40 minutes earlier passed on 2.3.2. Three
+        # unrelated merge-queue branches broke in the same window with no source
+        # change.
+        #
+        # The plugin already declares the range it is tested against, so read it
+        # from there rather than repeating it here -- one source of truth, and if
+        # the constant moves this fails loudly instead of silently reverting to
+        # installing latest.
+        FERRET_CONSTRAINT="$(python -c 'from automated_security_helper.plugin_modules.ash_ferret_plugins.ferret_scanner import DEFAULT_VERSION_CONSTRAINT as c; print(c)')"
+        if [ -z "$FERRET_CONSTRAINT" ]; then
+          echo "::error::Could not read ferret-scan's declared version constraint from its ASH plugin. Refusing to install an unconstrained version."
+          exit 1
+        fi
+        echo "Installing ferret-scan against its plugin-declared constraint: ${FERRET_CONSTRAINT}"
+        retry pip install "ferret-scan${FERRET_CONSTRAINT}"
         ferret-scan --version
 
     # Validate config

--- a/automated_security_helper/base/plugin_base.py
+++ b/automated_security_helper/base/plugin_base.py
@@ -22,6 +22,41 @@ class PluginDependency(BaseModel):
     package_manager: PackageManager = PackageManager.APT
 
 
+# Version strings starting with one of these are PEP 440 specifiers (a range),
+# not a single version.
+_VERSION_SPECIFIER_START = ("<", ">", "!", "~", "=")
+
+
+def pep440_requirement(name: str, version: str) -> str:
+    """Render ``name`` and ``version`` as one pip/uv requirement string.
+
+    ``version`` is interpreted three ways:
+
+    - ``"latest"`` -- no constraint, so the resolver takes the newest release.
+    - a PEP 440 specifier such as ``">=0.1.0,<2.0.0"`` -- passed through verbatim.
+    - a bare version such as ``"1.2.3"`` -- pinned exactly, with ``==``.
+
+    The middle case is why this helper exists. Rendering every non-``latest``
+    version as ``f"{name}=={version}"`` turns a range into a requirement pip
+    cannot parse (``ferret-scan==>=0.1.0,<2.0.0``), so a plugin that declared a
+    supported *range* had no way to get it honoured. The observable failure was
+    not an error, which is what made it expensive: the range went undeclared,
+    the installer fell back to "latest", and CI installed whichever release
+    happened to be newest at the moment the job ran. ferret-scan 2.3.3 was
+    published mid-run on 2026-08-20 and turned every open PR red without a
+    single source change.
+
+    Only pip and uv use this. apt, npm, brew, yum and choco all spell ranges
+    differently, and guessing a translation between them would trade a loud
+    failure for a quiet mis-install.
+    """
+    if version == "latest":
+        return name
+    if version.startswith(_VERSION_SPECIFIER_START):
+        return f"{name}{version}"
+    return f"{name}=={version}"
+
+
 class CustomCommand(BaseModel):
     args: List[str]
     shell: bool = False  # Set to True only when shell expansion is absolutely necessary
@@ -283,7 +318,7 @@ class PluginBase(UVToolMixin, BaseModel):
                             "-m",
                             "pip",
                             "install",
-                            f"{dep.name}{f'=={dep.version}' if dep.version != 'latest' else ''}",
+                            pep440_requirement(dep.name, dep.version),
                         ]
                     )
                 elif dep.package_manager == PackageManager.UV:
@@ -292,7 +327,7 @@ class PluginBase(UVToolMixin, BaseModel):
                             "uv",
                             "tool",
                             "install",
-                            f"{dep.name}{f'=={dep.version}' if dep.version != 'latest' else ''}",
+                            pep440_requirement(dep.name, dep.version),
                         ]
                     )
                 elif dep.package_manager == PackageManager.NPM:

--- a/automated_security_helper/cli/dependencies.py
+++ b/automated_security_helper/cli/dependencies.py
@@ -169,7 +169,14 @@ def install_dependencies(
                         source_dir=source_dir,
                         output_dir=output_dir,
                         work_dir=work_dir,
+                        # config_path is what makes --config/ASH_CONFIG mean
+                        # anything here. Omitting it made the option accept a
+                        # path and then quietly ignore it, so
+                        # `ash dependencies install --config .ash/.ash_community_plugins.yaml`
+                        # resolved the default config instead and installed
+                        # dependencies for the wrong set of plugins.
                         config=resolve_config(
+                            config_path=config,
                             source_dir=source_dir,
                             config_overrides=config_overrides,
                         ),

--- a/automated_security_helper/plugin_modules/ash_ferret_plugins/README.md
+++ b/automated_security_helper/plugin_modules/ash_ferret_plugins/README.md
@@ -24,14 +24,23 @@ Ferret Scan is a sensitive data detection tool that scans files for potential se
 Install Ferret Scan:
 
 ```bash
-# Via pip (recommended)
-pip install ferret-scan
+# Recommended: let ASH install the version this plugin is tested against
+ash dependencies install --config .ash/.ash_community_plugins.yaml
+
+# Or install by hand. Use the constraint, not a bare `pip install ferret-scan`:
+# the latter resolves to whatever is newest, which is how a release published
+# mid-CI-run once turned every open pull request red.
+pip install 'ferret-scan>=0.1.0,<2.0.0'
 
 # Or build from source
 git clone https://github.com/awslabs/ferret-scan.git
 cd ferret-scan
 make build
 ```
+
+The supported range is declared in `ferret_scanner.py` (`DEFAULT_VERSION_CONSTRAINT`)
+and is what `ash dependencies install` applies. If the two ever disagree, the
+constant is correct.
 
 ### Enable the Plugin
 

--- a/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
@@ -7,12 +7,14 @@ import json
 import logging
 import re
 import subprocess  # nosec B404 — ferret-scan is an external CLI tool invoked via subprocess
+import sys
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, List, Literal, Optional, Tuple
 
 from pydantic import Field, model_validator
 
 from automated_security_helper.base.options import ScannerOptionsBase
+from automated_security_helper.base.plugin_base import pep440_requirement
 from automated_security_helper.base.scanner_plugin import ScannerPluginConfigBase
 from automated_security_helper.models.core import ToolArgs, ToolExtraArg
 from automated_security_helper.base.scanner_plugin import ScannerPluginBase
@@ -415,6 +417,37 @@ class FerretScanScanner(ScannerPluginBase[FerretScannerConfig]):
         # Return default version constraint
         return DEFAULT_VERSION_CONSTRAINT
 
+    def get_installation_commands(self, platform: str, arch: str) -> List[List[str]]:
+        """Install ferret-scan under this plugin's declared version constraint.
+
+        Before this existed the plugin declared a supported range but never
+        installed anything, so every caller installed ferret-scan by hand and
+        nothing applied the range. CI ran ``pip install ferret-scan``, which
+        resolves to whatever is newest -- 2.3.3 on 2026-08-20, three major
+        versions above MAX_SUPPORTED_VERSION. It added an API_KEY_OR_SECRET
+        detector that matches ``session: Optional[Session]`` in generated
+        Pydantic schemas at "95% HIGH" confidence, and every open PR went red
+        with no source change.
+
+        The install is deliberately unconditional rather than skipped when the
+        binary is already present: an already-installed out-of-range build is
+        the case that needs correcting, and pip will downgrade it to satisfy
+        the constraint.
+        """
+        commands = super().get_installation_commands(platform, arch)
+        commands.append(
+            [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                pep440_requirement(
+                    "ferret-scan", self._get_tool_version_constraint() or "latest"
+                ),
+            ]
+        )
+        return commands
+
     def _get_installed_version(self) -> Optional[str]:
         """Get the currently installed ferret-scan version.
 
@@ -501,8 +534,12 @@ class FerretScanScanner(ScannerPluginBase[FerretScannerConfig]):
         ferret_binary = find_executable("ferret-scan")
         if not ferret_binary:
             self._plugin_log(
-                "ferret-scan binary not found. Please install it from "
-                "https://github.com/awslabs/ferret-scan or via 'pip install ferret-scan'",
+                "ferret-scan binary not found. Install it with "
+                "'ash dependencies install', which applies the version range this "
+                f"plugin supports, or by hand with 'pip install \"ferret-scan{DEFAULT_VERSION_CONSTRAINT}\"'. "
+                "A bare 'pip install ferret-scan' resolves to the newest release, "
+                "which may be outside the supported range. Source: "
+                "https://github.com/awslabs/ferret-scan",
                 level=logging.ERROR,
             )
             return False

--- a/docs/content/docs/plugins/community/ferret-scan-plugin.md
+++ b/docs/content/docs/plugins/community/ferret-scan-plugin.md
@@ -74,9 +74,17 @@ This plugin is tested and compatible with specific ferret-scan versions. Using v
 
 The plugin requires Ferret Scan to be installed and available in your system PATH.
 
-**pip (Recommended)**:
+**ASH (Recommended)** — installs the version the plugin is tested against:
 ```bash
-pip install ferret-scan
+ash dependencies install --config .ash/.ash_community_plugins.yaml
+```
+
+**pip**: pass the supported range. A bare `pip install ferret-scan` resolves to
+the newest release, which may sit outside the range in the table above — that is
+how a release published partway through a CI run once failed every open pull
+request without a source change.
+```bash
+pip install 'ferret-scan>=0.1.0,<2.0.0'
 ```
 
 **Build from Source**:

--- a/tests/unit/base/test_plugin_dependency_version_constraints.py
+++ b/tests/unit/base/test_plugin_dependency_version_constraints.py
@@ -1,0 +1,182 @@
+"""Tests for rendering plugin dependencies into install commands.
+
+These exist because the failure mode they pin is silent. ``PluginDependency.version``
+used to be rendered as ``f"{name}=={version}"`` for anything that was not the
+literal string ``"latest"``, so a plugin declaring a supported *range* produced
+``ferret-scan==>=0.1.0,<2.0.0`` -- which pip cannot parse. Nothing raised: the
+range simply never reached an installer, callers installed the package by hand,
+and CI resolved whatever release was newest at the moment the job ran.
+
+That is not a hypothetical. ferret-scan 2.3.3 was published at
+2026-08-20T21:14:59Z, three major versions above the range its ASH plugin
+declares as supported. Jobs whose install step ran after that timestamp picked it
+up, its new API_KEY_OR_SECRET detector matched ``session: Optional[Session]`` in
+a generated Pydantic schema, and three unrelated merge-queue branches went red
+inside eight minutes with no source change on any of them.
+"""
+
+import sys
+
+import pytest
+
+from automated_security_helper.base.plugin_base import (
+    PluginBase,
+    PluginDependency,
+    pep440_requirement,
+)
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.core.constants import ASH_WORK_DIR_NAME
+from automated_security_helper.core.enums import PackageManager
+
+
+@pytest.fixture
+def plugin_context(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    work_dir = output_dir / ASH_WORK_DIR_NAME
+    work_dir.mkdir()
+
+    return PluginContext(
+        source_dir=source_dir,
+        output_dir=output_dir,
+        work_dir=work_dir,
+        config=AshConfig(project_name="test"),
+    )
+
+
+class ConcretePlugin(PluginBase):
+    """Minimal concrete implementation for testing."""
+
+    def validate_plugin_dependencies(self) -> bool:
+        return True
+
+
+def _plugin_with_dependency(plugin_context, dep: PluginDependency) -> ConcretePlugin:
+    return ConcretePlugin(
+        context=plugin_context,
+        dependencies={"linux": {"amd64": [dep]}},
+    )
+
+
+class TestPep440Requirement:
+    """The three ways a declared version is interpreted."""
+
+    def test_latest_emits_no_constraint(self):
+        """``latest`` is the documented way to say "resolver's choice"."""
+        assert pep440_requirement("ferret-scan", "latest") == "ferret-scan"
+
+    def test_bare_version_is_pinned_exactly(self):
+        """A bare version keeps the historical ``==`` behaviour."""
+        assert pep440_requirement("ferret-scan", "1.10.0") == "ferret-scan==1.10.0"
+
+    @pytest.mark.parametrize(
+        "constraint",
+        [
+            ">=0.1.0,<2.0.0",
+            ">=1.0.0",
+            "<2.0.0",
+            "==1.10.0",
+            "!=1.9.0",
+            "~=1.10.0",
+        ],
+    )
+    def test_specifier_is_passed_through_verbatim(self, constraint):
+        """A specifier must not have a second operator glued in front of it."""
+        rendered = pep440_requirement("ferret-scan", constraint)
+        assert rendered == f"ferret-scan{constraint}"
+        assert "==>" not in rendered
+        assert "==<" not in rendered
+
+    def test_the_regression_shape_is_parseable(self):
+        """The exact string that used to be produced was invalid; this one is not."""
+        rendered = pep440_requirement("ferret-scan", ">=0.1.0,<2.0.0")
+        assert rendered == "ferret-scan>=0.1.0,<2.0.0"
+
+        # Prove it, rather than asserting a shape and hoping. packaging is a
+        # transitive dependency of the build stack, so skip instead of failing
+        # if it is genuinely unavailable.
+        packaging_requirements = pytest.importorskip("packaging.requirements")
+        parsed = packaging_requirements.Requirement(rendered)
+        assert parsed.name == "ferret-scan"
+        assert "1.10.0" in parsed.specifier
+        assert "2.3.3" not in parsed.specifier
+
+
+class TestGetInstallationCommandsRendersRanges:
+    """The renderer is the thing an installer actually calls."""
+
+    def test_pip_dependency_carries_the_range(self, plugin_context):
+        plugin = _plugin_with_dependency(
+            plugin_context,
+            PluginDependency(
+                name="ferret-scan",
+                version=">=0.1.0,<2.0.0",
+                package_manager=PackageManager.PIP,
+            ),
+        )
+        commands = plugin.get_installation_commands("linux", "amd64")
+        assert [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "ferret-scan>=0.1.0,<2.0.0",
+        ] in commands
+
+    def test_uv_dependency_carries_the_range(self, plugin_context):
+        plugin = _plugin_with_dependency(
+            plugin_context,
+            PluginDependency(
+                name="ferret-scan",
+                version=">=0.1.0,<2.0.0",
+                package_manager=PackageManager.UV,
+            ),
+        )
+        commands = plugin.get_installation_commands("linux", "amd64")
+        assert [
+            "uv",
+            "tool",
+            "install",
+            "ferret-scan>=0.1.0,<2.0.0",
+        ] in commands
+
+    def test_exact_pin_behaviour_is_unchanged(self, plugin_context):
+        """Existing declarations must render exactly as they did before."""
+        plugin = _plugin_with_dependency(
+            plugin_context,
+            PluginDependency(
+                name="bandit",
+                version="1.7.5",
+                package_manager=PackageManager.PIP,
+            ),
+        )
+        commands = plugin.get_installation_commands("linux", "amd64")
+        assert [sys.executable, "-m", "pip", "install", "bandit==1.7.5"] in commands
+
+    def test_latest_stays_unconstrained(self, plugin_context):
+        plugin = _plugin_with_dependency(
+            plugin_context,
+            PluginDependency(
+                name="bandit",
+                version="latest",
+                package_manager=PackageManager.PIP,
+            ),
+        )
+        commands = plugin.get_installation_commands("linux", "amd64")
+        assert [sys.executable, "-m", "pip", "install", "bandit"] in commands
+
+    def test_non_pep440_managers_are_left_alone(self, plugin_context):
+        """apt/npm/brew spell ranges differently; translating them would guess."""
+        plugin = _plugin_with_dependency(
+            plugin_context,
+            PluginDependency(
+                name="trivy",
+                version="0.50.0",
+                package_manager=PackageManager.APT,
+            ),
+        )
+        commands = plugin.get_installation_commands("linux", "amd64")
+        assert ["apt-get", "install", "-y", "trivy=0.50.0"] in commands

--- a/tests/unit/plugin_modules/ash_ferret_plugins/test_ferret_scanner.py
+++ b/tests/unit/plugin_modules/ash_ferret_plugins/test_ferret_scanner.py
@@ -954,6 +954,47 @@ class TestFerretScanScannerVersionSupport:
         constraint = scanner._get_tool_version_constraint()
         assert constraint == "==1.2.3"
 
+    def test_installation_command_applies_the_declared_constraint(
+        self, mock_plugin_context
+    ):
+        """The declared range has to reach the install command, not just a log line.
+
+        The plugin declared a supported range and installed nothing, so callers
+        ran `pip install ferret-scan` and got whatever was newest. On
+        2026-08-20 that was 2.3.3 -- past MAX_SUPPORTED_VERSION -- and its new
+        API_KEY_OR_SECRET detector failed the self-scan on two false positives.
+        """
+        from automated_security_helper.plugin_modules.ash_ferret_plugins.ferret_scanner import (
+            DEFAULT_VERSION_CONSTRAINT,
+        )
+
+        scanner = FerretScanScanner(context=mock_plugin_context)
+
+        commands = scanner.get_installation_commands("linux", "amd64")
+        install_cmds = [c for c in commands if "install" in c]
+        assert install_cmds, "the plugin must emit an install command"
+
+        specs = [c[-1] for c in install_cmds if c[-1].startswith("ferret-scan")]
+        assert specs == [f"ferret-scan{DEFAULT_VERSION_CONSTRAINT}"]
+
+        # The point of the constraint is excluding the version that broke CI.
+        packaging_requirements = pytest.importorskip("packaging.requirements")
+        specifier = packaging_requirements.Requirement(specs[0]).specifier
+        assert "2.3.3" not in specifier
+        assert "1.10.0" in specifier
+
+    def test_installation_command_honours_a_user_pin(self, mock_plugin_context):
+        """An explicit tool_version must win over the plugin default."""
+        config = FerretScannerConfig(
+            options=FerretScannerConfigOptions(tool_version="==1.9.0")
+        )
+
+        scanner = FerretScanScanner(context=mock_plugin_context, config=config)
+
+        commands = scanner.get_installation_commands("linux", "amd64")
+        specs = [c[-1] for c in commands if c and str(c[-1]).startswith("ferret-scan")]
+        assert specs == ["ferret-scan==1.9.0"]
+
     @patch(
         "automated_security_helper.plugin_modules.ash_ferret_plugins.ferret_scanner.find_executable"
     )


### PR DESCRIPTION
## Problem

CI installed community scanner tools with a bare `pip install ferret-scan`, which resolves to whatever is newest rather than a version anyone chose.

ferret-scan **2.3.3 was published to PyPI at 2026-08-20T21:14:59Z**. Jobs whose install step ran after that timestamp installed it; jobs from 40 minutes earlier installed 2.3.2 and passed. 2.3.3 added an `API_KEY_OR_SECRET` detector that matches

```python
session: Optional[Session] = Field(None, title="Session")
```

in the generated OCSF schema, reporting it as CRITICAL at "95% HIGH" confidence. Two of those failed the self-scan.

The blast radius was not one branch:

| time (UTC) | branch | `scan (python-local, macos-latest) - Community Plugins` |
|---|---|---|
| 17:37 – 18:58 | six branches | success (on 2.3.2) |
| 21:02 – 21:10 | `pr-420`, `pr-421`, `pr-423` queue branches + a feature branch | failure (on 2.3.3) |

Four unrelated branches broke inside eight minutes with no source change on any of them.

## Why the declared constraint didn't prevent it

The plugin already declared `DEFAULT_VERSION_CONSTRAINT = ">=0.1.0,<2.0.0"` and warned on every run that the installed 2.x was outside it. Nothing could act on that, for two independent reasons:

1. **The declaration was unreachable.** `ash dependencies install` renders commands from `PluginDependency`, and the renderer emitted `f"{name}=={version}"` for any version other than the literal `"latest"`. A range therefore rendered as `ferret-scan==>=0.1.0,<2.0.0`, which pip cannot parse — so no plugin declared one and the constraint stayed decorative.
2. **Nothing installed ferret-scan.** The plugin only checked for a pre-existing binary and told the caller to run `pip install ferret-scan` by hand — the unconstrained command.

## Changes

- **`plugin_base`** — add `pep440_requirement()` and use it in the PIP and UV renderers, so `PluginDependency.version` accepts a PEP 440 specifier. `latest` and exact pins behave exactly as before. apt/npm/brew/yum/choco are deliberately untouched: they spell ranges differently, and guessing a translation would swap a loud failure for a quiet mis-install.
- **ferret plugin** — implement `get_installation_commands()` so `ash dependencies install` applies the declared range. The install is unconditional rather than skipped when a binary exists, because an already-installed out-of-range build is exactly the case that needs repair; pip downgrades it.
- **`cli/dependencies`** — pass `config_path` to `resolve_config()`. `--config`/`ASH_CONFIG` were declared, accepted a path, and were then ignored, so `ash dependencies install --config .ash/.ash_community_plugins.yaml` silently resolved the default config.
- **`run-scan-test`** — read the range from the plugin rather than repeating it in YAML, and fail the step if it can't be read instead of falling back to installing latest.
- Docs and the binary-not-found error message now give the constrained command.

## Verification

- The range resolves to **1.10.0**. Every flag the plugin can emit (`--checks --confidence --config --debug --enable-preprocessors --exclude --file --format --no-color --output --profile --recursive --show-match --verbose --version`) is supported by it, and its wheel bundles all six platform binaries including `darwin-arm64` and `windows-amd64` — no runner loses coverage.
- Repo-wide scan with the configured checks (`CREDIT_CARD,SECRETS,SSN,PASSPORT` at high confidence) reports **only** `PASSPORT` at `scripts/generate_test_docx.py:198-199`, which the existing suppression covers exactly (`line_start: 198, line_end: 199`). Zero actionable findings, so no new suppression is needed.
- Confirmed pip downgrades an installed 2.3.3 to 1.10.0 to satisfy the range.
- **566 passed, 4 skipped** across `tests/unit/base`, the ferret plugin suite, and `tests/unit/cli`. No new ruff findings beyond two `UP006` from matching the `List[List[str]]` signature of the overridden method, which has 23 pre-existing instances in these same files.

## Known limitations

- The range is enforced, not an exact version, so any in-range release still installs automatically. Intended: the constraint bounds compatibility rather than freezing a build.
- 2.x stays excluded because the plugin hasn't been validated against it, even though 2.0.0–2.3.2 ran without incident for five weeks. Widening `MAX_SUPPORTED_VERSION` is a deliberate compatibility call and would additionally need an `API_KEY_OR_SECRET` suppression for the generated OCSF schemas; not folded in here.
- snyk (npm) and trivy (installer script/brew/zip) remain unpinned — neither plugin declares a constraint, and their package managers sit outside the PEP 440 path this adds.
