### PR TITLE
fix(mcp): report scanners that never ran instead of hiding them

### DIFF
--- a/automated_security_helper/cli/mcp_server.py
+++ b/automated_security_helper/cli/mcp_server.py
@@ -36,6 +36,9 @@ from automated_security_helper.core.constants import ASH_EXIT_CODES
 from automated_security_helper.core.resource_management.scan_registry import (
     get_scan_registry,
 )
+from automated_security_helper.core.resource_management.scan_tracking import (
+    summarize_scanner_statuses,
+)
 from automated_security_helper.core.resource_management.result_filters import (
     filter_summary,
     filter_minimal,
@@ -221,6 +224,12 @@ async def get_scan_progress(ctx: Context, scan_id: str) -> Dict[str, Any]:
         - status: Current status (running, completed, failed, cancelled)
         - progress_percentage: Estimated completion percentage
         - message: Human-readable status message
+        - scanner_statuses: Per-scanner status for every scanner ASH considered,
+          including ones that never ran. Empty until the scan finishes.
+        - skipped_scanners: The subset that did not run, each with a `reason` of
+          `missing_dependencies`, `excluded_by_configuration` or `skipped`. Use
+          this to tell "scanned, found nothing" from "never ran"; a zero finding
+          count alone cannot distinguish the two.
     """
     try:
         await ctx.info(f"Getting progress for scan: {scan_id}")
@@ -289,6 +298,16 @@ async def get_scan_progress(ctx: Context, scan_id: str) -> Dict[str, Any]:
 
         progress_info["scanners"] = scanner_results
         progress_info["severity_counts"] = severity_counts
+
+        # `scanners` above is built by globbing result files, so a scanner that
+        # never ran leaves nothing behind and silently disappears from it. That
+        # made a scanner skipped for missing dependencies indistinguishable from
+        # one that ran clean. These two keys come from scanner_results in the
+        # aggregated output, which records the real status for every scanner ASH
+        # considered. Empty while the scan is still running.
+        status_summary = summarize_scanner_statuses(output_dir)
+        progress_info["scanner_statuses"] = status_summary["scanner_statuses"]
+        progress_info["skipped_scanners"] = status_summary["skipped_scanners"]
 
         return progress_info
     except Exception as e:
@@ -404,9 +423,7 @@ async def get_scan_summary(
     Args:
         output_dir: Path to the scan output directory (absolute path recommended)
     """
-    summary = await get_scan_results(
-        ctx, output_dir=output_dir, filter_level="summary"
-    )
+    summary = await get_scan_results(ctx, output_dir=output_dir, filter_level="summary")
     # Tag the response with the entry point that produced it. get_scan_results
     # serves several filter levels, so callers use this to tell a summary obtained
     # via get_scan_summary from one obtained by calling get_scan_results directly.
@@ -667,7 +684,13 @@ def list_scanners() -> list:
         return mcp_list_scanners()
     except Exception as e:
         logger.exception(f"Error in list_scanners: {str(e)}")
-        return [{"success": False, "error": f"Error listing scanners: {str(e)}", "error_type": type(e).__name__}]
+        return [
+            {
+                "success": False,
+                "error": f"Error listing scanners: {str(e)}",
+                "error_type": type(e).__name__,
+            }
+        ]
 
 
 @mcp.tool()
@@ -710,7 +733,9 @@ def validate_config(
         Dict with valid (bool) and errors (list of {field, message, type}).
     """
     try:
-        return mcp_validate_config(config_content=config_content, config_path=config_path)
+        return mcp_validate_config(
+            config_content=config_content, config_path=config_path
+        )
     except Exception as e:
         logger.exception(f"Error in validate_config: {str(e)}")
         return {
@@ -741,6 +766,7 @@ def _read_ash_suppression_schema() -> str:
     """Return the AshSuppression JSON schema as a string."""
     from automated_security_helper.models.core import AshSuppression
     import json as _json
+
     return _json.dumps(AshSuppression.model_json_schema(), indent=2)
 
 

--- a/automated_security_helper/core/resource_management/scan_tracking.py
+++ b/automated_security_helper/core/resource_management/scan_tracking.py
@@ -10,6 +10,7 @@ and parse scan result files to extract progress information. It implements a mor
 reliable approach to track scan progress and completion than event-based tracking.
 """
 
+import json
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -487,6 +488,88 @@ def parse_scanner_result_file(
             f"Available keys: {list(data.keys()) if data else 'None'}"
         )
         return []
+
+
+def summarize_scanner_statuses(output_dir: Path) -> Dict[str, Any]:
+    """Read the authoritative per-scanner statuses for a scan.
+
+    A scanner skipped for missing dependencies used to be indistinguishable from
+    one that ran and found nothing, which for a security tool is the whole
+    answer. The information was never lost in the core -- scan_phase records
+    ``ScannerStatusInfo(status=ScannerStatus.MISSING, ...)`` in
+    ``scanner_results`` -- but the MCP progress view rebuilt its own map by
+    globbing ``scanners/*/*/ASH.ScanResults.json``. A scanner that never ran
+    writes no such file, so it fell out of the map entirely and the remaining
+    entries looked like the complete set.
+
+    This reads ``scanner_results`` instead of re-deriving it from whatever
+    happens to be on disk.
+
+    Returns a dict with two keys, both always present:
+
+    ``scanner_statuses``
+        Every scanner ASH considered, including those that never ran.
+    ``skipped_scanners``
+        Only those that did not run, each with a machine-readable ``reason`` so a
+        caller can tell a missing tool from a deliberate exclusion.
+
+    Returns empty collections rather than raising. ``get_scan_progress`` polls
+    this while a scan is still running, when the aggregated file does not exist
+    yet, so absence is the ordinary case and not an error.
+    """
+    empty: Dict[str, Any] = {"scanner_statuses": {}, "skipped_scanners": []}
+
+    results_path = Path(output_dir) / "ash_aggregated_results.json"
+    try:
+        raw = results_path.read_text(encoding="utf-8")
+    except OSError:
+        return empty
+
+    try:
+        data = json.loads(raw)
+    except (ValueError, TypeError):
+        # A poll can land midway through the file being written.
+        return empty
+
+    if not isinstance(data, dict):
+        return empty
+
+    scanner_results = data.get("scanner_results")
+    if not isinstance(scanner_results, dict):
+        return empty
+
+    statuses: Dict[str, Any] = {}
+    skipped: List[Dict[str, Any]] = []
+
+    for scanner_name, info in scanner_results.items():
+        if not isinstance(info, dict):
+            continue
+
+        status = info.get("status")
+        excluded = bool(info.get("excluded", False))
+        dependencies_satisfied = bool(info.get("dependencies_satisfied", True))
+
+        statuses[scanner_name] = {
+            "status": status,
+            "excluded": excluded,
+            "dependencies_satisfied": dependencies_satisfied,
+        }
+
+        # FAILED and ERROR are deliberately not included. Those scanners ran;
+        # reporting them as skipped would send a user looking for a missing tool.
+        if status not in ("MISSING", "SKIPPED"):
+            continue
+
+        if not dependencies_satisfied:
+            reason = "missing_dependencies"
+        elif excluded:
+            reason = "excluded_by_configuration"
+        else:
+            reason = "skipped"
+
+        skipped.append({"scanner": scanner_name, "status": status, "reason": reason})
+
+    return {"scanner_statuses": statuses, "skipped_scanners": skipped}
 
 
 def parse_aggregated_results(

--- a/tests/unit/core/resource_management/test_scanner_status_summary.py
+++ b/tests/unit/core/resource_management/test_scanner_status_summary.py
@@ -1,0 +1,170 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A scanner that never ran must not read as one that ran and found nothing.
+
+Why this file exists
+--------------------
+`get_scan_progress` over MCP reported scanners skipped for missing dependencies
+as indistinguishable from clean ones, so a consumer could not tell "scanned, no
+findings" from "never ran". For a security tool that difference is the whole
+answer.
+
+Where the information was lost
+------------------------------
+Not in the core. scan_phase.py records the truth:
+
+    aggregated_results.scanner_results[display_name] = ScannerStatusInfo(
+        status=ScannerStatus.MISSING, dependencies_satisfied=False, ...
+    )
+
+The MCP layer then rebuilt its own view by globbing
+`scanners/*/*/ASH.ScanResults.json`. A scanner that never ran writes no such
+file, so it simply fell out of the map, and the surrounding counts made the
+remaining ones look like the complete set. The fix reads the authoritative
+statuses instead of re-deriving them from what happens to be on disk.
+
+Why a standalone helper
+-----------------------
+This logic lives here rather than in cli/mcp_server.py because that module
+imports the MCP SDK at module scope, so a test of it cannot run without the SDK
+installed. Keeping the policy in a plain function makes it testable on its own
+and leaves the tool as transport.
+"""
+
+import json
+from pathlib import Path
+
+from automated_security_helper.core.resource_management.scan_tracking import (
+    summarize_scanner_statuses,
+)
+
+
+def _write_results(output_dir: Path, scanner_results: dict) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "ash_aggregated_results.json").write_text(
+        json.dumps({"scanner_results": scanner_results}), encoding="utf-8"
+    )
+
+
+class TestSkippedScannersAreDistinguishable:
+    def test_missing_dependencies_is_reported_with_a_reason(self, tmp_path):
+        """The reported case: semgrep and syft skipped for missing dependencies."""
+        _write_results(
+            tmp_path,
+            {
+                "bandit": {"status": "PASSED", "dependencies_satisfied": True},
+                "semgrep": {"status": "MISSING", "dependencies_satisfied": False},
+                "syft": {"status": "MISSING", "dependencies_satisfied": False},
+            },
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        skipped = {entry["scanner"]: entry for entry in summary["skipped_scanners"]}
+        assert set(skipped) == {"semgrep", "syft"}
+        assert skipped["semgrep"]["reason"] == "missing_dependencies"
+        assert skipped["semgrep"]["status"] == "MISSING"
+
+    def test_a_clean_scanner_is_not_listed_as_skipped(self, tmp_path):
+        """The distinction the issue is about: PASSED with no findings is not skipped."""
+        _write_results(
+            tmp_path, {"bandit": {"status": "PASSED", "dependencies_satisfied": True}}
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert summary["skipped_scanners"] == []
+        assert summary["scanner_statuses"]["bandit"]["status"] == "PASSED"
+
+    def test_excluded_scanner_reports_a_different_reason(self, tmp_path):
+        """Excluded by config is a user decision, not a broken environment.
+
+        Both land in skipped_scanners, but conflating the reasons would tell a
+        user to install something they deliberately turned off.
+        """
+        _write_results(
+            tmp_path,
+            {
+                "checkov": {
+                    "status": "SKIPPED",
+                    "excluded": True,
+                    "dependencies_satisfied": True,
+                }
+            },
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert summary["skipped_scanners"][0]["reason"] == "excluded_by_configuration"
+
+    def test_failed_and_error_are_not_reported_as_skipped(self, tmp_path):
+        """A scanner that ran and failed did run. It belongs in neither bucket."""
+        _write_results(
+            tmp_path,
+            {
+                "grype": {"status": "FAILED", "dependencies_satisfied": True},
+                "opengrep": {"status": "ERROR", "dependencies_satisfied": True},
+            },
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert summary["skipped_scanners"] == []
+        assert summary["scanner_statuses"]["grype"]["status"] == "FAILED"
+        assert summary["scanner_statuses"]["opengrep"]["status"] == "ERROR"
+
+    def test_every_scanner_appears_in_scanner_statuses(self, tmp_path):
+        """Including the ones that never ran.
+
+        This is the assertion that fails against a map built by globbing result
+        files, since a scanner that never ran leaves none behind.
+        """
+        _write_results(
+            tmp_path,
+            {
+                "bandit": {"status": "PASSED", "dependencies_satisfied": True},
+                "semgrep": {"status": "MISSING", "dependencies_satisfied": False},
+            },
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert set(summary["scanner_statuses"]) == {"bandit", "semgrep"}
+
+
+class TestDegradesQuietly:
+    def test_absent_results_file_yields_empty_summary(self, tmp_path):
+        """Mid-scan there is no aggregated file yet.
+
+        get_scan_progress is polled while the scan runs, so this is the common
+        case rather than an error, and it must not raise.
+        """
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert summary == {"scanner_statuses": {}, "skipped_scanners": []}
+
+    def test_malformed_results_file_yields_empty_summary(self, tmp_path):
+        """A partially written file must not break a progress poll."""
+        tmp_path.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "ash_aggregated_results.json").write_text(
+            '{"scanner_results": {', encoding="utf-8"
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert summary == {"scanner_statuses": {}, "skipped_scanners": []}
+
+    def test_non_mapping_scanner_entry_is_ignored(self, tmp_path):
+        """Defensive: scanner_results is user-adjacent data by the time we read it."""
+        _write_results(
+            tmp_path,
+            {
+                "bandit": {"status": "PASSED", "dependencies_satisfied": True},
+                "weird": "not-a-mapping",
+            },
+        )
+
+        summary = summarize_scanner_statuses(tmp_path)
+
+        assert set(summary["scanner_statuses"]) == {"bandit"}


### PR DESCRIPTION
## Where the information was lost

Not in the core. `scan_phase.py` already records the truth:

```python
aggregated_results.scanner_results[display_name] = ScannerStatusInfo(
    status=ScannerStatus.MISSING, dependencies_satisfied=False, ...
)
```

and `ScannerStatus` has had `MISSING` and `SKIPPED` all along.

The MCP layer discarded it. `get_scan_progress` rebuilt its own `scanners` map by globbing `scanners/*/*/ASH.ScanResults.json` -- and **a scanner that never ran writes no such file**, so it fell out of the map entirely. The scanners that did run then looked like the complete set, which is why a consumer sees only clean results and cannot tell them from absent ones.

## Fix

Two additive keys on `get_scan_progress`:

- `scanner_statuses` — every scanner ASH considered, including the ones that never ran.
- `skipped_scanners` — only those that did not run, each with a `reason`: `missing_dependencies`, `excluded_by_configuration`, or `skipped`.

`skipped_scanners` is what the issue asked for as a minimum. Both keys are additive, so existing consumers are unaffected.

`FAILED` and `ERROR` are **deliberately not** in `skipped_scanners`. Those scanners ran; listing them would send a user hunting for a tool to install. There is a test pinning that.

Distinguishing `missing_dependencies` from `excluded_by_configuration` matters for the same reason: telling someone to install a scanner they deliberately disabled is worse than saying nothing.

## On placement

The logic is in `scan_tracking.summarize_scanner_statuses`, not in `cli/mcp_server.py`, because that module does `from mcp.server.mcpserver import MCPServer, Context` at module scope -- so nothing in it can be unit tested without the SDK installed. As a plain function this is testable on its own and the tool stays transport. (I could not import `mcp_server` locally at all for this reason; it is byte-compiled and lint-checked instead, and CI exercises it properly.)

It returns empty collections rather than raising. `get_scan_progress` is polled every 5 seconds *while the scan runs*, when the aggregated file does not exist yet or is half-written, so absence and malformed JSON are the ordinary cases — two tests cover them.

## Verification

- 8 new tests; the key one asserts every scanner appears in `scanner_statuses`, which is exactly what a glob-built map cannot do.
- `tests/unit/core/resource_management/`: **205 passed**, no regressions.
- ruff 0.11.8 clean. It also reformatted `mcp_server.py`, already failing `format --check` on `main`.

Fixes #356