### PR TITLE
fix(ci): stop the fork-PR comment failure from failing the required ASH scan check

### DIFF
--- a/.github/workflows/run-ash-security-scan.yml
+++ b/.github/workflows/run-ash-security-scan.yml
@@ -221,11 +221,45 @@ jobs:
           cat "${ASH_OUTPUT_DIR}/reports/ash.summary.md" >> "${GITHUB_STEP_SUMMARY}"
           tree "${ASH_OUTPUT_DIR}"
 
+      # GITHUB_TOKEN is read-only for pull requests opened from a fork, whatever
+      # `permissions:` the caller declares -- GitHub downgrades it so untrusted
+      # code cannot write to the base repository. Commenting therefore cannot
+      # work on a fork PR, and because this job is a required status check, the
+      # failure took the whole check down *after the scan had already passed*:
+      #
+      #   ##[error]Resource not accessible by integration
+      #   https://docs.github.com/rest/issues/comments#create-an-issue-comment
+      #
+      # That made every external contributor's PR unmergeable for a cosmetic
+      # reason. The existing `github.repository_owner == inputs.repository-owner`
+      # guard does not catch it: for a fork PR *into* this repo the owner is
+      # still the base repo's owner, so the guard passes.
+      #
+      # Comparing head.repo.full_name against github.repository is the exact test
+      # for "same-repo PR". It is scoped to pull_request so merge_group and
+      # workflow_dispatch behaviour is unchanged.
       - name: Post ASH MarkdownReporter output as PR comment
         uses: mshick/add-pr-comment@v3
-        if: inputs.post-pr-comment && github.repository_owner == inputs.repository-owner && (success() || failure())
+        if: >-
+          inputs.post-pr-comment
+          && github.repository_owner == inputs.repository-owner
+          && (github.event_name != 'pull_request'
+              || github.event.pull_request.head.repo.full_name == github.repository)
+          && (success() || failure())
         with:
           message-path: ${{ inputs.output-dir }}/reports/ash.summary.md
+
+      # Say so rather than leaving a contributor wondering why the bot went
+      # quiet. Mirrors the ::warning:: the checks-permission probe below emits.
+      - name: Note that the PR comment was skipped for a fork
+        if: >-
+          inputs.post-pr-comment
+          && github.event_name == 'pull_request'
+          && github.event.pull_request.head.repo.full_name != github.repository
+          && (success() || failure())
+        shell: bash
+        run: |
+          echo "::notice::Scan results were not posted as a PR comment: GITHUB_TOKEN is read-only for fork pull requests. The full report is in this job's summary and in the ash_output artifact."
 
       - name: Collect ASH output artifact
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem

**Every pull request opened from a fork fails the `ash / SAST, SCA, and IaC Scan` check** — which is a *required* status check — so no external contributor's PR can merge. Observed on #386 ([job](https://github.com/awslabs/automated-security-helper/actions/runs/32431388623)):

```
##[error]Resource not accessible by integration
https://docs.github.com/rest/issues/comments#create-an-issue-comment
```

The scan itself had already passed. What failed was the step posting the summary as a PR comment.

## Cause

GitHub downgrades `GITHUB_TOKEN` to read-only for `pull_request` events raised from a fork, regardless of the `permissions:` the caller declares, so untrusted code cannot write to the base repository. `mshick/add-pr-comment` can therefore never succeed on a fork PR.

The existing guard does not catch it:

```yaml
if: inputs.post-pr-comment && github.repository_owner == inputs.repository-owner && ...
```

For a fork PR *into* this repository, `github.repository_owner` is still the **base** repo's owner (`awslabs`), so the guard passes and the step runs anyway. That guard only defends against the whole workflow running inside a fork of the repo — a different case.

## Fix

Skip the comment when the head repo is not this repo, which is the exact test for a cross-repo PR:

```yaml
github.event_name != 'pull_request'
  || github.event.pull_request.head.repo.full_name == github.repository
```

Scoped to `pull_request`, so `merge_group` and `workflow_dispatch` behaviour is unchanged. A companion step emits a `::notice::` saying where the report went, mirroring the `::warning::` the checks-permission probe already emits further down — otherwise a contributor is left wondering why the bot went quiet.

**Not chosen:** `continue-on-error` on the comment step. That would also mask a genuine permissions regression on same-repo runs, where commenting is supposed to work.

Nothing is lost on fork PRs: the report is still in the job summary and the `ash_output` artifact, both of which already run unconditionally.

## Verification

- YAML parses; both step conditions render as expected.
- The notice step's `run` contains no `${{ }}` interpolation, so it adds no workflow-injection surface.
- #386 is the live reproduction: its scan passed and only the comment step failed.
