### PR TITLE
test: remove a racy timestamp assertion in the OCSF reporter metadata test

### DIFF
--- a/tests/unit/reporters/test_ocsf_reporter.py
+++ b/tests/unit/reporters/test_ocsf_reporter.py
@@ -741,8 +741,14 @@ class TestOcsfReporterHelperMethods:
         assert finding.metadata.product.vendor_name == "Amazon Web Services"
         assert finding.metadata.product.version is not None
         assert finding.metadata.version == "1.1.0"
-        # Allow for small timing differences (within 10ms)
-        assert abs(finding.metadata.logged_time - current_time_ms) <= 10
+        # _create_vulnerability_finding passes `metadata` through untouched, so
+        # logged_time is whatever the sample_metadata fixture stamped -- it is not
+        # derived from current_time_ms. Comparing the two with a 10ms tolerance was
+        # therefore measuring how long pytest took to get from fixture setup to
+        # this line, which is sub-millisecond locally and much larger on a busy
+        # runner. It failed on ubuntu-24.04-arm/py3.11 at a 62ms gap. Asserting
+        # the pass-through directly is exact and cannot race.
+        assert finding.metadata.logged_time == sample_metadata.logged_time
 
         # Validate complete finding information (Requirement 3.2)
         assert finding.finding_info is not None


### PR DESCRIPTION
## Problem

`test_create_vulnerability_finding_complete_metadata_validation` failed on `unit-test (ubuntu-24.04-arm, py3.11)`, blocking CI on an unrelated PR ([job](https://github.com/awslabs/automated-security-helper/actions/runs/32425946179/job/96607801738)):

```
assert abs(finding.metadata.logged_time - current_time_ms) <= 10
where 62 = abs((1787266425800 - 1787266425862))
```

The assertion had **no product meaning**. `_create_vulnerability_finding` takes `metadata` and passes it through untouched (`metadata=metadata`), so `finding.metadata` *is* the `sample_metadata` fixture object, and its `logged_time` is whatever the fixture stamped at construction time. `current_time_ms` is a second, independent clock read taken later in the test body, and is never used for `logged_time`.

So the 10ms tolerance was measuring how long pytest takes to get from fixture setup to the first line of the test body — sub-millisecond on an idle machine, unbounded on a busy runner. 62ms here. Nothing about the reporter had to change for it to fail.

## Fix

```python
assert finding.metadata.logged_time == sample_metadata.logged_time
```

Exact, cannot race, and it tests the contract the old line did not: that the reporter preserves the metadata it was handed.

## Verification

- 55 passed in `tests/unit/reporters/test_ocsf_reporter.py`.
- Replaying the observed values: the old assertion evaluates `False` (62 > 10); the new one holds.
- `ruff format` clean. `ruff check` reports 24 findings both before and after — all pre-existing in this file, none introduced.
- Only one assertion in the repo used this pattern, so there is no sibling to fix.
