### PR TITLE
fix(homebrew): bump the tap to v3.6.0 and keep it bumped

### DIFF
--- a/Formula/ash.rb
+++ b/Formula/ash.rb
@@ -3,7 +3,11 @@ class Ash < Formula
 
   desc "Automated Security Helper - security scanning tool for code repositories"
   homepage "https://github.com/awslabs/automated-security-helper"
-  url "https://github.com/awslabs/automated-security-helper.git", tag: "v3.4.1"
+  # Kept current by `cz bump` via [tool.commitizen] version_files in
+  # pyproject.toml. tests/unit/test_homebrew_formula_version.py fails if this
+  # drifts from the packaged version, because a stale-but-real tag installs an
+  # old ASH without failing anything.
+  url "https://github.com/awslabs/automated-security-helper.git", tag: "v3.6.0"
   license "Apache-2.0"
 
   depends_on "python@3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,11 @@ automated-security-helper = "automated_security_helper.cli.main:app"
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "3.6.0"
-version_files = ["pyproject.toml:^version"]
+# Formula/ash.rb pins the git tag Homebrew builds from. It was absent here, so
+# releases bumped the package and left the tap on an older tag until `brew
+# install` broke. The `tag:` pattern matches the url line; commitizen rewrites
+# the version substring within it and leaves the leading "v" alone.
+version_files = ["pyproject.toml:^version", "Formula/ash.rb:tag:"]
 tag_format = "v$version"
 changelog_file = "CHANGELOG.md"
 update_changelog_on_bump = true

--- a/tests/unit/test_homebrew_formula_version.py
+++ b/tests/unit/test_homebrew_formula_version.py
@@ -1,0 +1,101 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Homebrew formula must point at the version this repository ships.
+
+Why this file exists
+--------------------
+`Formula/ash.rb` pins the git tag Homebrew builds from. Nothing updated it: the
+commitizen `version_files` list covered `pyproject.toml` only, so every release
+bumped the package and left the formula behind. It reached v3.4.1 while the
+repository was on v3.6.0, and `brew install` broke for anyone using the tap.
+
+A stale tag does not fail any build. Homebrew resolves it happily -- it is a
+real tag -- and just installs an old ASH, so the only signal is a user
+reporting it. This test converts that into a failing check at the point the
+drift is introduced.
+
+Reading the version
+-------------------
+The comparison reads `pyproject.toml` directly rather than calling
+`version_management.get_version()`. get_version() prefers installed package
+metadata over pyproject, so in any environment where ASH is installed from
+somewhere other than this checkout it reports that other version, and the test
+would compare the formula against an unrelated number.
+
+If this test fails after a release
+----------------------------------
+The formula did not get bumped. Check that `Formula/ash.rb` is still listed
+under `[tool.commitizen] version_files` in pyproject.toml; if the entry was
+removed or its pattern stopped matching the `tag:` line, `cz bump` silently
+skips the file rather than reporting anything.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:  # pragma: no cover - exercised only on 3.10
+    import tomli as tomllib
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FORMULA_PATH = REPO_ROOT / "Formula" / "ash.rb"
+PYPROJECT_PATH = REPO_ROOT / "pyproject.toml"
+
+# `url "...git", tag: "v3.6.0"` -- captures the tag without the leading v.
+_FORMULA_TAG = re.compile(r'tag:\s*"v(?P<version>[^"]+)"')
+
+
+def _formula_tag_version() -> str:
+    text = FORMULA_PATH.read_text(encoding="utf-8")
+    match = _FORMULA_TAG.search(text)
+    assert match is not None, (
+        f'No `tag: "v<version>"` found in {FORMULA_PATH}. If the formula moved '
+        "to a release tarball with a sha256 instead of a git tag, this test needs "
+        "to read whichever field now carries the version."
+    )
+    return match.group("version")
+
+
+def _pyproject_version() -> str:
+    with PYPROJECT_PATH.open("rb") as handle:
+        data = tomllib.load(handle)
+    return data["project"]["version"]
+
+
+@pytest.mark.skipif(
+    not FORMULA_PATH.exists(),
+    reason="Formula/ash.rb is absent; the tap is not maintained in-tree",
+)
+class TestHomebrewFormulaTracksPackageVersion:
+    def test_formula_tag_matches_pyproject_version(self):
+        formula_version = _formula_tag_version()
+        package_version = _pyproject_version()
+
+        assert formula_version == package_version, (
+            f"Formula/ash.rb builds from v{formula_version} but this repository "
+            f"is version {package_version}. `brew install` would fetch the older "
+            "release. Bump the tag in Formula/ash.rb, and confirm the file is "
+            "listed under [tool.commitizen] version_files so the next release "
+            "does this automatically."
+        )
+
+    def test_commitizen_bumps_the_formula(self):
+        """The prevention half of the fix, asserted directly.
+
+        Without this, a future edit could drop Formula/ash.rb from version_files
+        and the test above would only start failing one release later, by which
+        point the cause is no longer in the recent history.
+        """
+        with PYPROJECT_PATH.open("rb") as handle:
+            data = tomllib.load(handle)
+        version_files = data["tool"]["commitizen"]["version_files"]
+
+        assert any("Formula/ash.rb" in entry for entry in version_files), (
+            "Formula/ash.rb is not in [tool.commitizen] version_files, so "
+            f"`cz bump` will not update it. Current entries: {version_files}"
+        )


