### PR TITLE
fix(config): honor an explicit --config when source_dir is not supplied

### DIFF
--- a/automated_security_helper/config/resolve_config.py
+++ b/automated_security_helper/config/resolve_config.py
@@ -185,8 +185,18 @@ def resolve_config(
     try:
         # Start with default config
         config = get_default_config() if fallback_to_default else None
-        if source_dir is None and fallback_to_default:
-            ASH_LOGGER.verbose("source_dir is null, returning the default config")
+        # An explicit config_path has to survive a missing source_dir. source_dir
+        # only drives *discovery* of a config file; when the caller already named
+        # one, there is nothing to discover and no reason to bail out to the
+        # default. Testing source_dir alone here meant `ash report --config
+        # <file>` accepted the option and then reported against default settings,
+        # because cli/report.py passes config_path with no source_dir (as does
+        # cli/config.py). Below, source_dir falls back to Path.cwd(), which is
+        # only used to resolve a relative config_path at that point.
+        if source_dir is None and config_path is None and fallback_to_default:
+            ASH_LOGGER.verbose(
+                "source_dir and config_path are both null, returning the default config"
+            )
             # Apply overrides to default config if provided
             if config_overrides:
                 return apply_config_overrides(config, config_overrides)

--- a/tests/unit/config/test_resolve_config.py
+++ b/tests/unit/config/test_resolve_config.py
@@ -1,8 +1,7 @@
 """Tests for config/resolve_config.py — covers override parsing, resolve_config, and apply_config_overrides."""
 
-import json
 from pathlib import Path
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 import pytest
 
 from automated_security_helper.config.resolve_config import (
@@ -120,19 +119,22 @@ class TestApplyConfigOverrides:
 
     def test_validation_error_returns_original(self):
         from pydantic import ValidationError
+
         config = AshConfig(project_name="test")
         # Apply an override that makes the model invalid
         with patch(
             "automated_security_helper.config.resolve_config.AshConfig.model_validate",
             side_effect=ValidationError.from_exception_data(
                 title="AshConfig",
-                line_errors=[{
-                    "type": "value_error",
-                    "loc": ("project_name",),
-                    "msg": "invalid",
-                    "input": "bad",
-                    "ctx": {"error": ValueError("test")},
-                }],
+                line_errors=[
+                    {
+                        "type": "value_error",
+                        "loc": ("project_name",),
+                        "msg": "invalid",
+                        "input": "bad",
+                        "ctx": {"error": ValueError("test")},
+                    }
+                ],
             ),
         ):
             result = apply_config_overrides(config, ["project_name=new"])
@@ -154,10 +156,12 @@ class TestResolveConfig:
 
     def test_explicit_config_path(self, tmp_path):
         config_path = tmp_path / ".ash.yaml"
-        config_path.write_text("project-name: from-file\n")
+        # project_name, not project-name: there is no kebab-case alias for this
+        # field, so the hyphenated spelling is dropped by extra="ignore" and the
+        # assertion below would pass against the default config.
+        config_path.write_text("project_name: from-file\n")
         config = resolve_config(config_path=config_path)
-        # File should be loaded and config returned
-        assert config is not None
+        assert config.project_name == "from-file"
         assert isinstance(config, AshConfig)
 
     def test_config_path_not_found_with_fallback(self, tmp_path):
@@ -182,11 +186,13 @@ class TestResolveConfig:
         ash_dir = tmp_path / ".ash"
         ash_dir.mkdir()
         config_path = ash_dir / ".ash.yaml"
-        config_path.write_text("project-name: discovered\n")
+        config_path.write_text("project_name: discovered\n")
 
         config = resolve_config(source_dir=tmp_path)
-        assert config is not None
         assert isinstance(config, AshConfig)
+        # Asserts the file was actually discovered under <source_dir>/.ash/,
+        # which a not-None assertion cannot distinguish from the default config.
+        assert config.project_name == "discovered"
 
     def test_source_dir_no_config_with_fallback(self, tmp_path):
         config = resolve_config(source_dir=tmp_path, fallback_to_default=True)
@@ -217,12 +223,99 @@ class TestResolveConfig:
         ash_dir = tmp_path / ".ash"
         ash_dir.mkdir()
         config_path = ash_dir / ".ash.yaml"
-        config_path.write_text("project-name: str-path\n")
+        config_path.write_text("project_name: str-path\n")
 
         config = resolve_config(source_dir=str(tmp_path))
-        assert config is not None
         assert isinstance(config, AshConfig)
+        assert config.project_name == "str-path"
 
     def test_overrides_applied_to_default_when_no_source_dir(self):
         config = resolve_config(config_overrides=["project_name=via-override"])
         assert config.project_name == "via-override"
+
+
+class TestConfigPathHonoredWithoutSourceDir:
+    """An explicit config_path must win even when source_dir is not supplied.
+
+    Why this class exists
+    ---------------------
+    resolve_config used to return the default config whenever source_dir was
+    None, before it ever looked at config_path. `ash report --config <file>`
+    calls resolve_config(config_path=..., config_overrides=...) and passes no
+    source_dir, so the option was accepted and then silently ignored: the
+    command reported against default settings while appearing to honour the
+    file. `ash config` (cli/config.py) has the same call shape.
+
+    Why it was not caught
+    ---------------------
+    The pre-existing tests in this file wrote `project-name:` into the fixture
+    and then only asserted `config is not None`. Two things were wrong with
+    that: project_name has no kebab-case alias, so `project-name` is dropped by
+    extra="ignore" and never populates the field at all, and a not-None
+    assertion passes just as happily on the default config as on a loaded one.
+    Every test below asserts on a value that can only come from the file.
+    """
+
+    def test_config_path_is_loaded_when_source_dir_omitted(self, tmp_path):
+        """The `ash report --config <file>` shape: config_path, no source_dir."""
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_text("project_name: from-file\n")
+
+        config = resolve_config(config_path=config_path)
+
+        assert config.project_name == "from-file"
+
+    def test_config_path_is_loaded_when_source_dir_is_explicitly_none(self, tmp_path):
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_text("project_name: from-file\n")
+
+        config = resolve_config(config_path=config_path, source_dir=None)
+
+        assert config.project_name == "from-file"
+
+    def test_overrides_apply_on_top_of_config_path_without_source_dir(self, tmp_path):
+        """report.py passes config_path and config_overrides together.
+
+        The override must win over the file, and the file must still be read for
+        anything the override does not mention.
+        """
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_text("project_name: from-file\nfail_on_findings: false\n")
+
+        config = resolve_config(
+            config_path=config_path,
+            config_overrides=["project_name=from-override"],
+        )
+
+        assert config.project_name == "from-override"
+        assert config.fail_on_findings is False
+
+    def test_default_is_still_returned_when_neither_is_supplied(self):
+        """Guard against over-correcting.
+
+        With no config_path and no source_dir there is nothing to resolve, so
+        the default config is still the right answer. This is the case
+        test_source_dir_none_with_fallback covers, restated here so that a
+        future change to the config_path branch cannot quietly break it.
+        """
+        config = resolve_config()
+
+        assert config is not None
+        assert isinstance(config, AshConfig)
+
+    def test_relative_config_path_resolves_without_source_dir(
+        self, tmp_path, monkeypatch
+    ):
+        """A relative --config path is resolved against the process cwd.
+
+        resolve_config falls back to Path.cwd() for source_dir. That fallback is
+        only reachable once the source_dir-is-None short circuit is gone, so
+        this pins the behaviour rather than leaving it to chance.
+        """
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_text("project_name: from-relative\n")
+        monkeypatch.chdir(tmp_path)
+
+        config = resolve_config(config_path=Path(".ash.yaml"))
+
+        assert config.project_name == "from-relative"


### PR DESCRIPTION
## Problem

`ash report --config <file>` accepts the option and then ignores it, reporting against default settings.

`resolve_config` short-circuits to the default config whenever `source_dir` is `None`, before it ever looks at `config_path` (`automated_security_helper/config/resolve_config.py`). `cli/report.py:127` passes `config_path` and no `source_dir`, so the file is never read. `cli/config.py:160` has the same call shape.

Reproduced against `main` at v3.6.0:

```
key='project_name'
   with source_dir   -> 'from-file'    # file is read
   no  source_dir    -> 'ash-scan'     # default returned, file ignored
   source_dir=None   -> 'ash-scan'     # same
```

## Fix

`source_dir` only drives *discovery* of a config file. When the caller has named one there is nothing to discover, so the short circuit now also requires `config_path` to be `None`. `source_dir` still falls back to `Path.cwd()` below, which is what resolves a relative `--config` path.

The behaviour change is limited to callers that pass `config_path` without `source_dir`, which is exactly the bug. The other six call sites (`orchestrator`, `plugin`, `mcp_tools`, `dependencies`, `install_dependencies`) all pass `source_dir` and are unaffected.

## Why it was not caught

The three pre-existing tests that cover this path wrote `project-name:` into their fixtures and asserted only `config is not None`. Two independent problems:

- `project_name` has no kebab-case alias, so `extra="ignore"` drops the hyphenated key and the field keeps its default. The fixture never set anything.
- A not-None assertion passes against the default config just as readily as against a loaded one.

They now use `project_name` and assert the value, so they fail without this change.

## Verification

- 5 new tests plus 3 strengthened ones. All 8 fail on `main` and pass here.
- Differential run of `tests/unit/config/` + `tests/unit/cli/`, same venv, separate worktrees: **488 passed on main -> 493 here**, with failures and errors identical at 87/2. Those 87 are an older `mcp` SDK in the local venv (`No module named 'mcp.server.mcpserver'`) and reproduce unchanged on pristine `main`.
- ruff 0.11.8 (the pinned pre-commit version): clean, formatted. This file was already failing ruff on `main` with 3x F401; `--fix` removed the two that are still unused and `ruff-format` reformatted it.

## Note for a follow-up

`project-name` silently doing nothing is arguably its own bug: every other config key in the docs is hyphenated. Either `project_name` should get a kebab alias or the docs should be explicit. Not changed here, since adding an alias is a separate behaviour change.

Fixes #353