### PR TITLE
fix(container): stop pnpm audit hanging on a corepack prompt, and move to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,12 +100,18 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 #
-# Install nodejs@20 using latest recommended method
+# Install nodejs using latest recommended method.
+#
+# The major version has to satisfy the package managers cached below. pnpm 11
+# declares engines.node >=22.13 (pnpm 9 and 10 were >=18.12), and `corepack
+# prepare pnpm@latest` caches whatever the current major is, so Node 20 left the
+# image with a pnpm it could not run. tests/unit/test_dockerfile_node_toolchain.py
+# fails if this drops back below what pnpm needs.
 #
 RUN set -uex; \
     mkdir -p /etc/apt/keyrings; \
     with-retry 'curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg'; \
-    NODE_MAJOR=20; \
+    NODE_MAJOR=22; \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
     > /etc/apt/sources.list.d/nodesource.list; \
     apt-get -qy update; \
@@ -143,6 +149,18 @@ RUN with-retry 'bundle install --jobs=4'
 # JavaScript: corepack manages npm/yarn/pnpm versions via package.json engines
 # Prepare at build time so binaries are cached for offline runtime use
 #
+# A scanned repository pins its own version through `packageManager`, and corepack
+# honours that at runtime. When the pinned version is not the one cached above,
+# corepack asks before fetching it ("Do you want to continue? [Y/n]"). No tty is
+# attached here, so that prompt blocks on stdin indefinitely and the scan looks
+# like a hung `pnpm audit` rather than a failure. Setting this to 0 turns the
+# prompt into a decision corepack makes on its own, so the audit either runs or
+# fails with a message.
+#
+# ENV rather than a build-time export: the npm-audit scanner invokes pnpm at
+# runtime, which is the case that reported the hang.
+#
+ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN with-retry 'corepack enable && corepack prepare yarn@stable --activate && corepack prepare pnpm@latest --activate'
 
 

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
@@ -263,9 +263,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 # created above.  Build a minimal result from vuln_info.
                 if not has_dict_via and via_items:
                     vuln_id = f"npm-audit-transitive-{pkg_name}"
-                    via_refs = ", ".join(
-                        v for v in via_items if isinstance(v, str)
-                    )
+                    via_refs = ", ".join(v for v in via_items if isinstance(v, str))
                     title = f"Transitive vulnerability in {pkg_name} (via {via_refs})"
                     description = title
 
@@ -334,7 +332,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target_path)
@@ -354,7 +354,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — NpmAudit overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -394,7 +396,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target)
@@ -432,7 +436,6 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -539,6 +542,26 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                                     "npm audit offline mode validation failed, but continuing with scan"
                                 )
 
+                        # Corepack resolves the package manager version from the
+                        # repository's `packageManager` field, and fetches it if the
+                        # image has a different one cached. The Dockerfile sets
+                        # COREPACK_ENABLE_DOWNLOAD_PROMPT=0 so that fetch cannot
+                        # block on a stdin prompt that no one can answer -- but
+                        # disabling the prompt only stops the *asking*, not the
+                        # download.
+                        #
+                        # In offline mode a download is the wrong outcome twice
+                        # over: there is no network, so it fails, and it fails
+                        # instead of using the package manager already cached in the
+                        # image. COREPACK_ENABLE_NETWORK=0 makes corepack fall back
+                        # to the cached version rather than reach out.
+                        subprocess_env = None
+                        if self.config.options.offline:
+                            subprocess_env = {
+                                **os.environ,
+                                "COREPACK_ENABLE_NETWORK": "0",
+                            }
+
                         # Run from the lock file's parent directory so
                         # that pnpm (and yarn) can locate their lock
                         # files (#99).
@@ -548,6 +571,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             stdout_preference="both",
                             stderr_preference="both",
                             cwd=package_dir,
+                            env=subprocess_env,
                         )
                         ASH_LOGGER.info(result)
 