### PR DESCRIPTION
## Problem

`Formula/ash.rb` builds from tag **v3.4.1** while this repository is on **v3.6.0**, so `brew install` fetches a release two minor versions old. @Virta's comment on the issue ("the tap file is outdated") is exactly right.

## Cause

`Formula/ash.rb` was never listed in `[tool.commitizen] version_files`, which covered `pyproject.toml` alone:

```toml
version_files = ["pyproject.toml:^version"]
```

So every release bumped the package and left the tap behind. This was not a one-off mistake; it drifts by construction on every release.

## Fix

Three parts, because bumping the tag alone would just drift again:

1. Formula tag -> `v3.6.0`.
2. `Formula/ash.rb:tag:` added to `version_files`, so `cz bump` rewrites it from now on.
3. Two tests, so drift fails a check instead of waiting for a bug report.

## On verifying the version_files pattern

I did not assume the pattern works. `cz bump` **cannot run in this repository**: there is a floating `v3` tag, and commitizen rejects it before writing anything:

```
bump: version 3.6.0 -> 3.6.1
tag to create: v3.6.1
increment detected: PATCH

Invalid version tag: 'v3' does not match any configured tag format
No commits found
```

That reproduces **unchanged on pristine `main`**, so it is pre-existing and out of scope here, but it did mean the new entry could not be exercised in place. I verified it in a scratch repository with conforming tags instead:

```
BEFORE:  tag: "v1.0.0"
cz bump --files-only  ->  bump: version 1.0.0 -> 1.0.1
AFTER:   tag: "v1.0.1"
```

The version substring is replaced and the leading `v` is preserved. The formula has exactly one line containing `tag:`, so the pattern matches once.

That `v3` tag rejection probably deserves its own issue — 5 of the 64 tags in this repo do not match `tag_format` or `legacy_tag_formats`. I have not investigated why releases still succeed in CI and did not want to guess at it here.

## Tests

- `test_formula_tag_matches_pyproject_version` — a stale tag is still a *real* tag, so Homebrew resolves it happily and installs an old ASH. Nothing fails; the only signal is a user report. This makes it a failing check.
- `test_commitizen_bumps_the_formula` — asserts the file is still in `version_files`, so removing it fails immediately rather than one release later when the cause has left the recent history.

The version is read from `pyproject.toml` directly rather than via `version_management.get_version()`, which prefers installed package metadata and would compare the formula against whatever ASH happens to be installed in the test environment.

Both fail on `main`, pass here. ruff 0.11.8: clean, formatted.

Fixes #401