### PR TITLE
fix(sarif): relativize absolute URIs whose path crosses a symlink

### DIFF
--- a/automated_security_helper/utils/sarif_utils.py
+++ b/automated_security_helper/utils/sarif_utils.py
@@ -40,9 +40,7 @@ def get_finding_id(
     end_line: int | None = None,
 ) -> str:
     seed = "::".join(
-        str(item)
-        for item in [rule_id, file, start_line, end_line]
-        if item is not None
+        str(item) for item in [rule_id, file, start_line, end_line] if item is not None
     )
     rd = random.Random()  # nosec B311 — seeded PRNG for deterministic finding IDs, not security
     rd.seed(seed)
@@ -76,8 +74,28 @@ def _sanitize_uri(uri: str, source_dir_path: Path, source_dir_str: str) -> str:
         # Try to resolve the path and make it relative
         path_obj = Path(uri)
         if path_obj.is_absolute():
-            with suppress(ValueError):
+            try:
                 uri = str(path_obj.relative_to(source_dir_path))
+            except ValueError:
+                # relative_to is purely lexical, and the two sides need not be
+                # spelled the same way. sanitize_sarif_paths resolves
+                # source_dir, but a scanner's URI is whatever spelling the
+                # scanner was handed: on macOS a scan of /tmp/x reports
+                # /tmp/x/... while source_dir resolves to /private/tmp/x, so the
+                # lexical comparison raises and the URI was left absolute. An
+                # absolute URI then never matches a suppression `path`, which is
+                # written relative to the source directory.
+                #
+                # Resolving the URI puts both sides in the same namespace.
+                # resolve() is non-strict, so a path whose final component no
+                # longer exists still resolves; OSError is caught for the cases
+                # where it can still fail, such as a symlink loop or a path the
+                # process cannot stat.
+                #
+                # Only reached when the lexical form already failed, so the
+                # common case pays nothing for it.
+                with suppress(ValueError, OSError):
+                    uri = str(path_obj.resolve().relative_to(source_dir_path))
         elif uri.startswith(source_dir_str):
             uri = uri.removeprefix(source_dir_str)
     except Exception as e:
@@ -244,10 +262,10 @@ def _resolve_result_severity(result) -> str:
     if result.properties:
         props = result.properties
         if isinstance(props, PropertyBag):
-            props = props.model_dump(
-                mode="json", exclude_unset=True, exclude_none=True
-            )
-        issue_sev = props.get("issue_severity", "").upper() if isinstance(props, dict) else ""
+            props = props.model_dump(mode="json", exclude_unset=True, exclude_none=True)
+        issue_sev = (
+            props.get("issue_severity", "").upper() if isinstance(props, dict) else ""
+        )
         if issue_sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
             return issue_sev.lower()
 