@@ -634,7 +658,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             invocations=[
                                 Invocation(
                                     commandLine="npm audit --json",
-                                    executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                                    executionSuccessful=(
+                                        self.exit_code == 0 or self.exit_code == 1
+                                    ),
                                     exitCode=self.exit_code,
                                     workingDirectory=ArtifactLocation(
                                         uri=get_shortest_name(input=target)

--- a/tests/unit/test_dockerfile_node_toolchain.py
+++ b/tests/unit/test_dockerfile_node_toolchain.py
@@ -1,0 +1,96 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The container's Node must be able to run the package managers it caches.
+
+Why this file exists
+--------------------
+`pnpm audit` hung indefinitely for anyone scanning a repository that pins
+`packageManager: pnpm@11.x`. Two independent causes, both in the Dockerfile:
+
+1. Corepack asks before downloading a package manager it does not have cached::
+
+       ! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11...
+       ? Do you want to continue? [Y/n]
+
+   Nothing set ``COREPACK_ENABLE_DOWNLOAD_PROMPT``, so in a container with no
+   attached tty that prompt blocks on stdin forever. That is the hang: not a slow
+   audit, a process waiting for a keystroke that can never arrive.
+
+2. The image shipped Node 20 while running ``corepack prepare pnpm@latest``.
+   pnpm 11 declares ``engines.node >=22.13``, so the version the image caches for
+   itself cannot run on the Node the image installs. Verified against the npm
+   registry rather than assumed: pnpm 9 and 10 are ``>=18.12``, pnpm 11 moved to
+   ``>=22.13``.
+
+Why a static check
+------------------
+Building the image takes minutes and needs a working OCI runtime, so a test that
+builds it would not run in the unit suite. Both causes are single lines of
+Dockerfile, and both are the kind of thing a later edit silently reverts, so
+these read the Dockerfile as text. That catches a regression at the point it is
+introduced rather than when a user's scan hangs.
+
+Deliberately not asserted
+-------------------------
+No upper bound on NODE_MAJOR. Bumping Node is routine and should not need a test
+edit; only dropping below what the cached pnpm requires is a bug.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+# pnpm 11.x declares engines.node >=22.13. `corepack prepare pnpm@latest` caches
+# whatever the current major is, so the floor tracks that rather than the version
+# pinned by any one scanned repository.
+MIN_NODE_MAJOR_FOR_PNPM_11 = 22
+
+_NODE_MAJOR = re.compile(r"^\s*NODE_MAJOR=(?P<major>\d+)", re.MULTILINE)
+
+
+@pytest.fixture(scope="module")
+def dockerfile_text() -> str:
+    return DOCKERFILE.read_text(encoding="utf-8")
+
+
+def test_node_major_can_run_the_pnpm_the_image_caches(dockerfile_text):
+    match = _NODE_MAJOR.search(dockerfile_text)
+    assert match is not None, (
+        "No NODE_MAJOR=<n> assignment found in the Dockerfile. If the Node "
+        "install moved to a different mechanism, this check needs to read "
+        "whichever setting now pins the major version."
+    )
+
+    node_major = int(match.group("major"))
+
+    assert node_major >= MIN_NODE_MAJOR_FOR_PNPM_11, (
+        f"Dockerfile installs Node {node_major}, but it runs "
+        f"`corepack prepare pnpm@latest`, and pnpm 11 requires Node "
+        f">={MIN_NODE_MAJOR_FOR_PNPM_11}.13. The cached pnpm cannot run on the "
+        "installed Node, so `pnpm audit` fails for any project with a "
+        "pnpm-lock.yaml."
+    )
+
+
+def test_corepack_download_prompt_is_disabled(dockerfile_text):
+    """Without this the container hangs instead of failing.
+
+    Asserted on ENV rather than on a per-RUN assignment: the scanner invokes pnpm
+    at *runtime*, so a build-time-only export would leave the hang in place for
+    the case that actually reported it.
+    """
+    assert re.search(
+        r"^\s*ENV\s+COREPACK_ENABLE_DOWNLOAD_PROMPT=0\b",
+        dockerfile_text,
+        re.MULTILINE,
+    ), (
+        "COREPACK_ENABLE_DOWNLOAD_PROMPT=0 is not set as an ENV in the "
+        "Dockerfile. Corepack will prompt before downloading a package manager "
+        "version it has not cached, and with no tty attached that prompt blocks "
+        "on stdin forever rather than failing."
+    )


### PR DESCRIPTION
## Two causes, not one

### 1. The hang: corepack's download prompt blocks on stdin

Nothing set `COREPACK_ENABLE_DOWNLOAD_PROMPT`. A scanned repo pins its own version via `packageManager` and corepack honours that **at runtime**; when it is not the version cached at build time, corepack asks first:

```
! Corepack is about to download https://registry.npmjs.org/pnpm/-/pnpm-11...
? Do you want to continue? [Y/n]
```

No tty is attached in the container, so that prompt waits for a keystroke that can never arrive. That is why it presents as a hung `pnpm audit` rather than a failed one -- the process is not slow, it is waiting on stdin.

Set as `ENV`, not a build-time export: the npm-audit scanner invokes pnpm at **runtime**, which is the case that reported this.

### 2. The floor: Node 20 cannot run the pnpm the image caches for itself

The Dockerfile ran `corepack prepare pnpm@latest` while installing Node 20. Checked against the npm registry rather than assumed:

| pnpm | engines.node |
|---|---|
| 9.15.9 | `>=18.12` |
| 10.34.5 | `>=18.12` |
| **11.24.0** (`latest`) | **`>=22.13`** |

So the image cached a pnpm it could not execute. This is broken independently of what any scanned repo pins.

## Also worth knowing

Per [nodejs/Release](https://github.com/nodejs/Release) `schedule.json`, **Node 20 went end-of-life on 2026-04-30** -- about four months ago. The image was shipping an unsupported runtime, which matters more than usual in a security scanner. Node 22 is supported through 2027-04-30.

**Node 24** is the current active LTS (through 2028-04-30) and is a reasonable follow-up. I went with 22 deliberately: it is the minimum that satisfies pnpm 11, and moving the base runtime two majors is a bigger change than a hang fix should carry. Happy to make it 24 if you would rather do it in one go.

## Tests

Two static Dockerfile checks. Building the image takes minutes and a working OCI runtime, so it cannot run in the unit suite, and both causes are single lines of the kind a later edit quietly reverts.

No upper bound is asserted on `NODE_MAJOR` -- bumping Node is routine and should not require editing a test. Only dropping below what the cached pnpm needs is a bug.

Both fail on `main`, pass here. ruff 0.11.8 clean and formatted.

Fixes #322

---

## Update after review

`COREPACK_ENABLE_DOWNLOAD_PROMPT=0` stops Corepack **asking** before it downloads a package manager. It does not stop the download. In `offline` mode that is still a network call, which is exactly what offline mode promises not to make — so the flag that was supposed to fix the hang instead converted an interactive prompt into a silent fetch that fails without a useful message when there is no network.

`npm_audit_scanner` now also sets `COREPACK_ENABLE_NETWORK=0` in the subprocess environment when `options.offline` is set, which makes Corepack fail fast and explain itself instead of hanging or timing out.

Passed via the subprocess `env` rather than the Dockerfile, because `offline` is a per-scan option: setting it in the image would break online scans in that same image.