### PR TITLE
fix(config): lint and auto-fix suppression reasons that span multiple lines

### DIFF
--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -20,7 +20,10 @@ from automated_security_helper.config.ash_config import (
     ReporterConfigSegment,
     ScannerConfigSegment,
 )
-from automated_security_helper.config.resolve_config import find_config_file, resolve_config
+from automated_security_helper.config.resolve_config import (
+    find_config_file,
+    resolve_config,
+)
 from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
 from automated_security_helper.core.exceptions import ASHConfigValidationError
 from automated_security_helper.utils.log import get_logger
@@ -418,7 +421,7 @@ def lint(
         bool,
         typer.Option(
             "--fix",
-            help="Auto-fix fixable issues (internal fields, missing line_end, expired suppressions)",
+            help="Auto-fix fixable issues (internal fields, missing line_end, expired suppressions, multi-line suppression reasons)",
         ),
     ] = False,
     fix_unused: Annotated[
@@ -453,10 +456,11 @@ def lint(
     - Duplicate field definitions
     - Suppressions with line_start but missing line_end
     - Expired suppressions
+    - Suppression reasons spanning multiple lines
     - Unused suppressions (from last scan report)
 
     Use --fix to auto-fix common issues (removes internal fields, sets missing
-    line_end, removes expired suppressions).
+    line_end, removes expired suppressions, collapses multi-line reasons).
 
     Use --fix-unused to remove suppressions that are no longer matching any
     findings (based on the unused suppressions report from the last scan).
@@ -683,8 +687,6 @@ def _apply_unused_fixes(
     )
 
 
-
-
 def _get_scanner_names() -> List[tuple]:
     """Return (python_name, display_name) tuples for built-in scanners.
 
@@ -848,8 +850,10 @@ def wizard(
         "  Offline mode skips tool installation. Set the ASH_OFFLINE "
         "environment variable at runtime to activate it."
     )
-    current_offline = (
-        os.environ.get("ASH_OFFLINE", "NO").upper() in ("YES", "TRUE", "1")
+    current_offline = os.environ.get("ASH_OFFLINE", "NO").upper() in (
+        "YES",
+        "TRUE",
+        "1",
     )
     enable_offline = typer.confirm(
         "  Set ASH_OFFLINE=YES in the generated config comments as a reminder?",
@@ -911,7 +915,9 @@ def wizard(
         "# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json",
     ]
     if enable_offline:
-        config_strings.append("# Reminder: export ASH_OFFLINE=YES before running ASH for offline mode")
+        config_strings.append(
+            "# Reminder: export ASH_OFFLINE=YES before running ASH for offline mode"
+        )
 
     config_strings.append(
         yaml.dump(
@@ -945,8 +951,6 @@ def wizard(
 
 if __name__ == "__main__":
     config_app()
-
-
 
 
 if __name__ == "__main__":

--- a/automated_security_helper/config/config_linter.py
+++ b/automated_security_helper/config/config_linter.py
@@ -45,6 +45,7 @@ class LintCategory(str, Enum):
     SUPPRESSION_LINE_RANGE = "suppression-line-range"
     SUPPRESSION_EXPIRED = "suppression-expired"
     SUPPRESSION_UNUSED = "suppression-unused"
+    SUPPRESSION_MULTILINE_REASON = "suppression-multiline-reason"
     IGNORE_PATH_ISSUE = "ignore-path-issue"
     LEGACY_NAME_VARIANT = "legacy-name-variant"
     LEGACY_NAME_CONFLICT = "legacy-name-conflict"
@@ -216,6 +217,10 @@ class ConfigLinter:
 
             elif issue.category == LintCategory.SUPPRESSION_LINE_RANGE:
                 if cls._fix_suppression_line_range(config_data, issue):
+                    fixed_issues.append(issue)
+
+            elif issue.category == LintCategory.SUPPRESSION_MULTILINE_REASON:
+                if cls._fix_suppression_reason_newline(config_data, issue):
                     fixed_issues.append(issue)
 
             elif issue.category == LintCategory.LEGACY_NAME_VARIANT:
@@ -603,6 +608,40 @@ class ConfigLinter:
                         path=path_prefix,
                         fixable=True,
                         fix_description=f"Set line_end = {line_start} (same as line_start)",
+                    )
+                )
+
+            # Check: reason spanning multiple lines. The unused-suppressions
+            # reporter emits it as a single markdown bullet
+            # (`- **Reason**: {reason}`), so an embedded newline ends the bullet
+            # and the remainder renders as loose body text, detached from the
+            # suppression it describes.
+            #
+            # Only *interior* newlines are flagged. A YAML block scalar always
+            # ends with one under default clip chomping, so `reason: > ...` and
+            # single-line `reason: | ...` both carry a trailing newline while
+            # rendering perfectly well. Flagging those would warn on the common
+            # case for no benefit.
+            #
+            # A block scalar is a reasonable way to write a long justification,
+            # so this is a fixable warning rather than a validation error.
+            reason = suppression.get("reason")
+            if isinstance(reason, str) and (
+                "\n" in reason.strip() or "\r" in reason.strip()
+            ):
+                result.issues.append(
+                    LintIssue(
+                        severity=LintSeverity.WARNING,
+                        category=LintCategory.SUPPRESSION_MULTILINE_REASON,
+                        message=(
+                            "Suppression 'reason' spans multiple lines, which breaks "
+                            "its bullet in ash.unused-suppressions.md - the text "
+                            "after the first newline renders detached from the "
+                            "suppression"
+                        ),
+                        path=path_prefix,
+                        fixable=True,
+                        fix_description="Collapse the reason onto a single line",
                     )
                 )
 
@@ -1037,6 +1076,48 @@ class ConfigLinter:
                 suppression["line_end"] = suppression["line_start"]
                 return True
         return False
+
+    @staticmethod
+    def _collapse_reason_whitespace(reason: str) -> str:
+        """Collapse a reason onto one line.
+
+        Every run of whitespace becomes a single space and the result is
+        stripped. str.split() with no argument already splits on newlines,
+        carriage returns and tabs, which is what makes this safe for a CRLF file
+        as well as a YAML block scalar. Block scalars always end in a newline, so
+        the strip is load-bearing rather than cosmetic.
+        """
+        return " ".join(reason.split())
+
+    @classmethod
+    def _fix_suppression_reason_newline(
+        cls, config_data: Dict[str, Any], issue: LintIssue
+    ) -> bool:
+        """Collapse a multi-line suppression reason onto a single line."""
+        idx = cls._parse_suppression_index(issue.path)
+        if idx is None:
+            return False
+
+        suppressions = config_data.get("global_settings", {}).get("suppressions", [])
+        if idx >= len(suppressions):
+            return False
+
+        suppression = suppressions[idx]
+        if not isinstance(suppression, dict):
+            return False
+
+        reason = suppression.get("reason")
+        if not isinstance(reason, str):
+            return False
+
+        collapsed = cls._collapse_reason_whitespace(reason)
+        if collapsed == reason:
+            # Nothing to do. Reporting success here would make
+            # `ash config lint --fix` claim a fix it did not make.
+            return False
+
+        suppression["reason"] = collapsed
+        return True
 
     @classmethod
     def _fix_expired_suppression(

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/unused_suppressions_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/unused_suppressions_reporter.py
@@ -17,6 +17,26 @@ from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.models.core import AshSuppression
 
 
+def _one_line(text: str | None) -> str:
+    """Flatten prose so it survives being interpolated into a markdown bullet.
+
+    A newline in a suppression reason ends its bullet, and the remainder renders
+    as loose body text detached from the suppression it describes.
+
+    Collapsing at the point of rendering fixes the report for every existing
+    config, with no edit to anyone's file. The config linter also warns about a
+    multi-line reason and offers to collapse it, but that only helps someone who
+    runs the linter and accepts the fix -- and `ash config lint --fix` re-dumps
+    the whole config, dropping every comment in it. A hand-written block-scalar
+    reason is a strong signal of a hand-commented config, which is exactly the
+    file you least want rewritten.
+
+    str.split() with no argument splits on newlines, carriage returns and tabs,
+    so this handles a CRLF config as well as a YAML block scalar.
+    """
+    return " ".join((text or "").split())
+
+
 class UnusedSuppressionsReporterConfigOptions(ReporterOptionsBase):
     """Configuration options for the Unused Suppressions reporter."""
 
@@ -176,7 +196,7 @@ class UnusedSuppressionsReporter(ReporterPluginBase[UnusedSuppressionsReporterCo
                 else:
                     lines.append("- **Lines**: Any")
 
-                lines.append(f"- **Reason**: {suppression.reason}")
+                lines.append(f"- **Reason**: {_one_line(suppression.reason)}")
 
                 if suppression.expiration:
                     lines.append(f"- **Expiration**: {suppression.expiration}")

--- a/tests/unit/config/test_config_linter_reason_newline.py
+++ b/tests/unit/config/test_config_linter_reason_newline.py
@@ -1,0 +1,230 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A suppression `reason` containing a newline is a reporting hazard.
+
+Why this file exists
+--------------------
+The unused-suppressions reporter emits the reason as one markdown bullet
+(`- **Reason**: {reason}` in unused_suppressions_reporter.py), so an embedded
+newline ends the bullet and everything after it renders as loose body text,
+detached from the suppression it belongs to. Nothing caught this:
+`AshSuppression.reason` is a plain `str` with no content validation, and
+`ash config validate` reported "Configuration is valid!".
+
+The issue describes this as a broken markdown *table* row. That is close but not
+where it happens -- grepping the reporters shows `reason` is never rendered into
+a table, only into that bullet. The failure is the same either way, and so is
+the fix, but the check message names the bullet so a reader is not sent looking
+for a table.
+
+Interior newlines only
+----------------------
+A YAML block scalar always ends with a newline under default clip chomping, so
+`reason: >` and a single-line `reason: |` both produce a trailing newline while
+rendering perfectly well. The check strips before looking, otherwise it would
+warn on the common case for no benefit.
+
+Why lint rather than reject
+---------------------------
+The config is not *invalid* -- block scalars are a reasonable way to write a long
+justification, and rejecting them outright would break configs that work fine
+for every consumer other than that one reporter. So this is a fixable warning,
+matching how the linter already treats a missing `line_end`: tell the user, and
+collapse it for them under `--fix`.
+
+Collapsing rather than escaping is deliberate. The reason is prose meant for a
+human reading a report, so whitespace carries no meaning worth preserving, and a
+single space keeps it readable in the one place it renders. Escaping to `<br>`
+would leak markdown into a field that also appears in JSON and SARIF output.
+"""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.config.config_linter import (
+    ConfigLinter,
+    LintCategory,
+    LintSeverity,
+)
+
+
+def _write_config(tmp_path: Path, suppressions_yaml: str) -> Path:
+    body = textwrap.indent(textwrap.dedent(suppressions_yaml).rstrip("\n"), " " * 4)
+    config_path = tmp_path / ".ash.yaml"
+    config_path.write_text(
+        "project_name: reason-newline-probe\n"
+        "global_settings:\n"
+        "  suppressions:\n" + body + "\n",
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _reason_issues(config_path: Path):
+    result = ConfigLinter.lint(config_path)
+    return [
+        issue
+        for issue in result.issues
+        if issue.category == LintCategory.SUPPRESSION_MULTILINE_REASON
+    ]
+
+
+class TestMultilineReasonIsFlagged:
+    def test_block_scalar_reason_is_flagged(self, tmp_path):
+        """The exact shape from the issue report: a `|` block scalar."""
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/foo.py"
+              rule_id: "B201"
+              reason: |
+                Multi-line reason
+                with a newline.
+            """,
+        )
+
+        issues = _reason_issues(config_path)
+
+        assert len(issues) == 1
+        assert issues[0].severity == LintSeverity.WARNING
+        assert issues[0].fixable is True
+        assert "global_settings.suppressions[0]" == issues[0].path
+
+    def test_single_line_reason_is_not_flagged(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/foo.py"
+              rule_id: "B201"
+              reason: "A perfectly ordinary reason"
+            """,
+        )
+
+        assert _reason_issues(config_path) == []
+
+    def test_folded_scalar_reason_is_not_flagged(self, tmp_path):
+        """`>` folds the interior newlines but still leaves a trailing one.
+
+        The loaded value here is "...source lines.\\n", so a naive `"\\n" in
+        reason` check flags it. It renders correctly, because a trailing newline
+        just ends the bullet where the bullet was going to end anyway. This
+        passes because the check strips first, and that is the whole reason the
+        strip is there.
+        """
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/foo.py"
+              rule_id: "B201"
+              reason: >
+                A long reason that happens to be
+                wrapped across source lines.
+            """,
+        )
+
+        assert _reason_issues(config_path) == []
+
+    def test_only_the_offending_entry_is_flagged(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/a.py"
+              rule_id: "B101"
+              reason: "Fine"
+            - path: "src/b.py"
+              rule_id: "B102"
+              reason: |
+                Broken
+                across lines.
+            - path: "src/c.py"
+              rule_id: "B103"
+              reason: "Also fine"
+            """,
+        )
+
+        issues = _reason_issues(config_path)
+
+        assert len(issues) == 1
+        assert issues[0].path == "global_settings.suppressions[1]"
+
+    def test_carriage_return_reason_is_flagged(self, tmp_path):
+        """A CRLF file should not smuggle a newline past the check."""
+        config_path = tmp_path / ".ash.yaml"
+        config_path.write_bytes(
+            b"project_name: crlf-probe\r\n"
+            b"global_settings:\r\n"
+            b"  suppressions:\r\n"
+            b'    - path: "src/foo.py"\r\n'
+            b'      rule_id: "B201"\r\n'
+            b'      reason: "first\\nsecond"\r\n'
+        )
+
+        assert len(_reason_issues(config_path)) == 1
+
+
+class TestMultilineReasonIsFixed:
+    def test_fix_collapses_the_newline(self, tmp_path):
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/foo.py"
+              rule_id: "B201"
+              reason: |
+                Multi-line reason
+                with a newline.
+            """,
+        )
+
+        fixed_content, fixed_issues = ConfigLinter.fix(config_path)
+
+        assert any(
+            issue.category == LintCategory.SUPPRESSION_MULTILINE_REASON
+            for issue in fixed_issues
+        )
+        # The rendered reason must survive as one line of readable prose.
+        assert "Multi-line reason with a newline." in fixed_content
+
+    def test_fixed_config_lints_clean(self, tmp_path):
+        """Applying the fix has to actually clear the warning.
+
+        A fix that reports success without changing the loaded value would leave
+        `ash config lint --fix` looping on the same warning forever.
+        """
+        config_path = _write_config(
+            tmp_path,
+            """\
+            - path: "src/foo.py"
+              rule_id: "B201"
+              reason: |
+                Multi-line reason
+                with a newline.
+            """,
+        )
+
+        fixed_content, _ = ConfigLinter.fix(config_path)
+        config_path.write_text(fixed_content, encoding="utf-8")
+
+        assert _reason_issues(config_path) == []
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("one\ntwo", "one two"),
+        ("one\r\ntwo", "one two"),
+        ("trailing newline\n", "trailing newline"),
+        ("  padded \n out  ", "padded out"),
+        ("collapse\n\n\nruns", "collapse runs"),
+        ("already fine", "already fine"),
+    ],
+)
+def test_collapse_helper(raw, expected):
+    """Pin the collapse rule directly, including the whitespace-run cases.
+
+    A block scalar always ends with a newline, so "trailing newline\\n" is the
+    common case rather than an edge case, and it must not become "x ".
+    """
+    assert ConfigLinter._collapse_reason_whitespace(raw) == expected

--- a/tests/unit/config/test_config_linter_reason_newline.py
+++ b/tests/unit/config/test_config_linter_reason_newline.py
@@ -217,6 +217,39 @@ class TestMultilineReasonIsFixed:
         ("one\r\ntwo", "one two"),
         ("trailing newline\n", "trailing newline"),
         ("  padded \n out  ", "padded out"),
+        ("leading\n\nnewlines", "leading newlines"),
+        (None, ""),
+        ("", ""),
+    ],
+)
+def test_the_reporter_flattens_the_reason_on_render(raw, expected):
+    """The linter warning is advisory; this is where the bug is actually fixed.
+
+    The defect is in the reporter: it interpolates the reason into a single
+    markdown bullet, so a newline ends that bullet. Fixing it here repairs the
+    report for every config that already exists, without asking anyone to edit
+    their file or run `--fix` (which re-dumps the config and drops its comments).
+
+    Note this also handles the *leading*-newline case, which the linter's check
+    deliberately does not flag: `reason.strip()` tolerates newlines at either end
+    so the common trailing-newline-from-a-block-scalar does not warn, but a
+    leading newline still breaks the bullet. Fixing it at the render point covers
+    both without making the warning noisier.
+    """
+    from automated_security_helper.plugin_modules.ash_builtin.reporters.unused_suppressions_reporter import (
+        _one_line,
+    )
+
+    assert _one_line(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("one\ntwo", "one two"),
+        ("one\r\ntwo", "one two"),
+        ("trailing newline\n", "trailing newline"),
+        ("  padded \n out  ", "padded out"),
         ("collapse\n\n\nruns", "collapse runs"),
         ("already fine", "already fine"),
     ],


### PR DESCRIPTION
## Problem

A suppression `reason` containing a newline passes `ash config validate` ("Configuration is valid!") and then breaks its own report.

## One correction to the report

The issue says the reason lands in a markdown **table** cell. It does not -- `reason` is never rendered into a table anywhere in the tree. The single place it renders is a bullet in the unused-suppressions reporter:

```python
lines.append(f"- **Reason**: {suppression.reason}")
```

An embedded newline ends that bullet, and the remainder renders as loose body text detached from the suppression it describes. Same failure, same fix; I mention it only because the warning message names the bullet, so nobody goes looking for a table that isn't there.

## Fix

A new fixable `suppression-multiline-reason` warning, following the existing `line_end` check: warn, and collapse it under `--fix`.

### Interior newlines only

This is the part worth reviewing. A YAML block scalar **always** ends with a newline under default clip chomping, so a naive `"\n" in reason` warns on:

```yaml
reason: >
  A long reason that happens to be
  wrapped across source lines.
```

which loads as `"A long reason that happens to be wrapped across source lines.\n"` and renders perfectly well -- a trailing newline just ends the bullet where it was going to end anyway. I only found this because the test I wrote asserting `>` is *not* flagged failed, so I checked the loaded value instead of trusting my assumption that the fold removed it. The check now strips before looking.

Net effect: `reason: |` with two lines warns, `reason: >` and single-line `reason: |` do not.

### Collapse, not escape

Whitespace runs become single spaces. Escaping to `<br>` was the alternative and is wrong here: the same field is emitted to JSON and SARIF, where markdown would leak into consumers that never render it.

`_fix_suppression_reason_newline` returns `False` when the collapse is a no-op, so `--fix` cannot report a change it did not make -- otherwise `ash config lint --fix` would keep claiming to fix the same warning.

## Tests

13 tests in `tests/unit/config/test_config_linter_reason_newline.py`: the block-scalar case from the issue, the folded-scalar and single-line non-cases, multi-entry indexing, a CRLF file, the fix itself, a round-trip asserting the fixed config lints clean, and the collapse rule pinned directly including the trailing-newline and whitespace-run cases.

`--fix` help text and the command docstring now list the new category alongside the existing ones.

## Verification

- 129 passed across `tests/unit/config/` + `tests/unit/cli/test_config_lint.py`, no regressions.
- ruff 0.11.8: clean, formatted. It also reformatted `cli/config.py`, which was **already** failing `format --check` on `main`.

Fixes #346

---

## Update after review

The linter warning alone does not fix anyone's report. It only helps someone who runs `ash config lint` *and* accepts `--fix` — and `--fix` re-dumps the whole config, dropping every comment in it. A hand-written block-scalar `reason` is a strong signal of a hand-commented config, which is the file you least want rewritten.

So the reporter is fixed too. `unused_suppressions_reporter.py` gains a module-level `_one_line()` that collapses the reason at the point of rendering, which repairs the markdown for every config that already exists with no edit to anyone's file.

The warning stays, because telling the user their config has a latent formatting hazard is still worth doing.

`_one_line()` also covers a case the linter's check deliberately does not flag: a **leading** newline. The check does `reason.strip()` before looking, so the near-universal trailing newline from a YAML block scalar does not warn — but a leading newline still breaks the bullet. Fixing it at the render point covers both without making the warning noisier.