@@ -331,11 +349,13 @@ def _normalize_sarif_uri(
     """
     uri_normalized = uri.replace("\\", "/")
     if uri_normalized.startswith(source_dir_prefix):
-        return uri_normalized[len(source_dir_prefix):]
+        return uri_normalized[len(source_dir_prefix) :]
     if uri_normalized.startswith(source_dir_prefix_with_slash):
-        return uri_normalized[len(source_dir_prefix_with_slash):]
-    if source_dir_prefix_no_drive and uri_normalized.startswith(source_dir_prefix_no_drive):
-        return uri_normalized[len(source_dir_prefix_no_drive):]
+        return uri_normalized[len(source_dir_prefix_with_slash) :]
+    if source_dir_prefix_no_drive and uri_normalized.startswith(
+        source_dir_prefix_no_drive
+    ):
+        return uri_normalized[len(source_dir_prefix_no_drive) :]
     # source_dir_basename is None when the source dir contains a child of the same
     # name (see #361): the basename is a real project dir, not a scanner artifact,
     # so stripping it would corrupt the path. relative_to(None) raises TypeError,
@@ -367,7 +387,9 @@ def _apply_config_suppression(
 
     Mutates result.suppressions on match. Returns True when a suppression was applied.
     """
-    should_suppress, matching_suppression = should_suppress_finding(flat_finding, suppressions)
+    should_suppress, matching_suppression = should_suppress_finding(
+        flat_finding, suppressions
+    )
     if not should_suppress:
         return False
 
@@ -382,7 +404,9 @@ def _apply_config_suppression(
         )
         return True
 
-    reason = (matching_suppression and matching_suppression.reason) or "No reason provided"
+    reason = (
+        matching_suppression and matching_suppression.reason
+    ) or "No reason provided"
     ASH_LOGGER.verbose(
         f"Suppressing rule '{result.ruleId}' on location '{flat_finding.file_path}' based on suppression rule: [yellow]{reason}[/yellow]"
     )
@@ -411,7 +435,10 @@ def _apply_inline_suppression(
     if file_key not in inline_cache:
         inline_cache[file_key] = find_inline_suppressions(file_path)
     for isup in inline_cache[file_key]:
-        if isup.rule_id.lower() == result.ruleId.lower() and isup.line_number == result_line:
+        if (
+            isup.rule_id.lower() == result.ruleId.lower()
+            and isup.line_number == result_line
+        ):
             if not result.suppressions:
                 result.suppressions = []
             ASH_LOGGER.verbose(
@@ -465,12 +492,16 @@ def apply_suppressions_to_sarif(
     _output_dir_resolved = plugin_context.output_dir.resolve()
     _work_dir_resolved = plugin_context.output_dir.joinpath(ASH_WORK_DIR_NAME).resolve()
     _uri_resolve_cache: dict[str, Path] = {}
-    _source_dir_prefix = str(plugin_context.source_dir.resolve()).replace("\\", "/") + "/"
+    _source_dir_prefix = (
+        str(plugin_context.source_dir.resolve()).replace("\\", "/") + "/"
+    )
     # On Windows, SARIF URIs may have a leading "/" before the drive letter (e.g., /D:/path)
     _source_dir_prefix_with_slash = "/" + _source_dir_prefix
     # Some Windows scanners strip the drive letter entirely (e.g., /a/repo/ instead of D:/a/repo/)
     _source_dir_prefix_no_drive = (
-        _source_dir_prefix[2:] if len(_source_dir_prefix) > 2 and _source_dir_prefix[1] == ":" else None
+        _source_dir_prefix[2:]
+        if len(_source_dir_prefix) > 2 and _source_dir_prefix[1] == ":"
+        else None
     )
     # Offline opengrep produces relative paths with source_dir basename prefix (e.g., "src/.github/...")
     # However, skip basename stripping when source_dir contains a subdirectory with the same name
@@ -517,9 +548,9 @@ def apply_suppressions_to_sarif(
                     if uri not in _uri_resolve_cache:
                         _uri_resolve_cache[uri] = Path(uri).resolve()
                     resolved_uri = _uri_resolve_cache[uri]
-                    if resolved_uri.is_relative_to(_output_dir_resolved) and not resolved_uri.is_relative_to(
-                        _work_dir_resolved
-                    ):
+                    if resolved_uri.is_relative_to(
+                        _output_dir_resolved
+                    ) and not resolved_uri.is_relative_to(_work_dir_resolved):
                         ASH_LOGGER.verbose(
                             f"Excluding result -- location is in output path and NOT in the work directory and should not have been included: '{uri}'"
                         )
@@ -549,13 +580,17 @@ def apply_suppressions_to_sarif(
                         and location.physicalLocation.root.artifactLocation
                     ):
                         raw_uri = location.physicalLocation.root.artifactLocation.uri
-                        uri = _normalize_sarif_uri(
-                            raw_uri or "",
-                            _source_dir_prefix,
-                            _source_dir_prefix_with_slash,
-                            _source_dir_prefix_no_drive,
-                            _source_dir_basename,
-                        ) if raw_uri else (raw_uri or "")
+                        uri = (
+                            _normalize_sarif_uri(
+                                raw_uri or "",
+                                _source_dir_prefix,
+                                _source_dir_prefix_with_slash,
+                                _source_dir_prefix_no_drive,
+                                _source_dir_basename,
+                            )
+                            if raw_uri
+                            else (raw_uri or "")
+                        )
                         line_start = None
                         line_end = None
                         if (
@@ -599,7 +634,9 @@ def apply_suppressions_to_sarif(
                         continue
 
             # --- Step 3: inline suppression ---
-            if not ignore_suppressions and not (result.suppressions and len(result.suppressions) >= 1):
+            if not ignore_suppressions and not (
+                result.suppressions and len(result.suppressions) >= 1
+            ):
                 if result.ruleId and result.locations:
                     for location in result.locations:
                         if not (
@@ -615,7 +652,9 @@ def apply_suppressions_to_sarif(
                             hasattr(location.physicalLocation.root, "region")
                             and location.physicalLocation.root.region
                         ):
-                            result_line = location.physicalLocation.root.region.startLine
+                            result_line = (
+                                location.physicalLocation.root.region.startLine
+                            )
                         if result_line is None:
                             continue
                         uri = _normalize_sarif_uri(
@@ -626,7 +665,11 @@ def apply_suppressions_to_sarif(
                             _source_dir_basename,
                         )
                         _apply_inline_suppression(
-                            result, uri, plugin_context.source_dir, result_line, _inline_suppression_cache
+                            result,
+                            uri,
+                            plugin_context.source_dir,
+                            result_line,
+                            _inline_suppression_cache,
                         )
 
             updated_results.append(result)

--- a/tests/unit/utils/test_sarif_uri_symlink_resolution.py
+++ b/tests/unit/utils/test_sarif_uri_symlink_resolution.py
@@ -1,0 +1,165 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""SARIF URIs must relativize even when the source directory path has symlinks.
+
+Why this file exists
+--------------------
+`sanitize_sarif_paths` resolves the source directory (`Path(source_dir)
+.resolve()`) but a scanner's SARIF URI is whatever spelling the scanner was
+handed. `Path.relative_to` is purely lexical, so the two only line up when
+neither side crosses a symlink. When they disagree the ValueError was suppressed
+and the URI was left absolute.
+
+An absolute URI then fails suppression matching, because a suppression `path` is
+written relative to the source directory ("src/insecure.js"), and
+`file_path_matches` compares the two as strings. The reported symptom is the
+worst kind: the finding stays actionable *and* the unused-suppressions reporter
+declares the suppression unused, so the config looks wrong rather than the
+matcher.
+
+macOS hits this on every scan under /tmp, because /tmp is a symlink to
+/private/tmp. The reporter also found it with OneDrive on macOS, where the
+visible `~/OneDrive - <Tenant>/...` path is a symlink into `~/Library/CloudStorage`.
+
+Why a symlink rather than a mocked path
+--------------------------------------
+The bug is a property of real filesystem resolution, so a test that stubs
+`Path.resolve` would pass against a matcher that still cannot see through a
+symlink. These tests build an actual symlinked tree, which is why they are
+skipped on Windows: creating one there needs either developer mode or elevation,
+and a skip is better than a test that fails for a reason unrelated to the fix.
+"""
+
+import os
+
+import pytest
+
+from automated_security_helper.utils.sarif_utils import _sanitize_uri
+from automated_security_helper.utils.suppression_matcher import file_path_matches
+
+pytestmark = pytest.mark.skipif(
+    os.name == "nt",
+    reason="Creating symlinks on Windows requires developer mode or elevation",
+)
+
+
+@pytest.fixture
+def symlinked_source(tmp_path):
+    """A source tree reachable by two different absolute paths.
+
+    Mirrors macOS /tmp -> /private/tmp: `link/proj` and `real/proj` are the same
+    directory, spelled differently.
+    """
+    real = tmp_path / "real" / "proj"
+    (real / "src").mkdir(parents=True)
+    (real / "src" / "insecure.js").write_text("// finding here\n", encoding="utf-8")
+
+    link = tmp_path / "link"
+    link.symlink_to(tmp_path / "real", target_is_directory=True)
+
+    return {
+        "real_source": real,
+        "link_source": link / "proj",
+    }
+
+
+class TestAbsoluteUriThroughASymlink:
+    def test_uri_spelled_via_symlink_is_made_relative(self, symlinked_source):
+        """The reported case, in the shape sanitize_sarif_paths produces.
+
+        sanitize_sarif_paths resolves source_dir before calling _sanitize_uri, so
+        source_dir_path is the /real spelling while the scanner reported /link.
+        """
+        source_dir_path = symlinked_source["link_source"].resolve()
+        source_dir_str = str(source_dir_path) + "/"
+        uri = str(symlinked_source["link_source"] / "src" / "insecure.js")
+
+        sanitized = _sanitize_uri(uri, source_dir_path, source_dir_str)
+
+        assert sanitized == "src/insecure.js"
+
+    def test_the_reverse_spelling_also_relativizes(self, symlinked_source):
+        """source_dir given as the resolved path, URI reported through the link.
+
+        Covered separately because which side holds the symlink depends on how
+        the scanner was invoked, and only one direction was ever exercised.
+        """
+        source_dir_path = symlinked_source["real_source"]
+        source_dir_str = str(source_dir_path) + "/"
+        uri = str(symlinked_source["link_source"] / "src" / "insecure.js")
+
+        sanitized = _sanitize_uri(uri, source_dir_path, source_dir_str)
+
+        assert sanitized == "src/insecure.js"
+
+    def test_sanitized_uri_then_matches_a_relative_suppression(self, symlinked_source):
+        """The point of the fix, asserted end to end.
+
+        A suppression path is written relative to the source directory, so an
+        absolute URI silently fails to match. This is the assertion that would
+        have caught the reported behaviour.
+        """
+        source_dir_path = symlinked_source["link_source"].resolve()
+        source_dir_str = str(source_dir_path) + "/"
+        uri = str(symlinked_source["link_source"] / "src" / "insecure.js")
+
+        sanitized = _sanitize_uri(uri, source_dir_path, source_dir_str)
+
+        assert file_path_matches(sanitized, "src/insecure.js")
+
+    def test_missing_file_under_a_symlinked_dir_still_relativizes(
+        self, symlinked_source
+    ):
+        """Path.resolve() is non-strict, so the file need not exist.
+
+        Scanners report paths for files that may have been cleaned up, and a
+        converted-target URI need not exist on disk at sanitize time. Only the
+        symlinked directory has to be resolvable.
+        """
+        source_dir_path = symlinked_source["link_source"].resolve()
+        source_dir_str = str(source_dir_path) + "/"
+        uri = str(symlinked_source["link_source"] / "src" / "never-existed.js")
+
+        sanitized = _sanitize_uri(uri, source_dir_path, source_dir_str)
+
+        assert sanitized == "src/never-existed.js"
+
+
+class TestNoBehaviourChangeElsewhere:
+    def test_uri_outside_the_source_dir_stays_absolute(
+        self, symlinked_source, tmp_path
+    ):
+        """Guard against over-correcting.
+
+        A finding genuinely outside the source tree has no relative form. It must
+        keep its absolute path rather than acquire a misleading `../..` one.
+        """
+        source_dir_path = symlinked_source["real_source"]
+        source_dir_str = str(source_dir_path) + "/"
+        outside = tmp_path / "elsewhere" / "other.js"
+        outside.parent.mkdir(parents=True)
+        outside.write_text("// unrelated\n", encoding="utf-8")
+
+        sanitized = _sanitize_uri(str(outside), source_dir_path, source_dir_str)
+
+        assert sanitized == str(outside).replace("\\", "/")
+
+    def test_plain_absolute_uri_under_source_dir_is_unaffected(self, symlinked_source):
+        """The common case, with no symlink involved, must not change."""
+        source_dir_path = symlinked_source["real_source"]
+        source_dir_str = str(source_dir_path) + "/"
+        uri = str(source_dir_path / "src" / "insecure.js")
+
+        sanitized = _sanitize_uri(uri, source_dir_path, source_dir_str)
+
+        assert sanitized == "src/insecure.js"
+
+    def test_relative_uri_is_unaffected(self, symlinked_source):
+        source_dir_path = symlinked_source["real_source"]
+        source_dir_str = str(source_dir_path) + "/"
+
+        assert (
+            _sanitize_uri("src/insecure.js", source_dir_path, source_dir_str)
+            == "src/insecure.js"
+        )


### PR DESCRIPTION
## Root cause

`sanitize_sarif_paths` resolves the source directory:

```python
source_dir_path = Path(source_dir).resolve()
```

but a scanner's SARIF URI keeps whatever spelling the scanner was handed. `Path.relative_to` is **purely lexical**, so `/tmp/x/src/a.js`.relative_to(`/private/tmp/x`) raises `ValueError` -- and the `with suppress(ValueError)` swallowed it, leaving the URI absolute.

An absolute URI then never matches a suppression, because a suppression `path` is relative to the source dir and `file_path_matches` compares strings. Hence the confusing pair in the report: the finding stays **actionable** *and* the unused-suppressions reporter calls the suppression **unused**, so it reads as a bad config rather than a matcher bug.

## Fix

When the lexical attempt fails, resolve the URI and retry, putting both sides in one namespace. Notes on the guards:

- `resolve()` is non-strict, so a path whose final component no longer exists still resolves. Scanners do report paths for files that were cleaned up.
- `OSError` is caught alongside `ValueError` for symlink loops and paths the process cannot stat.
- The retry only runs **after** the lexical form failed, so the common case pays nothing.

## Tests

Seven tests building a **real symlinked tree**, not a stubbed `Path.resolve`. That distinction matters: a stubbed test would pass against code that still cannot see through a symlink, which is the whole bug. Skipped on Windows, where symlink creation needs developer mode or elevation.

Four cover the fix, including both spellings (which side holds the symlink depends on how the scanner was invoked) and a non-existent file. One asserts the end-to-end point: the sanitized URI now matches `src/insecure.js` via `file_path_matches` -- on `main` that assertion fails with `assert False`, which is exactly the user-visible symptom.

Three pin the unchanged behaviour, notably that a URI genuinely **outside** the source tree keeps its absolute path rather than acquiring a misleading `../..` one.

## Verification

- 4 of 7 fail on `main`; the 3 no-change tests pass on both. All 7 pass here.
- `tests/unit/utils/`: **575 passed, 2 skipped**, no regressions.
- ruff 0.11.8: clean. It also reformatted the rest of `sarif_utils.py`, which was **already** failing `format --check` on `main`.

## Related

The `#440` gate docstring notes a separate cwd-versus-source_dir defect in this same function, where a scan whose cwd differs from source_dir emits absolute URIs. This fix does not address that one; it only stops a symlink from breaking the relativization.

Fixes #348