### PR TITLE
fix(mcp): write command output to stderr so stdio JSON-RPC stays parseable

### DIFF
--- a/automated_security_helper/cli/mcp/__init__.py
+++ b/automated_security_helper/cli/mcp/__init__.py
@@ -17,6 +17,7 @@ supports multiple transports:
 
 from __future__ import annotations
 
+import os
 from typing import Annotated, Optional
 import typer
 from rich.console import Console
@@ -300,6 +301,17 @@ def mcp_command(
     # Handle resilient parsing for command discovery
     if ctx.resilient_parsing:
         return
+
+    # The MCP server runs scans in-process: mcp_tools hands run_ash_scan to
+    # loop.run_in_executor, which is a thread in this same process. That scan calls
+    # get_logger and attaches a RichHandler to the shared "ash" logger, so without
+    # this every log record from the scan phase, suppression matching and the
+    # reporters would be written to stdout -- inside the JSON-RPC stream on the
+    # stdio transport, which is the reported "Expecting value" failure.
+    #
+    # Set before the transport is chosen so it also covers the HTTP transports,
+    # where it is harmless, and before any scan can start.
+    os.environ["ASH_LOG_TO_STDERR"] = "1"
 
     # Check for MCP dependencies using our validation function
     if not validate_mcp_dependencies():

--- a/automated_security_helper/cli/mcp/__init__.py
+++ b/automated_security_helper/cli/mcp/__init__.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 from typing import Annotated, Optional
 import typer
-from rich import print
+from rich.console import Console
 
 from automated_security_helper.core.enums import AshLogLevel
 from automated_security_helper.core.exceptions import ScannerError, ASHValidationError
@@ -35,6 +35,14 @@ except ImportError:  # pragma: no cover - exercised only when MCP missing
 
 # Configure module logger
 _logger = ASH_LOGGER
+
+# Everything this command writes goes to stderr. On the stdio transport stdout is
+# the JSON-RPC channel, so one human-readable line there makes the client fail to
+# parse the stream -- the reported symptom was "Expecting value". Binding the
+# console to stderr makes that structural instead of depending on each call site
+# remembering to check --quiet, which the dependency-missing and validation-error
+# paths never did. --quiet still controls *whether* to write, not where.
+_stderr = Console(stderr=True)
 
 # Valid --transport values. Kept as a tuple so typer can render help cleanly
 # without forcing an Enum class on the public CLI surface.
@@ -124,7 +132,10 @@ def _build_auth_middleware(header_name: str, header_value: str):
                 received.encode("latin-1", errors="replace"), expected_value_bytes
             ):
                 return JSONResponse(
-                    {"error": "unauthorized", "detail": "missing or invalid auth header"},
+                    {
+                        "error": "unauthorized",
+                        "detail": "missing or invalid auth header",
+                    },
                     status_code=401,
                 )
             return await call_next(request)
@@ -292,31 +303,35 @@ def mcp_command(
 
     # Check for MCP dependencies using our validation function
     if not validate_mcp_dependencies():
-        print("[red]Error: MCP dependencies are not available.[/red]")
-        print()
-        print("MCP support is included by default in ASH v3. Try reinstalling ASH:")
-        print("  [cyan]pip install --force-reinstall automated-security-helper[/cyan]")
-        print("  [cyan]uv sync --reinstall[/cyan]")
-        print()
-        print(
+        _stderr.print("[red]Error: MCP dependencies are not available.[/red]")
+        _stderr.print()
+        _stderr.print(
+            "MCP support is included by default in ASH v3. Try reinstalling ASH:"
+        )
+        _stderr.print(
+            "  [cyan]pip install --force-reinstall automated-security-helper[/cyan]"
+        )
+        _stderr.print("  [cyan]uv sync --reinstall[/cyan]")
+        _stderr.print()
+        _stderr.print(
             "If the issue persists, check your Python environment and ASH installation."
         )
         raise typer.Exit(1)
 
     # If we reach here, MCP dependencies are available
     if not quiet:
-        print("[green]MCP dependencies found. Starting MCP server...[/green]")
+        _stderr.print("[green]MCP dependencies found. Starting MCP server...[/green]")
 
     # Validate command options for consistency
     try:
         validate_command_options(verbose, debug, quiet)
         _validate_auth_options(auth_header_name, auth_header_value)
     except ASHValidationError as e:
-        print(f"[red]Validation Error: {str(e)}[/red]")
+        _stderr.print(f"[red]Validation Error: {str(e)}[/red]")
         raise typer.Exit(3)
 
     if transport not in _VALID_TRANSPORTS:
-        print(
+        _stderr.print(
             f"[red]Validation Error: --transport must be one of {_VALID_TRANSPORTS}, got '{transport}'.[/red]"
         )
         raise typer.Exit(3)
@@ -344,7 +359,7 @@ def mcp_command(
                 auth_header_value=auth_header_value,
             )
             if not quiet:
-                print(
+                _stderr.print(
                     f"[green]Streamable-HTTP MCP server listening on "
                     f"http://{host}:{port}{mount_path}[/green]"
                 )
@@ -360,7 +375,7 @@ def mcp_command(
                 auth_header_value=auth_header_value,
             )
             if not quiet:
-                print(
+                _stderr.print(
                     f"[green]SSE MCP server listening on "
                     f"http://{host}:{port}{sse_path}[/green]"
                 )
@@ -368,30 +383,30 @@ def mcp_command(
     except KeyboardInterrupt:
         _logger.info("MCP server shutdown requested by user")
         if not quiet:
-            print("\n[yellow]MCP server shutdown requested by user[/yellow]")
+            _stderr.print("\n[yellow]MCP server shutdown requested by user[/yellow]")
         raise typer.Exit(0)
     except ScannerError as e:
         _logger.error(f"ASH Scanner Error: {str(e)}")
         if not quiet:
-            print(f"[red]ASH Scanner Error: {str(e)}[/red]")
-            print(
+            _stderr.print(f"[red]ASH Scanner Error: {str(e)}[/red]")
+            _stderr.print(
                 "[yellow]This indicates an issue with ASH configuration or dependencies.[/yellow]"
             )
         raise typer.Exit(2)
     except ASHValidationError as e:
         _logger.error(f"ASH Validation Error: {str(e)}")
         if not quiet:
-            print(f"[red]ASH Validation Error: {str(e)}[/red]")
-            print(
+            _stderr.print(f"[red]ASH Validation Error: {str(e)}[/red]")
+            _stderr.print(
                 "[yellow]This indicates invalid configuration or parameters.[/yellow]"
             )
         raise typer.Exit(3)
     except Exception as e:
         _logger.exception(f"Unexpected error starting MCP server: {str(e)}")
         if not quiet:
-            print(f"[red]Unexpected error starting MCP server: {str(e)}[/red]")
-            print(f"[red]Error type: {type(e).__name__}[/red]")
-            print(
+            _stderr.print(f"[red]Unexpected error starting MCP server: {str(e)}[/red]")
+            _stderr.print(f"[red]Error type: {type(e).__name__}[/red]")
+            _stderr.print(
                 "[yellow]Please check system resources and ASH installation.[/yellow]"
             )
         raise typer.Exit(1)

--- a/automated_security_helper/utils/log.py
+++ b/automated_security_helper/utils/log.py
@@ -375,6 +375,7 @@ def get_logger(
     simple_format: bool = False,
     file_log_level: str | int | None = None,
     truncate_log: bool = True,
+    use_stderr: bool = False,
 ) -> "ASHLogger":
     # Make the console able to encode what ASH emits before anything is written.
     configure_windows_safe_logging()
@@ -443,7 +444,27 @@ def get_logger(
     if os.environ.get("ASH_IN_CONTAINER", "NO").upper() in ["YES", "1", "TRUE"]:
         console_base_params["width"] = 150
 
-    custom_console_params = {"console": Console(**console_base_params)}
+    # The stdio MCP transport uses stdout as its JSON-RPC channel, and the MCP
+    # server runs scans in-process (mcp_tools hands run_ash_scan to
+    # loop.run_in_executor, i.e. a thread in the same process). So once a scan
+    # starts, every record this handler emits would land inside the JSON-RPC
+    # stream and the client fails to parse it -- the reported "Expecting value".
+    # Routing the command's own banner to stderr is not enough; the logger is the
+    # larger source, and it only attaches once a scan begins.
+    #
+    # Read from the environment rather than threaded through as a parameter,
+    # because the caller that knows (the mcp command) is several layers above the
+    # caller that configures logging (run_ash_scan._setup_logger), and the
+    # in-process scan inherits the same environment.
+    log_to_stderr = use_stderr or os.environ.get("ASH_LOG_TO_STDERR", "NO").upper() in [
+        "YES",
+        "1",
+        "TRUE",
+    ]
+
+    custom_console_params = {
+        "console": Console(stderr=log_to_stderr, **console_base_params)
+    }
     if SHOW_DEBUG_INFO:
         handler = RichHandler(
             show_level=not simple_format,

--- a/tests/unit/cli/mcp/test_stdout_jsonrpc_safety.py
+++ b/tests/unit/cli/mcp/test_stdout_jsonrpc_safety.py
@@ -1,0 +1,115 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""`ash mcp` must never write to stdout.
+
+Why this file exists
+--------------------
+On the stdio transport, stdout *is* the JSON-RPC channel. Anything else written
+there lands mid-stream and the client fails to parse it -- the reported symptom
+was `Expecting value`, because a human-readable line arrived where a JSON frame
+was expected.
+
+The command used `from rich import print`, which writes to stdout. The startup
+message was already gated behind `if not quiet`, and `quiet` defaults to True,
+so the default invocation was safe. That is not enough:
+
+* `validate_command_options` rejects `--quiet` combined with `--verbose` or
+  `--debug`, so anyone debugging a stdio MCP server has to pass `--no-quiet`,
+  which is exactly when the stream gets corrupted.
+* The dependency-missing and validation-error paths printed unconditionally,
+  with no `quiet` gate at all.
+
+So the destination is the bug, not the gate. These tests assert on stdout being
+empty rather than on the gate being present, so a future message added without
+a `quiet` check cannot reintroduce the failure.
+
+Why these particular paths
+--------------------------
+Each case below exits before a server is started, so none of them need a
+transport, a socket, or a running event loop. The invalid-transport path is
+useful twice over: with `--no-quiet` it emits the startup message at one line
+and then fails validation a few lines later, which covers the banner without
+blocking on a server.
+"""
+
+from unittest.mock import patch
+
+import pytest
+import typer
+
+from automated_security_helper.cli.mcp import mcp_command
+
+
+class _Ctx:
+    """Minimal stand-in for typer.Context.
+
+    mcp_command only reads ``resilient_parsing`` before the code under test.
+    """
+
+    resilient_parsing = False
+
+
+def _run(deps_available=True, **kwargs):
+    """Call the command directly and return the typer.Exit it raises.
+
+    Every parameter of mcp_command has a concrete default, so a direct call is
+    equivalent to a CLI invocation for these paths and avoids CliRunner's own
+    stream handling.
+
+    validate_mcp_dependencies is always patched rather than left to the
+    environment. Without that, a runner whose `mcp` package does not import
+    exits at the dependency gate and never reaches the path under test, so the
+    assertions would pass or fail based on what happens to be installed.
+    """
+    with patch(
+        "automated_security_helper.cli.mcp.validate_mcp_dependencies",
+        return_value=deps_available,
+    ):
+        with pytest.raises(typer.Exit) as excinfo:
+            mcp_command(ctx=_Ctx(), **kwargs)
+    return excinfo.value
+
+
+class TestNothingIsWrittenToStdout:
+    def test_invalid_transport_error_avoids_stdout(self, capsys):
+        exc = _run(transport="not-a-transport")
+
+        captured = capsys.readouterr()
+        assert exc.exit_code == 3
+        assert captured.out == ""
+        assert "not-a-transport" in captured.err
+
+    def test_startup_message_avoids_stdout_when_not_quiet(self, capsys):
+        """The regression case from the issue.
+
+        --no-quiet is the only way to combine MCP with --verbose/--debug, so
+        this is the path a user debugging a stdio server actually takes.
+        """
+        exc = _run(quiet=False, transport="not-a-transport")
+
+        captured = capsys.readouterr()
+        assert exc.exit_code == 3
+        assert captured.out == ""
+        # Both the startup message and the error land on stderr.
+        assert "Starting MCP server" in captured.err
+        assert "not-a-transport" in captured.err
+
+    def test_conflicting_quiet_and_verbose_error_avoids_stdout(self, capsys):
+        exc = _run(quiet=True, verbose=True)
+
+        captured = capsys.readouterr()
+        assert exc.exit_code == 3
+        assert captured.out == ""
+        assert "quiet" in captured.err.lower()
+
+    def test_missing_dependency_guidance_avoids_stdout(self, capsys):
+        """This path had no `quiet` gate at all, so the gate was never the fix."""
+        exc = _run(deps_available=False)
+
+        captured = capsys.readouterr()
+        assert exc.exit_code == 1
+        assert captured.out == ""
+        assert "MCP dependencies are not available" in captured.err
+        # The remediation guidance has to be readable, just not on stdout.
+        assert "force-reinstall" in captured.err

--- a/tests/unit/cli/mcp/test_stdout_jsonrpc_safety.py
+++ b/tests/unit/cli/mcp/test_stdout_jsonrpc_safety.py
@@ -33,12 +33,56 @@ and then fails validation a few lines later, which covers the banner without
 blocking on a server.
 """
 
+import os
 from unittest.mock import patch
 
 import pytest
 import typer
 
 from automated_security_helper.cli.mcp import mcp_command
+from automated_security_helper.utils.log import get_logger
+
+
+class TestTheLoggerHonoursTheStderrSwitch:
+    """The logger is the larger stdout source, and it only attaches during a scan."""
+
+    def test_records_go_to_stderr_when_the_switch_is_set(self, capsys):
+        original = os.environ.get("ASH_LOG_TO_STDERR")
+        os.environ["ASH_LOG_TO_STDERR"] = "1"
+        try:
+            # A fresh name each time: loggers are cached, so reusing one would
+            # reuse the handler built under the previous setting.
+            get_logger(name="ash-stderr-probe", show_progress=False).info("MARKER")
+        finally:
+            if original is None:
+                os.environ.pop("ASH_LOG_TO_STDERR", None)
+            else:
+                os.environ["ASH_LOG_TO_STDERR"] = original
+
+        captured = capsys.readouterr()
+        assert "MARKER" not in captured.out, (
+            "A log record reached stdout with ASH_LOG_TO_STDERR set, so it would "
+            "corrupt the JSON-RPC stream."
+        )
+        assert "MARKER" in captured.err
+
+    def test_the_cli_default_is_unchanged(self, capsys):
+        """Guard against over-correcting.
+
+        CLI users' logs belong on stdout where they have always been; only the MCP
+        path opts in. Moving everyone to stderr would be a silent behaviour change
+        for every non-MCP consumer.
+        """
+        original = os.environ.get("ASH_LOG_TO_STDERR")
+        os.environ.pop("ASH_LOG_TO_STDERR", None)
+        try:
+            get_logger(name="ash-stdout-probe", show_progress=False).info("MARKER")
+        finally:
+            if original is not None:
+                os.environ["ASH_LOG_TO_STDERR"] = original
+
+        captured = capsys.readouterr()
+        assert "MARKER" in captured.out
 
 
 class _Ctx:
@@ -102,6 +146,41 @@ class TestNothingIsWrittenToStdout:
         assert exc.exit_code == 3
         assert captured.out == ""
         assert "quiet" in captured.err.lower()
+
+    def test_the_command_redirects_the_logger_away_from_stdout(self, capsys):
+        """The banner was never the biggest source of stdout writes.
+
+        The MCP server runs scans *in-process*: mcp_tools hands run_ash_scan to
+        loop.run_in_executor, a thread in this same process. That scan calls
+        get_logger, which attaches a RichHandler to the shared "ash" logger. Before
+        this, that handler's Console was bound to stdout, so from the moment a scan
+        started every record from the scan phase, suppression matching and the
+        reporters went into the JSON-RPC stream.
+
+        Gating the command's own prints on --quiet could never have covered that,
+        because the handler does not exist until a scan begins. Asserted on the
+        command rather than on the logger so the wiring cannot be dropped.
+        """
+        original = os.environ.get("ASH_LOG_TO_STDERR")
+        try:
+            os.environ.pop("ASH_LOG_TO_STDERR", None)
+            _run(transport="not-a-transport")
+
+            assert os.environ.get("ASH_LOG_TO_STDERR", "").upper() in (
+                "YES",
+                "1",
+                "TRUE",
+            ), (
+                "The mcp command does not redirect logging to stderr, so an "
+                "in-process scan will write its log records into the JSON-RPC "
+                "stream."
+            )
+        finally:
+            if original is None:
+                os.environ.pop("ASH_LOG_TO_STDERR", None)
+            else:
+                os.environ["ASH_LOG_TO_STDERR"] = original
+        capsys.readouterr()
 
     def test_missing_dependency_guidance_avoids_stdout(self, capsys):
         """This path had no `quiet` gate at all, so the gate was never the fix."""


### PR DESCRIPTION
## Problem

`ash mcp` wrote to **stdout**. On the stdio transport stdout is the JSON-RPC channel, so those writes land where a JSON frame is expected and the client fails with `Expecting value`.

## Two sources, and the second is the bigger one

**1. The command's own output.** `from rich import print` writes to stdout. `quiet` defaults to `True`, so the plain invocation was safe — but `validate_command_options` rejects `--quiet` together with `--verbose`/`--debug`, so anyone debugging a stdio server must pass `--no-quiet`, which is exactly when it breaks. The dependency-missing and validation paths printed with no `quiet` check at all. Fixed with a `Console(stderr=True)`; all 20 call sites use it.

**2. The logger — and this is the one that reproduces the reported failure.** An earlier revision of this PR stopped at (1), which was not enough.

The MCP server runs scans **in-process**: `mcp_tools` hands `run_ash_scan` to `loop.run_in_executor`, a thread in the same process as the JSON-RPC stream. That scan calls `get_logger`, which attaches a `RichHandler` whose `Console` was bound to stdout. So from the moment a scan starts, every record from the scan phase, suppression matching and the reporters goes into the JSON-RPC stream.

Gating prints on `--quiet` could never have covered this, because that handler does not exist until a scan begins. `ASH_LOGGER` starts handler-free, which is why the command's own `_logger.info` calls were harmless and why this looked finished.

`get_logger` now takes `use_stderr` and also honours `ASH_LOG_TO_STDERR`. The env var carries it rather than a threaded parameter because the caller that knows (the `mcp` command) sits several layers above the one that configures logging (`run_ash_scan._setup_logger`), and the in-process scan inherits the environment. The command sets it before the transport is chosen, so it covers the HTTP transports too, where it is harmless.

## The CLI default is deliberately unchanged

With the switch unset, records still go to stdout where they always have. Moving every consumer to stderr would be a silent behaviour change for everyone not using MCP, so there is a test pinning the default as well as the redirect.

Verified by running the logger three ways: default → stdout; `ASH_LOG_TO_STDERR=1` → stderr with **stdout clean**; explicit `use_stderr=True` → stderr.

## Tests

7 tests. They assert **stdout is empty** rather than that a `quiet` check exists, so a message added later without a gate cannot reintroduce the bug. Each exits before a server starts, so none needs a socket or an event loop.

They also patch `validate_mcp_dependencies` instead of reading the environment — without that, a runner whose `mcp` package fails to import exits at the dependency gate and never reaches the path under test, so the assertions would pass for the wrong reason. I hit exactly that while writing them.

## Verification

Differential over the full unit suite, separate worktrees, same venv: **`main` 2881 passed → 2888 here**, failures and errors identical at 87 and 2. Those 87 are an older `mcp` SDK in the local venv and reproduce unchanged on `main`.

ruff 0.11.8 clean. It also reformatted one unrelated `JSONResponse` call in `_build_auth_middleware`; this file was already failing `format --check` on `main`.

Fixes #345