### PR TITLE
fix(scanners): bound the tool invocation so a scanner cannot run forever

### DIFF
--- a/automated_security_helper/base/options.py
+++ b/automated_security_helper/base/options.py
@@ -30,6 +30,23 @@ class ScannerOptionsBase(PluginOptionsBase):
         ),
     ] = None
 
+    # Lives on the base rather than on individual scanners because the hang it
+    # prevents is a property of the shared subprocess path, not of any one tool.
+    # detect-secrets previously carried its own copy of this option, which is why
+    # it was the only scanner that timed out cleanly while the rest could run
+    # unbounded. 300 matches the default it chose.
+    scan_timeout: Annotated[
+        int | None,
+        Field(
+            description=(
+                "Maximum time in seconds to allow this scanner's tool invocation "
+                "to run before it is killed. Set to null to leave the scanner "
+                "unbounded, which risks a scan that never completes."
+            ),
+            ge=1,
+        ),
+    ] = 300
+
 
 class ReporterOptionsBase(PluginOptionsBase):
     """Base class for reporter options."""

--- a/automated_security_helper/base/options.py
+++ b/automated_security_helper/base/options.py
@@ -45,7 +45,7 @@ class ScannerOptionsBase(PluginOptionsBase):
             ),
             ge=1,
         ),
-    ] = 300
+    ] = 1800
 
 
 class ReporterOptionsBase(PluginOptionsBase):

--- a/automated_security_helper/base/plugin_base.py
+++ b/automated_security_helper/base/plugin_base.py
@@ -254,6 +254,14 @@ class PluginBase(UVToolMixin, BaseModel):
             if self.use_uv_tool and self.command and len(command) > 0:
                 # Check if the first element of the command is our tool command
                 if command[0] == self.command:
+                    # timeout has to be handed to this path too, not just to the
+                    # direct-execution call below. This branch returns, so a
+                    # timeout passed only below would apply exclusively to
+                    # scanners for which uv is unavailable. bandit, checkov and
+                    # semgrep all set use_uv_tool=True unconditionally and only
+                    # clear it when uv is missing, and ASH ships via uv -- so on a
+                    # normal install the reported bandit hang went through here,
+                    # unbounded, no matter what scan_timeout said.
                     uv_result = self._try_uv_tool_execution(
                         command,
                         working_dir,
@@ -261,6 +269,7 @@ class PluginBase(UVToolMixin, BaseModel):
                         stdout_preference=stdout_preference,
                         stderr_preference=stderr_preference,
                         env=env,
+                        timeout=timeout,
                     )
                     if uv_result is not None:
                         return uv_result

--- a/automated_security_helper/base/plugin_base.py
+++ b/automated_security_helper/base/plugin_base.py
@@ -205,7 +205,9 @@ class PluginBase(UVToolMixin, BaseModel):
         # Use abs() so negative codes (e.g. -1 for timeout) aren't
         # silently swallowed by max(0, -1).
         new_code = response.get("returncode", 1)
-        self.exit_code = max(self.exit_code, abs(new_code) if new_code < 0 else new_code)
+        self.exit_code = max(
+            self.exit_code, abs(new_code) if new_code < 0 else new_code
+        )
 
     def _run_subprocess(
         self,
@@ -215,6 +217,7 @@ class PluginBase(UVToolMixin, BaseModel):
         stderr_preference: Literal["return", "write", "both", "none"] = "write",
         cwd: Path | str | None = None,
         env: Dict[str, str] | None = None,
+        timeout: float | None = None,
     ) -> Dict[str, str]:
         """Run a subprocess with the given command.
 
@@ -275,6 +278,7 @@ class PluginBase(UVToolMixin, BaseModel):
                 class_name=self.__class__.__name__,
                 encoding="utf-8",
                 errors="replace",
+                timeout=timeout,
             )
 
             self._process_command_response(response)

--- a/automated_security_helper/base/scanner_plugin.py
+++ b/automated_security_helper/base/scanner_plugin.py
@@ -10,13 +10,28 @@ from automated_security_helper.core.enums import OfflineStrategy, ScannerToolTyp
 from automated_security_helper.core.exceptions import ScannerError
 from automated_security_helper.models.core import IgnorePathWithReason, ToolArgs
 from automated_security_helper.schemas.cyclonedx_bom_1_6_schema import CycloneDXReport
-from automated_security_helper.schemas.sarif_schema_model import ArtifactLocation, Invocation, SarifReport
+from automated_security_helper.schemas.sarif_schema_model import (
+    ArtifactLocation,
+    Invocation,
+    SarifReport,
+)
 from automated_security_helper.utils.get_shortest_name import get_shortest_name
 from automated_security_helper.utils.log import ASH_LOGGER
 from automated_security_helper.utils.subprocess_utils import find_executable
 
 from pydantic import Field
-from typing import Annotated, Any, ClassVar, Generic, List, Literal, Optional, Set, Tuple, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 from abc import abstractmethod
 
 # Pattern for valid CLI flag keys: one or two leading dashes followed by
@@ -323,9 +338,7 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             return
         working_dir = ArtifactLocation(uri=get_shortest_name(input=target))  # type: ignore[call-arg]
         extras = self._invocation_extras(sarif_report, final_args, target)
-        command_line = (
-            shlex.join(str(a) for a in final_args) if final_args else ""
-        )
+        command_line = shlex.join(str(a) for a in final_args) if final_args else ""
         sarif_report.runs[0].invocations = [
             Invocation(  # type: ignore[call-arg]
                 commandLine=command_line,
@@ -443,6 +456,25 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             "or override scan() directly."
         )
 
+    def _effective_scan_timeout(self) -> float | None:
+        """Seconds to allow this scanner's tool, or None to leave it unbounded.
+
+        Read defensively rather than as self.config.options.scan_timeout. A
+        third-party scanner may define options that predate this field, or set
+        config to None entirely, and a scan must not fail with AttributeError
+        because of a timeout lookup. An absent option means unbounded, which is
+        the behaviour those scanners already had.
+        """
+        options = getattr(self.config, "options", None)
+        timeout = getattr(options, "scan_timeout", None)
+        if timeout is None:
+            return None
+        try:
+            timeout = float(timeout)
+        except (TypeError, ValueError):
+            return None
+        return timeout if timeout > 0 else None
+
     def scan(
         self,
         target: "Path",
@@ -490,10 +522,16 @@ class ScannerPluginBase(PluginBase, Generic[T]):
                 global_ignore_paths=global_ignore_paths,
             )
 
+            # Bound the tool invocation. Without this every template-based
+            # scanner could run indefinitely: bandit was reported running past 50
+            # minutes on a project the CLI scanned in 20 seconds. detect-secrets
+            # was the only scanner that timed out cleanly, because it carried its
+            # own copy of this option and enforced it in its own scan override.
             self._run_subprocess(
                 command=final_args,
                 results_dir=results_file.parent,
                 env=subprocess_env,
+                timeout=self._effective_scan_timeout(),
             )
 
             self._post_scan(target=target, target_type=target_type)

--- a/automated_security_helper/base/scanner_plugin.py
+++ b/automated_security_helper/base/scanner_plugin.py
@@ -527,14 +527,32 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             # minutes on a project the CLI scanned in 20 seconds. detect-secrets
             # was the only scanner that timed out cleanly, because it carried its
             # own copy of this option and enforced it in its own scan override.
-            self._run_subprocess(
+            effective_timeout = self._effective_scan_timeout()
+            response = self._run_subprocess(
                 command=final_args,
                 results_dir=results_file.parent,
                 env=subprocess_env,
-                timeout=self._effective_scan_timeout(),
+                timeout=effective_timeout,
             )
 
             self._post_scan(target=target, target_type=target_type)
+
+            # Say "timed out" rather than "No such file or directory".
+            #
+            # A killed tool never writes its results file, so _read_results_file
+            # below raises FileNotFoundError, which the except clause turns into
+            # "<Scanner> scan failed: [Errno 2] No such file or directory". That
+            # reads as a path bug and sends the reader looking in the wrong place.
+            # The cause is a timeout and the message should say so, along with the
+            # knob to change it.
+            if isinstance(response, dict) and response.get("timed_out"):
+                raise ScannerError(
+                    f"{self.__class__.__name__} timed out after "
+                    f"{effective_timeout}s and was killed, so it produced no "
+                    f"results file. Raise scanners.{getattr(self.config, 'name', '<scanner>')}"
+                    ".options.scan_timeout if this target legitimately needs "
+                    "longer, or set it to null to leave this scanner unbounded."
+                )
 
             raw = self._read_results_file(results_file)
             if raw is None:

--- a/automated_security_helper/base/uv_tool_mixin.py
+++ b/automated_security_helper/base/uv_tool_mixin.py
@@ -110,6 +110,7 @@ class UVToolMixin:
         stdout_preference: str = "write",
         stderr_preference: str = "write",
         env: Optional[Dict[str, str]] = None,
+        timeout: Optional[float] = None,
     ) -> Optional[Dict[str, str]]:
         """Attempt to execute command using UV tool run.
 
@@ -165,6 +166,7 @@ class UVToolMixin:
                 stderr_preference=stderr_preference,
                 class_name=self.__class__.__name__,
                 env=env,
+                timeout=timeout,
             )
 
             response = {

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
@@ -98,7 +98,9 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — CfnNag overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -172,7 +174,6 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -274,6 +275,7 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
                     results_dir=results_file_dir,
                     stdout_preference="both",
                     stderr_preference="both",
+                    timeout=self._effective_scan_timeout(),
                 )
                 try:
                     stdout = proc_resp.get("stdout", "")
@@ -284,9 +286,7 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
                         )
                         failed_files.append((cfn_file, "empty stdout"))
                         continue
-                    file_sarif = SarifReport.model_validate_json(
-                        json_data=stdout
-                    )
+                    file_sarif = SarifReport.model_validate_json(json_data=stdout)
                     if sarif_report is None and file_sarif is not None:
                         sarif_report = file_sarif
                     elif file_sarif is not None:

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
@@ -1,4 +1,5 @@
 import logging
+
 """Module containing the detect-secrets security scanner implementation."""
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
@@ -89,12 +90,13 @@ class DetectSecretsScannerConfigOptions(ScannerOptionsBase):
             description="Settings to use with detect-secrets. Refer to the detect-secrets documentation for formatting information. By default, all plugins will be used and no filters are configured. scan_settings takes precedence over baseline_file",
         ),
     ] = DetectSecretsScanSettings()
-    scan_timeout: Annotated[
-        int,
-        Field(
-            description="Maximum time in seconds to allow the detect-secrets scan to run before aborting. Prevents hangs on pathological files.",
-        ),
-    ] = 300
+    # scan_timeout is inherited from ScannerOptionsBase now. The local copy that
+    # used to live here declared `int` with no `ge`, so it shadowed the base field
+    # and gave detect-secrets a different contract from every other scanner:
+    # `scan_timeout: null` -- which the base field's own description documents as
+    # the way to run unbounded -- raised a validation error here only, and
+    # `scan_timeout: 0` was accepted here and rejected elsewhere, then passed
+    # straight to future.result(timeout=0) so every scan timed out instantly.
 
 
 class DetectSecretsScannerConfig(ScannerPluginConfigBase):
@@ -137,9 +139,7 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
         # We additionally consult the consolidated UV-or-direct-binary
         # resolver for diagnostic logging only — its return value never gates
         # the result because the Python import is the authoritative signal.
-        cmd = get_uv_tool_command(
-            "detect-secrets", fallback_binary="detect-secrets"
-        )
+        cmd = get_uv_tool_command("detect-secrets", fallback_binary="detect-secrets")
         if cmd is not None:
             ASH_LOGGER.debug(
                 f"detect-secrets CLI also reachable via {cmd[0]}; "
@@ -304,7 +304,9 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — DetectSecrets overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -377,7 +379,6 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -469,7 +470,7 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                     for file_path in scannable
                     if not any(
                         path_matches_pattern(
-                            file_path[len(source_prefix):]
+                            file_path[len(source_prefix) :]
                             if file_path.startswith(source_prefix)
                             else file_path,
                             ignore_path.path,

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 from pathlib import Path
 from typing import Annotated, ClassVar, Dict, List, Literal, Any
 
@@ -571,6 +572,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             stdout_preference="both",
                             stderr_preference="both",
                             cwd=package_dir,
+                            env=subprocess_env,
                             timeout=self._effective_scan_timeout(),
                         )
                         ASH_LOGGER.info(result)

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
@@ -263,9 +263,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 # created above.  Build a minimal result from vuln_info.
                 if not has_dict_via and via_items:
                     vuln_id = f"npm-audit-transitive-{pkg_name}"
-                    via_refs = ", ".join(
-                        v for v in via_items if isinstance(v, str)
-                    )
+                    via_refs = ", ".join(v for v in via_items if isinstance(v, str))
                     title = f"Transitive vulnerability in {pkg_name} (via {via_refs})"
                     description = title
 
@@ -334,7 +332,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target_path)
@@ -354,7 +354,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — NpmAudit overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -394,7 +396,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target)
@@ -432,7 +436,6 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -548,6 +551,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             stdout_preference="both",
                             stderr_preference="both",
                             cwd=package_dir,
+                            timeout=self._effective_scan_timeout(),
                         )
                         ASH_LOGGER.info(result)
 
@@ -634,7 +638,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             invocations=[
                                 Invocation(
                                     commandLine="npm audit --json",
-                                    executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                                    executionSuccessful=(
+                                        self.exit_code == 0 or self.exit_code == 1
+                                    ),
                                     exitCode=self.exit_code,
                                     workingDirectory=ArtifactLocation(
                                         uri=get_shortest_name(input=target)

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
@@ -99,9 +99,7 @@ class SyftScanner(ScannerPluginBase[SyftScannerConfig]):
                     "SYFT_LOG_QUIET": "true",
                 }
             )
-            ASH_LOGGER.info(
-                "Running Syft in offline mode - update checks disabled"
-            )
+            ASH_LOGGER.info("Running Syft in offline mode - update checks disabled")
 
         super().model_post_init(context)
 
@@ -216,7 +214,6 @@ class SyftScanner(ScannerPluginBase[SyftScannerConfig]):
             )
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(
                 target=target,
@@ -266,6 +263,7 @@ class SyftScanner(ScannerPluginBase[SyftScannerConfig]):
                 command=final_args,
                 results_dir=target_results_dir,
                 env=subprocess_env,
+                timeout=self._effective_scan_timeout(),
             )
 
             self._post_scan(

--- a/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
@@ -832,7 +832,6 @@ class FerretScanScanner(ScannerPluginBase[FerretScannerConfig]):
             self._post_scan(target=target, target_type=target_type)
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(target=target, target_type=target_type)
             return False
@@ -872,6 +871,7 @@ class FerretScanScanner(ScannerPluginBase[FerretScannerConfig]):
                 results_dir=target_results_dir,
                 stdout_preference="write",
                 stderr_preference="write",
+                timeout=self._effective_scan_timeout(),
             )
 
             self._post_scan(target=target, target_type=target_type)

--- a/automated_security_helper/plugin_modules/ash_snyk_plugins/snyk_code_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_snyk_plugins/snyk_code_scanner.py
@@ -211,7 +211,6 @@ class SnykCodeScanner(ScannerPluginBase[SnykCodeScannerConfig]):
             )
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(
                 target=target,
@@ -238,6 +237,7 @@ class SnykCodeScanner(ScannerPluginBase[SnykCodeScannerConfig]):
             self._run_subprocess(
                 command=final_args,
                 results_dir=target_results_dir,
+                timeout=self._effective_scan_timeout(),
             )
 
             # Handle errors executing the scanner. For Snyk, non-zero response indicate the scanner was not

--- a/automated_security_helper/plugin_modules/ash_trivy_plugins/trivy_repo_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_trivy_plugins/trivy_repo_scanner.py
@@ -248,7 +248,6 @@ class TrivyRepoScanner(ScannerPluginBase[TrivyRepoScannerConfig]):
             )
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(
                 target=target,
@@ -279,6 +278,7 @@ class TrivyRepoScanner(ScannerPluginBase[TrivyRepoScannerConfig]):
                 command=final_args,
                 results_dir=target_results_dir,
                 env=subprocess_env,
+                timeout=self._effective_scan_timeout(),
             )
 
             # SARIF mode - parse SARIF results
@@ -316,7 +316,9 @@ class TrivyRepoScanner(ScannerPluginBase[TrivyRepoScannerConfig]):
                                 arguments=final_args[1:],
                                 startTimeUtc=self.start_time,
                                 endTimeUtc=self.end_time,
-                                executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                                executionSuccessful=(
+                                    self.exit_code == 0 or self.exit_code == 1
+                                ),
                                 exitCode=self.exit_code,
                                 exitCodeDescription="\n".join(self.errors),
                                 workingDirectory=ArtifactLocation(

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1509,7 +1509,7 @@
                 "excluded_paths": [],
                 "ignore_nosec": false,
                 "install_timeout": 300,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null,
                 "tool_version": ">=1.7.0,<2.0.0"
               }
@@ -1526,7 +1526,7 @@
                   "NIST80053R5Checks": false,
                   "PCIDSS321Checks": false
                 },
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -1534,7 +1534,7 @@
               "enabled": true,
               "name": "cfn-nag",
               "options": {
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -1551,7 +1551,7 @@
                 ],
                 "install_timeout": 300,
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null,
                 "skip_frameworks": [],
                 "skip_path": [],
@@ -1570,7 +1570,7 @@
                   "results": {},
                   "version": null
                 },
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -1580,7 +1580,7 @@
               "options": {
                 "config_file": null,
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -1589,7 +1589,7 @@
               "name": "npm-audit",
               "options": {
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -1606,7 +1606,7 @@
                 "metrics": "auto",
                 "offline": false,
                 "patterns": [],
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity": [],
                 "severity_threshold": null,
                 "version": "v1.15.1"
@@ -1625,7 +1625,7 @@
                 "install_timeout": 300,
                 "metrics": "auto",
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity": [],
                 "severity_threshold": null,
                 "tool_version": null
@@ -1641,7 +1641,7 @@
                 "config_file": null,
                 "exclude": [],
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             }
@@ -1946,7 +1946,7 @@
             "excluded_paths": [],
             "ignore_nosec": false,
             "install_timeout": 300,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null,
             "tool_version": ">=1.7.0,<2.0.0"
           },
@@ -2038,7 +2038,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2269,7 +2269,7 @@
               "NIST80053R5Checks": false,
               "PCIDSS321Checks": false
             },
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Bandit scanner"
@@ -2309,7 +2309,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2515,7 +2515,7 @@
         "options": {
           "$ref": "#/$defs/CfnNagScannerConfigOptions",
           "default": {
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure CFN Nag scanner"
@@ -2537,7 +2537,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2591,7 +2591,7 @@
             ],
             "install_timeout": 300,
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null,
             "skip_frameworks": [],
             "skip_path": [],
@@ -2716,7 +2716,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -5660,7 +5660,7 @@
               "results": {},
               "version": null
             },
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure detect-secrets scanner"
@@ -5710,7 +5710,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -8106,7 +8106,7 @@
           "default": {
             "config_file": null,
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Grype scanner"
@@ -8150,7 +8150,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -11011,7 +11011,7 @@
           "$ref": "#/$defs/NpmAuditScannerConfigOptions",
           "default": {
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure NpmAudit scanner"
@@ -11038,7 +11038,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -11207,7 +11207,7 @@
             "metrics": "auto",
             "offline": false,
             "patterns": [],
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity": [],
             "severity_threshold": null,
             "version": "v1.15.1"
@@ -11283,7 +11283,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -15845,7 +15845,7 @@
               "excluded_paths": [],
               "ignore_nosec": false,
               "install_timeout": 300,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null,
               "tool_version": ">=1.7.0,<2.0.0"
             }
@@ -15866,7 +15866,7 @@
                 "NIST80053R5Checks": false,
                 "PCIDSS321Checks": false
               },
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -15878,7 +15878,7 @@
             "enabled": true,
             "name": "cfn-nag",
             "options": {
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -15899,7 +15899,7 @@
               ],
               "install_timeout": 300,
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null,
               "skip_frameworks": [],
               "skip_path": [],
@@ -15922,7 +15922,7 @@
                 "results": {},
                 "version": null
               },
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -15936,7 +15936,7 @@
             "options": {
               "config_file": null,
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -15949,7 +15949,7 @@
             "name": "npm-audit",
             "options": {
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -15970,7 +15970,7 @@
               "metrics": "auto",
               "offline": false,
               "patterns": [],
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity": [],
               "severity_threshold": null,
               "version": "v1.15.1"
@@ -15993,7 +15993,7 @@
               "install_timeout": 300,
               "metrics": "auto",
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity": [],
               "severity_threshold": null,
               "tool_version": null
@@ -16013,7 +16013,7 @@
               "config_file": null,
               "exclude": [],
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -16037,7 +16037,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -16313,7 +16313,7 @@
         "options": {
           "$ref": "#/$defs/ScannerOptionsBase",
           "default": {
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Scanner options"
@@ -16569,7 +16569,7 @@
             "install_timeout": 300,
             "metrics": "auto",
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity": [],
             "severity_threshold": null,
             "tool_version": null
@@ -16642,7 +16642,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -17998,7 +17998,7 @@
             "config_file": null,
             "exclude": [],
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Syft scanner"
@@ -18069,7 +18069,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -5701,10 +5701,18 @@
           "description": "Settings to use with detect-secrets. Refer to the detect-secrets documentation for formatting information. By default, all plugins will be used and no filters are configured. scan_settings takes precedence over baseline_file"
         },
         "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": 300,
-          "description": "Maximum time in seconds to allow the detect-secrets scan to run before aborting. Prevents hangs on pathological files.",
-          "title": "Scan Timeout",
-          "type": "integer"
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1509,6 +1509,7 @@
                 "excluded_paths": [],
                 "ignore_nosec": false,
                 "install_timeout": 300,
+                "scan_timeout": 300,
                 "severity_threshold": null,
                 "tool_version": ">=1.7.0,<2.0.0"
               }
@@ -1525,6 +1526,7 @@
                   "NIST80053R5Checks": false,
                   "PCIDSS321Checks": false
                 },
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -1532,6 +1534,7 @@
               "enabled": true,
               "name": "cfn-nag",
               "options": {
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -1548,6 +1551,7 @@
                 ],
                 "install_timeout": 300,
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null,
                 "skip_frameworks": [],
                 "skip_path": [],
@@ -1576,6 +1580,7 @@
               "options": {
                 "config_file": null,
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -1584,6 +1589,7 @@
               "name": "npm-audit",
               "options": {
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -1600,6 +1606,7 @@
                 "metrics": "auto",
                 "offline": false,
                 "patterns": [],
+                "scan_timeout": 300,
                 "severity": [],
                 "severity_threshold": null,
                 "version": "v1.15.1"
@@ -1618,6 +1625,7 @@
                 "install_timeout": 300,
                 "metrics": "auto",
                 "offline": false,
+                "scan_timeout": 300,
                 "severity": [],
                 "severity_threshold": null,
                 "tool_version": null
@@ -1633,6 +1641,7 @@
                 "config_file": null,
                 "exclude": [],
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             }
@@ -1937,6 +1946,7 @@
             "excluded_paths": [],
             "ignore_nosec": false,
             "install_timeout": 300,
+            "scan_timeout": 300,
             "severity_threshold": null,
             "tool_version": ">=1.7.0,<2.0.0"
           },
@@ -2017,6 +2027,20 @@
           "description": "Timeout in seconds for tool installation",
           "title": "Install Timeout",
           "type": "integer"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -2245,6 +2269,7 @@
               "NIST80053R5Checks": false,
               "PCIDSS321Checks": false
             },
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Bandit scanner"
@@ -2273,6 +2298,20 @@
             "PCIDSS321Checks": false
           },
           "description": "CDK Nag packs to enable"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -2476,6 +2515,7 @@
         "options": {
           "$ref": "#/$defs/CfnNagScannerConfigOptions",
           "default": {
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure CFN Nag scanner"
@@ -2487,6 +2527,20 @@
     "CfnNagScannerConfigOptions": {
       "additionalProperties": true,
       "properties": {
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
+        },
         "severity_threshold": {
           "anyOf": [
             {
@@ -2537,6 +2591,7 @@
             ],
             "install_timeout": 300,
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null,
             "skip_frameworks": [],
             "skip_path": [],
@@ -2650,6 +2705,20 @@
           "description": "Run in offline mode, disabling policy downloads",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -8029,6 +8098,7 @@
           "default": {
             "config_file": null,
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Grype scanner"
@@ -8061,6 +8131,20 @@
           "description": "Run in offline mode, disabling database updates and validation",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -10919,6 +11003,7 @@
           "$ref": "#/$defs/NpmAuditScannerConfigOptions",
           "default": {
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure NpmAudit scanner"
@@ -10934,6 +11019,20 @@
           "description": "Run in offline mode, using locally cached data",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -11100,6 +11199,7 @@
             "metrics": "auto",
             "offline": false,
             "patterns": [],
+            "scan_timeout": 300,
             "severity": [],
             "severity_threshold": null,
             "version": "v1.15.1"
@@ -11164,6 +11264,20 @@
           },
           "title": "Patterns",
           "type": "array"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity": {
           "default": [],
@@ -15723,6 +15837,7 @@
               "excluded_paths": [],
               "ignore_nosec": false,
               "install_timeout": 300,
+              "scan_timeout": 300,
               "severity_threshold": null,
               "tool_version": ">=1.7.0,<2.0.0"
             }
@@ -15743,6 +15858,7 @@
                 "NIST80053R5Checks": false,
                 "PCIDSS321Checks": false
               },
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -15754,6 +15870,7 @@
             "enabled": true,
             "name": "cfn-nag",
             "options": {
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -15774,6 +15891,7 @@
               ],
               "install_timeout": 300,
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null,
               "skip_frameworks": [],
               "skip_path": [],
@@ -15810,6 +15928,7 @@
             "options": {
               "config_file": null,
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -15822,6 +15941,7 @@
             "name": "npm-audit",
             "options": {
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -15842,6 +15962,7 @@
               "metrics": "auto",
               "offline": false,
               "patterns": [],
+              "scan_timeout": 300,
               "severity": [],
               "severity_threshold": null,
               "version": "v1.15.1"
@@ -15864,6 +15985,7 @@
               "install_timeout": 300,
               "metrics": "auto",
               "offline": false,
+              "scan_timeout": 300,
               "severity": [],
               "severity_threshold": null,
               "tool_version": null
@@ -15883,6 +16005,7 @@
               "config_file": null,
               "exclude": [],
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -15896,6 +16019,20 @@
       "additionalProperties": true,
       "description": "Base class for scanner options.",
       "properties": {
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
+        },
         "severity_threshold": {
           "anyOf": [
             {
@@ -16168,6 +16305,7 @@
         "options": {
           "$ref": "#/$defs/ScannerOptionsBase",
           "default": {
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Scanner options"
@@ -16423,6 +16561,7 @@
             "install_timeout": 300,
             "metrics": "auto",
             "offline": false,
+            "scan_timeout": 300,
             "severity": [],
             "severity_threshold": null,
             "tool_version": null
@@ -16484,6 +16623,20 @@
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity": {
           "default": [],
@@ -17837,6 +17990,7 @@
             "config_file": null,
             "exclude": [],
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Syft scanner"
@@ -17896,6 +18050,20 @@
           "description": "Run in offline mode, disabling update checks",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -21524,7 +21692,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.6.0"
+                "version": "3.5.9"
               },
               "extensions": [],
               "properties": null

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -21692,7 +21692,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.5.9"
+                "version": "3.6.0"
               },
               "extensions": [],
               "properties": null

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -271,7 +271,7 @@
                 "excluded_paths": [],
                 "ignore_nosec": false,
                 "install_timeout": 300,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null,
                 "tool_version": ">=1.7.0,<2.0.0"
               }
@@ -288,7 +288,7 @@
                   "NIST80053R5Checks": false,
                   "PCIDSS321Checks": false
                 },
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -296,7 +296,7 @@
               "enabled": true,
               "name": "cfn-nag",
               "options": {
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -313,7 +313,7 @@
                 ],
                 "install_timeout": 300,
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null,
                 "skip_frameworks": [],
                 "skip_path": [],
@@ -332,7 +332,7 @@
                   "results": {},
                   "version": null
                 },
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -342,7 +342,7 @@
               "options": {
                 "config_file": null,
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -351,7 +351,7 @@
               "name": "npm-audit",
               "options": {
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             },
@@ -368,7 +368,7 @@
                 "metrics": "auto",
                 "offline": false,
                 "patterns": [],
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity": [],
                 "severity_threshold": null,
                 "version": "v1.15.1"
@@ -387,7 +387,7 @@
                 "install_timeout": 300,
                 "metrics": "auto",
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity": [],
                 "severity_threshold": null,
                 "tool_version": null
@@ -403,7 +403,7 @@
                 "config_file": null,
                 "exclude": [],
                 "offline": false,
-                "scan_timeout": 300,
+                "scan_timeout": 1800,
                 "severity_threshold": null
               }
             }
@@ -590,7 +590,7 @@
             "excluded_paths": [],
             "ignore_nosec": false,
             "install_timeout": 300,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null,
             "tool_version": ">=1.7.0,<2.0.0"
           },
@@ -682,7 +682,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -857,7 +857,7 @@
               "NIST80053R5Checks": false,
               "PCIDSS321Checks": false
             },
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Bandit scanner"
@@ -897,7 +897,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -942,7 +942,7 @@
         "options": {
           "$ref": "#/$defs/CfnNagScannerConfigOptions",
           "default": {
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure CFN Nag scanner"
@@ -964,7 +964,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -1018,7 +1018,7 @@
             ],
             "install_timeout": 300,
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null,
             "skip_frameworks": [],
             "skip_path": [],
@@ -1143,7 +1143,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -1533,7 +1533,7 @@
               "results": {},
               "version": null
             },
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure detect-secrets scanner"
@@ -1583,7 +1583,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -1854,7 +1854,7 @@
           "default": {
             "config_file": null,
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Grype scanner"
@@ -1898,7 +1898,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2313,7 +2313,7 @@
           "$ref": "#/$defs/NpmAuditScannerConfigOptions",
           "default": {
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure NpmAudit scanner"
@@ -2340,7 +2340,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2427,7 +2427,7 @@
             "metrics": "auto",
             "offline": false,
             "patterns": [],
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity": [],
             "severity_threshold": null,
             "version": "v1.15.1"
@@ -2503,7 +2503,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -2994,7 +2994,7 @@
               "excluded_paths": [],
               "ignore_nosec": false,
               "install_timeout": 300,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null,
               "tool_version": ">=1.7.0,<2.0.0"
             }
@@ -3015,7 +3015,7 @@
                 "NIST80053R5Checks": false,
                 "PCIDSS321Checks": false
               },
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3027,7 +3027,7 @@
             "enabled": true,
             "name": "cfn-nag",
             "options": {
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3048,7 +3048,7 @@
               ],
               "install_timeout": 300,
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null,
               "skip_frameworks": [],
               "skip_path": [],
@@ -3071,7 +3071,7 @@
                 "results": {},
                 "version": null
               },
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3085,7 +3085,7 @@
             "options": {
               "config_file": null,
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3098,7 +3098,7 @@
             "name": "npm-audit",
             "options": {
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3119,7 +3119,7 @@
               "metrics": "auto",
               "offline": false,
               "patterns": [],
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity": [],
               "severity_threshold": null,
               "version": "v1.15.1"
@@ -3142,7 +3142,7 @@
               "install_timeout": 300,
               "metrics": "auto",
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity": [],
               "severity_threshold": null,
               "tool_version": null
@@ -3162,7 +3162,7 @@
               "config_file": null,
               "exclude": [],
               "offline": false,
-              "scan_timeout": 300,
+              "scan_timeout": 1800,
               "severity_threshold": null
             }
           },
@@ -3186,7 +3186,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -3462,7 +3462,7 @@
         "options": {
           "$ref": "#/$defs/ScannerOptionsBase",
           "default": {
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Scanner options"
@@ -3513,7 +3513,7 @@
             "install_timeout": 300,
             "metrics": "auto",
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity": [],
             "severity_threshold": null,
             "tool_version": null
@@ -3586,7 +3586,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },
@@ -3664,7 +3664,7 @@
             "config_file": null,
             "exclude": [],
             "offline": false,
-            "scan_timeout": 300,
+            "scan_timeout": 1800,
             "severity_threshold": null
           },
           "description": "Configure Syft scanner"
@@ -3735,7 +3735,7 @@
               "type": "null"
             }
           ],
-          "default": 300,
+          "default": 1800,
           "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
           "title": "Scan Timeout"
         },

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -271,6 +271,7 @@
                 "excluded_paths": [],
                 "ignore_nosec": false,
                 "install_timeout": 300,
+                "scan_timeout": 300,
                 "severity_threshold": null,
                 "tool_version": ">=1.7.0,<2.0.0"
               }
@@ -287,6 +288,7 @@
                   "NIST80053R5Checks": false,
                   "PCIDSS321Checks": false
                 },
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -294,6 +296,7 @@
               "enabled": true,
               "name": "cfn-nag",
               "options": {
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -310,6 +313,7 @@
                 ],
                 "install_timeout": 300,
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null,
                 "skip_frameworks": [],
                 "skip_path": [],
@@ -338,6 +342,7 @@
               "options": {
                 "config_file": null,
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -346,6 +351,7 @@
               "name": "npm-audit",
               "options": {
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             },
@@ -362,6 +368,7 @@
                 "metrics": "auto",
                 "offline": false,
                 "patterns": [],
+                "scan_timeout": 300,
                 "severity": [],
                 "severity_threshold": null,
                 "version": "v1.15.1"
@@ -380,6 +387,7 @@
                 "install_timeout": 300,
                 "metrics": "auto",
                 "offline": false,
+                "scan_timeout": 300,
                 "severity": [],
                 "severity_threshold": null,
                 "tool_version": null
@@ -395,6 +403,7 @@
                 "config_file": null,
                 "exclude": [],
                 "offline": false,
+                "scan_timeout": 300,
                 "severity_threshold": null
               }
             }
@@ -581,6 +590,7 @@
             "excluded_paths": [],
             "ignore_nosec": false,
             "install_timeout": 300,
+            "scan_timeout": 300,
             "severity_threshold": null,
             "tool_version": ">=1.7.0,<2.0.0"
           },
@@ -661,6 +671,20 @@
           "description": "Timeout in seconds for tool installation",
           "title": "Install Timeout",
           "type": "integer"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -833,6 +857,7 @@
               "NIST80053R5Checks": false,
               "PCIDSS321Checks": false
             },
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Bandit scanner"
@@ -861,6 +886,20 @@
             "PCIDSS321Checks": false
           },
           "description": "CDK Nag packs to enable"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -903,6 +942,7 @@
         "options": {
           "$ref": "#/$defs/CfnNagScannerConfigOptions",
           "default": {
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure CFN Nag scanner"
@@ -914,6 +954,20 @@
     "CfnNagScannerConfigOptions": {
       "additionalProperties": true,
       "properties": {
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
+        },
         "severity_threshold": {
           "anyOf": [
             {
@@ -964,6 +1018,7 @@
             ],
             "install_timeout": 300,
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null,
             "skip_frameworks": [],
             "skip_path": [],
@@ -1077,6 +1132,20 @@
           "description": "Run in offline mode, disabling policy downloads",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -1777,6 +1846,7 @@
           "default": {
             "config_file": null,
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Grype scanner"
@@ -1809,6 +1879,20 @@
           "description": "Run in offline mode, disabling database updates and validation",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -2221,6 +2305,7 @@
           "$ref": "#/$defs/NpmAuditScannerConfigOptions",
           "default": {
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure NpmAudit scanner"
@@ -2236,6 +2321,20 @@
           "description": "Run in offline mode, using locally cached data",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [
@@ -2320,6 +2419,7 @@
             "metrics": "auto",
             "offline": false,
             "patterns": [],
+            "scan_timeout": 300,
             "severity": [],
             "severity_threshold": null,
             "version": "v1.15.1"
@@ -2384,6 +2484,20 @@
           },
           "title": "Patterns",
           "type": "array"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity": {
           "default": [],
@@ -2872,6 +2986,7 @@
               "excluded_paths": [],
               "ignore_nosec": false,
               "install_timeout": 300,
+              "scan_timeout": 300,
               "severity_threshold": null,
               "tool_version": ">=1.7.0,<2.0.0"
             }
@@ -2892,6 +3007,7 @@
                 "NIST80053R5Checks": false,
                 "PCIDSS321Checks": false
               },
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -2903,6 +3019,7 @@
             "enabled": true,
             "name": "cfn-nag",
             "options": {
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -2923,6 +3040,7 @@
               ],
               "install_timeout": 300,
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null,
               "skip_frameworks": [],
               "skip_path": [],
@@ -2959,6 +3077,7 @@
             "options": {
               "config_file": null,
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -2971,6 +3090,7 @@
             "name": "npm-audit",
             "options": {
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -2991,6 +3111,7 @@
               "metrics": "auto",
               "offline": false,
               "patterns": [],
+              "scan_timeout": 300,
               "severity": [],
               "severity_threshold": null,
               "version": "v1.15.1"
@@ -3013,6 +3134,7 @@
               "install_timeout": 300,
               "metrics": "auto",
               "offline": false,
+              "scan_timeout": 300,
               "severity": [],
               "severity_threshold": null,
               "tool_version": null
@@ -3032,6 +3154,7 @@
               "config_file": null,
               "exclude": [],
               "offline": false,
+              "scan_timeout": 300,
               "severity_threshold": null
             }
           },
@@ -3045,6 +3168,20 @@
       "additionalProperties": true,
       "description": "Base class for scanner options.",
       "properties": {
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
+        },
         "severity_threshold": {
           "anyOf": [
             {
@@ -3317,6 +3454,7 @@
         "options": {
           "$ref": "#/$defs/ScannerOptionsBase",
           "default": {
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Scanner options"
@@ -3367,6 +3505,7 @@
             "install_timeout": 300,
             "metrics": "auto",
             "offline": false,
+            "scan_timeout": 300,
             "severity": [],
             "severity_threshold": null,
             "tool_version": null
@@ -3428,6 +3567,20 @@
           "description": "Run in offline mode, using locally cached rules.",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity": {
           "default": [],
@@ -3503,6 +3656,7 @@
             "config_file": null,
             "exclude": [],
             "offline": false,
+            "scan_timeout": 300,
             "severity_threshold": null
           },
           "description": "Configure Syft scanner"
@@ -3562,6 +3716,20 @@
           "description": "Run in offline mode, disabling update checks",
           "title": "Offline",
           "type": "boolean"
+        },
+        "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 300,
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -1574,10 +1574,18 @@
           "description": "Settings to use with detect-secrets. Refer to the detect-secrets documentation for formatting information. By default, all plugins will be used and no filters are configured. scan_settings takes precedence over baseline_file"
         },
         "scan_timeout": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": 300,
-          "description": "Maximum time in seconds to allow the detect-secrets scan to run before aborting. Prevents hangs on pathological files.",
-          "title": "Scan Timeout",
-          "type": "integer"
+          "description": "Maximum time in seconds to allow this scanner's tool invocation to run before it is killed. Set to null to leave the scanner unbounded, which risks a scan that never completes.",
+          "title": "Scan Timeout"
         },
         "severity_threshold": {
           "anyOf": [

--- a/automated_security_helper/utils/subprocess_utils.py
+++ b/automated_security_helper/utils/subprocess_utils.py
@@ -193,6 +193,7 @@ def run_command_with_output_handling(
     class_name: str = None,
     encoding: Optional[str] = None,
     errors: str = "replace",
+    timeout: Optional[float] = None,
 ) -> Dict[str, Any]:
     """Run a subprocess with the given command and handle output according to preferences.
 
@@ -205,9 +206,14 @@ def run_command_with_output_handling(
         env: Environment variables for the command
         shell: Whether to run the command in a shell
         class_name: Optional class name for log file naming
+        timeout: Seconds to allow the command before it is killed. None leaves it
+            unbounded, which is the previous behaviour and the default so that
+            existing callers are unchanged.
 
     Returns:
-        Dictionary with stdout, stderr, and returncode if requested
+        Dictionary with stdout, stderr, and returncode if requested. A timed-out
+        command returns returncode 124 (matching coreutils ``timeout(1)``) and
+        ``timed_out: True``, so callers can tell it from the generic failure path.
     """
     # Resolve the full path to the executable if possible
     if command and not shell:
@@ -234,6 +240,7 @@ def run_command_with_output_handling(
             env=env,
             encoding=encoding,
             errors=errors,
+            timeout=timeout,
         )
 
         # Use the actual returncode from the result
@@ -280,6 +287,32 @@ def run_command_with_output_handling(
                 response["stderr"] = result.stderr
 
         return response
+
+    except subprocess.TimeoutExpired as e:
+        # subprocess.run has already killed the child by the time this is raised,
+        # which is the point: without the kill the tool would keep running after
+        # ASH stopped waiting for it.
+        #
+        # Handled ahead of the generic branch below so a timeout is reported as
+        # such. That branch returns returncode 1 for everything, which cannot be
+        # told apart from a tool that simply exited 1.
+        error_msg = f"Command timed out after {timeout}s: {cmd_str}"
+        ASH_LOGGER.error(error_msg)
+        partial = {}
+        for stream_name in ("stdout", "stderr"):
+            captured = getattr(e, stream_name, None)
+            if not captured:
+                continue
+            if isinstance(captured, bytes):
+                captured = captured.decode("utf-8", errors="replace")
+            partial[stream_name] = captured
+        return {
+            "error": error_msg,
+            "returncode": 124,
+            "timed_out": True,
+            "stderr": f"{partial.get('stderr', '')}\n{error_msg}".strip(),
+            **{k: v for k, v in partial.items() if k == "stdout"},
+        }
 
     except Exception as e:
         error_msg = f"Error running {cmd_str}: {e}"
@@ -400,7 +433,9 @@ def get_host_uid() -> int:
         return int(result.stdout.strip())
     except Exception as e:
         ASH_LOGGER.error(f"Error getting host UID: {e}")
-        ASH_LOGGER.warning("Falling back to default UID 1000 (command 'id -u' unavailable on this platform)")
+        ASH_LOGGER.warning(
+            "Falling back to default UID 1000 (command 'id -u' unavailable on this platform)"
+        )
         return 1000  # Default UID as fallback
 
 
@@ -415,7 +450,9 @@ def get_host_gid() -> int:
         return int(result.stdout.strip())
     except Exception as e:
         ASH_LOGGER.error(f"Error getting host GID: {e}")
-        ASH_LOGGER.warning("Falling back to default GID 1000 (command 'id -g' unavailable on this platform)")
+        ASH_LOGGER.warning(
+            "Falling back to default GID 1000 (command 'id -g' unavailable on this platform)"
+        )
         return 1000  # Default GID as fallback
 
 

--- a/automated_security_helper/utils/uv_tool_runner.py
+++ b/automated_security_helper/utils/uv_tool_runner.py
@@ -383,6 +383,11 @@ class UVToolRunner:
                     class_name=class_name or f"UVTool_{tool_name}",
                     encoding="utf-8" if text else None,
                     errors="replace" if text else None,
+                    # Every scanner passes results_dir, so this is the branch they
+                    # take. Omitting timeout here meant the parameter was honoured
+                    # only on the fallback below, i.e. only for callers that do not
+                    # want output files -- which is none of the scanners.
+                    timeout=timeout,
                 )
 
                 # Create a CompletedProcess-like object from the response

--- a/tests/unit/plugin_modules/ash_builtin/scanners/test_npm_audit_offline_env.py
+++ b/tests/unit/plugin_modules/ash_builtin/scanners/test_npm_audit_offline_env.py
@@ -1,0 +1,182 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Offline mode must actually reach the subprocess with corepack's network off.
+
+Why this file exists
+--------------------
+#451 taught npm-audit to set ``COREPACK_ENABLE_NETWORK=0`` when
+``options.offline`` is set. ``COREPACK_ENABLE_DOWNLOAD_PROMPT=0`` (set in the
+Dockerfile) stops corepack *asking* before it downloads a package manager; it
+does not stop the download. In offline mode a download is wrong twice over --
+there is no network, so it fails, and it fails instead of using the package
+manager already cached in the image.
+
+Nothing tested it. Grepping the tree for ``COREPACK_ENABLE_NETWORK`` before this
+file found two hits, both in the scanner source and neither in a test, and that
+absence let two separate defects through:
+
+1. ``os.environ`` was used to build the environment while the module never
+   imported ``os``. ruff reports it as F821 and offline scans raised
+   ``NameError: name 'os' is not defined``. It shipped to main, because the only
+   code path that evaluates the expression is guarded by ``options.offline`` and
+   no test set that flag.
+
+2. A later merge resolved a conflict on the ``_run_subprocess`` call by keeping
+   the ``timeout=`` argument the other side added and dropping ``env=``. The
+   ``subprocess_env`` local was still computed just above the call, so the code
+   read as though it worked while the environment reached nothing -- a silent
+   revert of #451 that no test noticed.
+
+Both failure modes are invisible in a diff that looks reasonable, which is why
+the assertion here is on what ``_run_subprocess`` actually receives rather than
+on the shape of the source.
+
+Why assert on the call rather than run corepack
+-----------------------------------------------
+The contract worth pinning is "the offline environment reaches the child
+process". Actually invoking pnpm would need a package manager, a lock file and a
+network policy in the test environment, and would still not distinguish "env was
+never passed" from "corepack ignored it". The double records its kwargs, so a
+dropped argument fails loudly and immediately.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from automated_security_helper.plugin_modules.ash_builtin.scanners import (
+    npm_audit_scanner as npm_audit_module,
+)
+from automated_security_helper.plugin_modules.ash_builtin.scanners.npm_audit_scanner import (
+    NpmAuditScanner,
+    NpmAuditScannerConfig,
+    NpmAuditScannerConfigOptions,
+)
+
+
+def _scanner(context, *, offline: bool):
+    scanner = NpmAuditScanner(
+        context=context,
+        config=NpmAuditScannerConfig(
+            options=NpmAuditScannerConfigOptions(offline=offline)
+        ),
+    )
+    scanner.exit_code = 0
+    scanner.dependencies_satisfied = True
+    scanner.tool_version = "1.0.0"
+    return scanner
+
+
+def _run_scan(scanner, tmp_path):
+    """Drive scan() over one pnpm project and return the recorded kwargs.
+
+    ``fake_run`` takes ``**kwargs`` deliberately. Pinning the real signature here
+    would make this test fail whenever _run_subprocess gains an argument, which
+    is what happened to the syft double when ``timeout`` was added -- and a test
+    that breaks for that reason gets "fixed" by loosening the assertion.
+    """
+    root = tmp_path / "repo"
+    nested = root / "packages" / "sub"
+    nested.mkdir(parents=True)
+    (nested / "package.json").write_text('{"name":"sub"}')
+    (nested / "pnpm-lock.yaml").write_text("")
+    scanner.context.source_dir = root
+
+    captured = []
+
+    def fake_run(command, **kwargs):
+        captured.append(kwargs)
+        return {"stdout": '{"vulnerabilities":{}}', "returncode": 0}
+
+    with (
+        patch(
+            "automated_security_helper.plugin_modules.ash_builtin.scanners.npm_audit_scanner.find_executable",
+            return_value="/usr/local/bin/pnpm",
+        ),
+        patch(
+            "automated_security_helper.plugin_modules.ash_builtin.scanners.npm_audit_scanner.scan_set",
+            return_value=[str(nested / "package.json")],
+        ),
+        patch.object(scanner, "_pre_scan", return_value=True),
+        patch.object(scanner, "_post_scan"),
+        patch.object(scanner, "_run_subprocess", side_effect=fake_run),
+    ):
+        scanner.scan(target=root, target_type="source")
+
+    return captured
+
+
+def test_the_module_binds_os():
+    """Names the NameError directly, so the diagnosis is not 'offline scan broke'.
+
+    Kept separate from the behavioural tests because it fails for exactly one
+    reason and says so, where the scan-level test below fails for either defect.
+    """
+    assert hasattr(npm_audit_module, "os"), (
+        "npm_audit_scanner builds its offline environment from os.environ but "
+        "does not import os; offline scans raise NameError"
+    )
+
+
+def test_offline_mode_disables_corepack_network(test_plugin_context, tmp_path):
+    """The whole point of #451: the child process must see the flag."""
+    scanner = _scanner(test_plugin_context, offline=True)
+
+    captured = _run_scan(scanner, tmp_path)
+
+    assert captured, "scan() never reached _run_subprocess"
+    envs = [kw.get("env") for kw in captured]
+    assert any(
+        env is not None and env.get("COREPACK_ENABLE_NETWORK") == "0" for env in envs
+    ), (
+        "offline mode did not pass COREPACK_ENABLE_NETWORK=0 to the subprocess; "
+        f"envs seen: {[None if e is None else sorted(set(e) & {'COREPACK_ENABLE_NETWORK'}) for e in envs]}"
+    )
+
+
+def test_the_offline_environment_still_carries_the_parent_environment(
+    test_plugin_context, tmp_path
+):
+    """Replacing rather than extending os.environ would strip PATH, and the
+    package manager is found on PATH."""
+    scanner = _scanner(test_plugin_context, offline=True)
+
+    captured = _run_scan(scanner, tmp_path)
+
+    env = next(
+        kw["env"]
+        for kw in captured
+        if kw.get("env") and kw["env"].get("COREPACK_ENABLE_NETWORK") == "0"
+    )
+    for key in os_keys_expected_present():
+        assert key in env, f"offline env dropped {key} from the parent environment"
+
+
+def os_keys_expected_present():
+    """Parent-environment keys that are present on every platform CI runs on.
+
+    PATH is the load-bearing one; it is how the package manager is located.
+    """
+    return ["PATH"]
+
+
+@pytest.mark.parametrize("offline", [False])
+def test_online_mode_passes_no_environment_override(
+    test_plugin_context, tmp_path, offline
+):
+    """Online scans must not inherit the offline override.
+
+    Asserting None rather than "no COREPACK_ENABLE_NETWORK key" on purpose: the
+    scanner's contract is that it does not touch the environment unless offline,
+    and passing a full copy of os.environ online would silently change what the
+    child inherits if the caller ever set that variable themselves.
+    """
+    scanner = _scanner(test_plugin_context, offline=offline)
+
+    captured = _run_scan(scanner, tmp_path)
+
+    assert captured, "scan() never reached _run_subprocess"
+    assert all(kw.get("env") is None for kw in captured), (
+        f"online scan passed an env override: {[kw.get('env') for kw in captured]}"
+    )

--- a/tests/unit/plugin_modules/scanners/test_grep_scanner_base.py
+++ b/tests/unit/plugin_modules/scanners/test_grep_scanner_base.py
@@ -126,9 +126,7 @@ class TestOfflineCacheDiscovery:
         rule_file.write_text("rules: []")
         monkeypatch.setenv("SEMGREP_RULES_CACHE_DIR", str(tmp_path))
 
-        config = SemgrepScannerConfig(
-            options=SemgrepScannerConfigOptions(offline=True)
-        )
+        config = SemgrepScannerConfig(options=SemgrepScannerConfigOptions(offline=True))
         scanner = SemgrepScanner(context=test_plugin_context, config=config)
 
         pairs = _extra_arg_pairs(scanner)
@@ -225,8 +223,13 @@ def _run_post_scan_pipeline(scanner, target: Path, sarif_dict: dict) -> dict:
 
     captured: dict = {}
 
-    def fake_run_subprocess(self, command, results_dir, env=None):
+    # **kwargs rather than an explicit timeout parameter: this double stands in
+    # for _run_subprocess, and pinning its exact signature made three tests fail
+    # when the real method gained a `timeout` argument. The double only cares
+    # about command and results_dir, so it should ignore the rest.
+    def fake_run_subprocess(self, command, results_dir, env=None, **kwargs):
         captured["command"] = command
+        captured["kwargs"] = kwargs
         results_file = Path(results_dir) / "results_sarif.sarif"
         results_file.write_text(json.dumps(sarif_dict))
         self.exit_code = 0

--- a/tests/unit/plugin_modules/test_scanner_fixes.py
+++ b/tests/unit/plugin_modules/test_scanner_fixes.py
@@ -204,7 +204,12 @@ class TestSyftExcludePathPreservation:
         # command, results_dir and env. env carries the offline-mode overrides
         # (self.extra_env) and is None when there are none, so it must be accepted
         # here or scan() fails with a TypeError before the args can be inspected.
-        def capture_run(command, results_dir, env=None):
+        #
+        # **kwargs rather than an exhaustive parameter list, which is the same
+        # hazard the note above describes: pinning the signature made this test
+        # fail again when the real method gained a `timeout` argument. The double
+        # only inspects command and env, so it should ignore whatever else arrives.
+        def capture_run(command, results_dir, env=None, **kwargs):
             captured_commands.append(command)
             captured_envs.append(env)
 

--- a/tests/unit/utils/test_subprocess_timeout.py
+++ b/tests/unit/utils/test_subprocess_timeout.py
@@ -35,6 +35,7 @@ error path returned for everything.
 
 import sys
 import time
+from unittest.mock import patch
 
 from automated_security_helper.base.options import ScannerOptionsBase
 from automated_security_helper.utils.subprocess_utils import (
@@ -132,6 +133,131 @@ class TestNormalExecutionIsUnaffected:
 
         assert response["returncode"] == 0
         assert "unbounded" in response.get("stdout", "")
+
+
+class TestTheUvToolPathIsAlsoBounded:
+    """The path bandit, checkov and semgrep actually take.
+
+    `_run_subprocess` has two execution paths. The uv-tool branch returns before
+    the direct-execution call, so a timeout wired only into the latter applies
+    exclusively to scanners for which uv is *unavailable*.
+
+    bandit, checkov and semgrep set `use_uv_tool = True` unconditionally and clear
+    it only when uv is missing. ASH ships via uv, so on a normal install the
+    reported bandit hang went through the uv branch, unbounded, no matter what
+    scan_timeout said. The original version of this file tested
+    `run_command_with_output_handling` directly and never exercised that branch,
+    which is exactly why the gap survived a green build.
+    """
+
+    def test_run_tool_forwards_the_timeout_on_the_results_dir_branch(self, tmp_path):
+        """This is the branch scanners take: they all pass results_dir.
+
+        `run_tool` already accepted a `timeout`, but honoured it only on its
+        fallback path -- the one used by callers that do *not* want output files,
+        i.e. none of the scanners.
+        """
+        from automated_security_helper.utils import subprocess_utils
+        from automated_security_helper.utils.uv_tool_runner import get_uv_tool_runner
+
+        captured = {}
+
+        def _fake(**kwargs):
+            captured.update(kwargs)
+            return {"returncode": 0, "stdout": "", "stderr": ""}
+
+        with patch.object(
+            subprocess_utils, "run_command_with_output_handling", side_effect=_fake
+        ):
+            get_uv_tool_runner().run_tool(
+                tool_name="bandit",
+                args=["--version"],
+                results_dir=tmp_path,
+                timeout=_TIMEOUT_SECONDS,
+            )
+
+        assert captured.get("timeout") == _TIMEOUT_SECONDS, (
+            "run_tool dropped the timeout on the results_dir branch, so every "
+            "uv-run scanner executes unbounded."
+        )
+
+    def test_try_uv_tool_execution_forwards_the_timeout(self, tmp_path):
+        """The seam between the plugin and the runner.
+
+        Patched at `uv_tool_runner.get_uv_tool_runner`, not on the mixin module.
+        The mixin imports it *inside* the method, so the name is resolved from the
+        source module at call time and never becomes an attribute of
+        uv_tool_mixin -- patching there with create=True silently installs a decoy
+        that nothing ever reads, and the test passes for the wrong reason.
+        """
+        from automated_security_helper.utils import uv_tool_runner as runner_module
+        from automated_security_helper.base.uv_tool_mixin import UVToolMixin
+
+        class _Probe(UVToolMixin):
+            """Minimal host: the mixin only needs these three from its owner."""
+
+            command = "bandit"
+            use_uv_tool = True
+
+            def _plugin_log(self, *args, **kwargs):
+                return None
+
+            def _get_tool_package_extras(self):
+                return None
+
+            def _get_tool_version_constraint(self):
+                return None
+
+        captured = {}
+
+        class _Runner:
+            def is_uv_available(self):
+                return True
+
+            def run_tool(self, **kwargs):
+                captured.update(kwargs)
+
+                class _Result:
+                    stdout = ""
+                    stderr = ""
+                    returncode = 0
+
+                return _Result()
+
+        with patch.object(runner_module, "get_uv_tool_runner", return_value=_Runner()):
+            _Probe()._try_uv_tool_execution(
+                ["bandit", "--version"],
+                tmp_path,
+                results_dir=tmp_path,
+                timeout=_TIMEOUT_SECONDS,
+            )
+
+        assert captured.get("timeout") == _TIMEOUT_SECONDS, (
+            "_try_uv_tool_execution accepted a timeout but did not pass it to "
+            f"run_tool: {captured!r}"
+        )
+
+
+def test_detect_secrets_inherits_the_shared_scan_timeout():
+    """detect-secrets must not carry its own copy of the option.
+
+    Its local field declared `int` with no `ge`, shadowing the base field and
+    giving one scanner a different contract from the rest: `scan_timeout: null`,
+    documented by the base field as the way to run unbounded, raised a validation
+    error for detect-secrets only, and `scan_timeout: 0` was accepted here and
+    rejected everywhere else -- then passed to future.result(timeout=0), timing out
+    instantly on every run.
+    """
+    from automated_security_helper.plugin_modules.ash_builtin.scanners.detect_secrets_scanner import (
+        DetectSecretsScannerConfigOptions,
+    )
+
+    field = DetectSecretsScannerConfigOptions.model_fields["scan_timeout"]
+
+    assert DetectSecretsScannerConfigOptions(scan_timeout=None).scan_timeout is None, (
+        "detect-secrets rejects scan_timeout: null, so it still shadows the base "
+        f"field: {field!r}"
+    )
 
 
 def test_scanner_options_expose_a_scan_timeout_default():

--- a/tests/unit/utils/test_subprocess_timeout.py
+++ b/tests/unit/utils/test_subprocess_timeout.py
@@ -1,0 +1,145 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A scanner subprocess must be bounded, not left to run forever.
+
+Why this file exists
+--------------------
+Bandit ran for over 50 minutes under the MCP server and never finished. The same
+project scanned in about 20 seconds from the CLI, so the report reads like an MCP
+bug, but the cause is simpler: nothing bounded the scanner subprocess at all.
+
+`run_command_with_output_handling` called `subprocess.run` with no `timeout`, and
+that is the single call every template-based scanner goes through
+(`ScannerPluginBase.scan` -> `_run_subprocess` -> here). So bandit, checkov,
+semgrep, grype, syft, opengrep, cfn_nag and npm-audit were all equally unbounded.
+
+detect-secrets was the exception, and it is the reason the report contrasts the
+two: it grew its own `scan_timeout` option (default 300s) and enforces it with
+`future.result(timeout=...)` in its own overridden scan. That was a per-scanner
+workaround for a gap in the shared path, which is why only that one scanner
+timed out cleanly in the reporter's log.
+
+What "bounded" has to mean
+--------------------------
+`subprocess.run(timeout=...)` raises TimeoutExpired *and kills the child*. That
+matters more than the exception: without the kill, the scanner process would keep
+holding CPU after ASH stopped waiting for it. The tests below assert on elapsed
+time to prove the call actually returns early, rather than only that some error
+was reported.
+
+Exit code 124 is used for a timeout, matching coreutils `timeout(1)`, so a
+timed-out scanner is distinguishable from the generic returncode 1 the previous
+error path returned for everything.
+"""
+
+import sys
+import time
+
+from automated_security_helper.base.options import ScannerOptionsBase
+from automated_security_helper.utils.subprocess_utils import (
+    run_command_with_output_handling,
+)
+
+# Long enough that a passing test cannot have waited for it.
+_SLEEP_SECONDS = 60
+_TIMEOUT_SECONDS = 2
+
+
+def _sleep_command(seconds: int = _SLEEP_SECONDS):
+    return [sys.executable, "-c", f"import time; time.sleep({seconds})"]
+
+
+class TestTimeoutIsEnforced:
+    def test_a_hanging_command_returns_instead_of_blocking(self, tmp_path):
+        """The reported failure mode, reduced to its smallest form."""
+        started = time.monotonic()
+
+        response = run_command_with_output_handling(
+            command=_sleep_command(),
+            results_dir=tmp_path,
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+        elapsed = time.monotonic() - started
+
+        # Generous headroom over the timeout for interpreter startup on a loaded
+        # runner, while still far below the 60s the command wanted.
+        assert elapsed < 30, (
+            f"Call took {elapsed:.1f}s for a {_TIMEOUT_SECONDS}s timeout, so the "
+            "timeout is not being applied to the subprocess."
+        )
+        assert response["returncode"] == 124
+        assert response.get("timed_out") is True
+
+    def test_timeout_message_names_the_limit(self, tmp_path):
+        """A hang is hard to diagnose, so the message has to say what happened."""
+        response = run_command_with_output_handling(
+            command=_sleep_command(),
+            results_dir=tmp_path,
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+        combined = f"{response.get('error', '')} {response.get('stderr', '')}"
+        assert "timed out" in combined.lower()
+        assert str(_TIMEOUT_SECONDS) in combined
+
+    def test_timeout_is_distinguishable_from_a_generic_failure(self, tmp_path):
+        """124 vs 1.
+
+        The previous error path returned returncode 1 for every exception, so a
+        caller could not tell a timeout from a missing binary. Anything that keys
+        off the exit code needs those to differ.
+        """
+        timed_out = run_command_with_output_handling(
+            command=_sleep_command(), results_dir=tmp_path, timeout=_TIMEOUT_SECONDS
+        )
+        failed = run_command_with_output_handling(
+            command=[sys.executable, "-c", "raise SystemExit(3)"],
+            results_dir=tmp_path,
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+        assert timed_out["returncode"] == 124
+        assert failed["returncode"] == 3
+        assert failed.get("timed_out") is not True
+
+
+class TestNormalExecutionIsUnaffected:
+    def test_fast_command_succeeds_within_a_timeout(self, tmp_path):
+        response = run_command_with_output_handling(
+            command=[sys.executable, "-c", "print('done')"],
+            results_dir=tmp_path,
+            stdout_preference="return",
+            timeout=_TIMEOUT_SECONDS,
+        )
+
+        assert response["returncode"] == 0
+        assert "done" in response.get("stdout", "")
+        assert response.get("timed_out") is not True
+
+    def test_no_timeout_argument_keeps_previous_behaviour(self, tmp_path):
+        """Omitting timeout must not start bounding callers that never asked.
+
+        The parameter defaults to None so existing callers behave exactly as
+        before; only the scanner template opts in.
+        """
+        response = run_command_with_output_handling(
+            command=[sys.executable, "-c", "print('unbounded')"],
+            results_dir=tmp_path,
+            stdout_preference="return",
+        )
+
+        assert response["returncode"] == 0
+        assert "unbounded" in response.get("stdout", "")
+
+
+def test_scanner_options_expose_a_scan_timeout_default():
+    """Every scanner gets the knob, not just the one that grew its own.
+
+    300s matches the default detect-secrets already chose for the same problem,
+    and what the issue asks for.
+    """
+    options = ScannerOptionsBase()
+
+    assert options.scan_timeout == 300

--- a/tests/unit/utils/test_subprocess_timeout.py
+++ b/tests/unit/utils/test_subprocess_timeout.py
@@ -260,12 +260,62 @@ def test_detect_secrets_inherits_the_shared_scan_timeout():
     )
 
 
+def test_scanners_that_override_scan_still_pass_the_timeout():
+    """A field that appears in a schema and does nothing is worse than absent.
+
+    scan_timeout lives on ScannerOptionsBase, so it shows up in every scanner's
+    generated schema. But six scanners override `scan()` and call
+    `_run_subprocess` themselves rather than going through the template, so
+    setting the option on them had no effect and nothing said so.
+
+    This is a structural check on the source rather than a behavioural one:
+    driving each of the six through a real scan needs a PluginContext, a target
+    tree and per-tool fixtures, which is a wider harness than the property
+    warrants. It catches the regression that matters -- someone adding another
+    `scan()` override without threading the timeout -- and the message says where
+    to look.
+    """
+    import pathlib
+
+    repo_root = pathlib.Path(__file__).resolve().parents[2]
+    overriding_scanners = [
+        "plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py",
+        "plugin_modules/ash_builtin/scanners/npm_audit_scanner.py",
+        "plugin_modules/ash_builtin/scanners/syft_scanner.py",
+        "plugin_modules/ash_ferret_plugins/ferret_scanner.py",
+        "plugin_modules/ash_snyk_plugins/snyk_code_scanner.py",
+        "plugin_modules/ash_trivy_plugins/trivy_repo_scanner.py",
+    ]
+
+    missing = []
+    for rel in overriding_scanners:
+        path = repo_root / "automated_security_helper" / rel
+        if not path.exists():
+            continue
+        if "_effective_scan_timeout()" not in path.read_text(encoding="utf-8"):
+            missing.append(rel)
+
+    assert not missing, (
+        "These scanners override scan() and call _run_subprocess without a "
+        "timeout, so scan_timeout is silently ignored for them even though it "
+        f"appears in their schema: {missing}"
+    )
+
+
 def test_scanner_options_expose_a_scan_timeout_default():
     """Every scanner gets the knob, not just the one that grew its own.
 
-    300s matches the default detect-secrets already chose for the same problem,
-    and what the issue asks for.
+    1800 rather than the 300 detect-secrets chose, and rather than the 300 the
+    issue suggested. Two reasons: it matches the timeout ASH already declares for
+    a scan operation (mcp_resource_management.scan_timeout_seconds), so there is
+    one number rather than two differing by 6x; and 300 would newly fail scans
+    that succeed today -- checkov on a large Terraform tree fetching external
+    modules, grype's first-run DB pull, semgrep against a full ruleset all
+    routinely exceed five minutes.
+
+    A genuinely stuck scanner now burns 30 minutes before it is cut, which is the
+    cost of not breaking working scans.
     """
     options = ScannerOptionsBase()
 
-    assert options.scan_timeout == 300
+    assert options.scan_timeout == 1800


### PR DESCRIPTION
## Root cause

Nothing bounded the scanner subprocess. `run_command_with_output_handling` called `subprocess.run` with **no `timeout`**, and that is the call every template-based scanner reaches through `ScannerPluginBase.scan` -> `_run_subprocess`.

Two details worth knowing:

- The sibling `run_command` **in the same module** has had full timeout handling all along. It is simply not the function scanners go through.
- detect-secrets is the exception the report contrasts against: it grew *its own* `scan_timeout` option enforced with `future.result(timeout=...)` in its own `scan` override — a per-scanner workaround for a gap in the shared path.

## Three links were missing the argument, not one

This is the part to review, and it is the reason an earlier revision of this PR **did not fix the reported bug**:

```
plugin_base._run_subprocess  ->  _try_uv_tool_execution            (never passed it)
uv_tool_mixin                ->  run_tool                          (never passed it)
uv_tool_runner.run_tool      ->  run_command_with_output_handling  (honoured timeout
                                 only on its fallback path; every scanner passes
                                 results_dir and so took the other branch)
```

`_run_subprocess` has two execution paths, and **the uv-tool branch returns before the direct-execution call**. bandit, checkov and semgrep all set `use_uv_tool = True` unconditionally and clear it only when uv is *missing*. ASH ships via uv/uvx, so on a normal install bandit ran `uv tool run bandit` with no bound at all — the 50-minute hang was unchanged, and whether the cap applied depended on whether uv happened to be installed.

`run_tool` already declared a `timeout` parameter, which is exactly why this looked wired up. It was accepted and then dropped for the only callers that needed it.

## detect-secrets' duplicate field is gone

It declared `int` with no `ge`, shadowing the new base field and giving one scanner a different contract: `scan_timeout: null` — documented by the base field as the way to run unbounded — raised a validation error *there only*, and `scan_timeout: 0` was accepted there and rejected elsewhere, then passed straight to `future.result(timeout=0)`, timing out instantly on every run. Schemas regenerated for the shape change.

## Please sanity-check the default

**This bounds scans that previously ran unbounded.** A large repository that used to take 400s will now fail that scanner until the timeout is raised. That is intended, and the alternative is leaving the hang in place — but 300 is a policy choice, not a derived value, and it is a one-line change if you would rather start at the 1800 already used by `mcp_resource_management.scan_timeout_seconds`.

Related, and not addressed here: six scanners (`cfn_nag`, `npm-audit`, `syft`, `trivy`, `snyk`, `ferret`) override `scan()` and call `_run_subprocess` without a timeout, so the field appears in their schema but is not enforced. Worth a follow-up either to pass it at those call sites or to scope the field.

## Tests

The new `TestTheUvToolPathIsAlsoBounded` exercises the uv branch. The earlier tests did not — they called `run_command_with_output_handling` directly and never reached it, which is precisely why the gap survived a green build.

One of the new tests initially passed for the wrong reason: patching `get_uv_tool_runner` on the *mixin* module with `create=True` installs a decoy, because the mixin imports it inside the method and the name never becomes an attribute there. It patches the source module now. Worth knowing if you add similar tests.

## Verification

Full-suite differential, separate worktrees, same venv:

| | passed | failed | errors |
|---|---|---|---|
| `main` | 2881 | 87 | 2 |
| this branch | **2890** | 87 | 2 |

Those 87 are an older `mcp` SDK in the local venv and reproduce unchanged on `main`. ruff findings on the touched files are identical to `main` (the pre-existing E402 cluster, line-shifted).

Fixes #357

---

## Update after review

Three changes, and the first one means the original PR did not do what it claimed.

**1. The timeout never reached bandit, checkov or semgrep.** `_run_subprocess` accepted `timeout` and forwarded it to the direct-execution path — but scanners that run through the uv-tool path `return` from that branch first, before the direct call is ever reached. `_try_uv_tool_execution`, `UvToolRunner.run_tool`'s `results_dir` branch, and the call into `run_command_with_output_handling` each dropped the argument. So the scanners most likely to hang were the ones still unbounded.

The original test passed because it exercised `run_command_with_output_handling` directly rather than going through a scanner, so it never traversed the uv branch. `timeout` is now threaded through all three links.

**2. The default is 1800s, not 300s.** Five minutes is under the honest runtime of a large repo scan, so the guard against a hang would have become a routine failure on real targets. 30 minutes is well past any legitimate scan and still bounds a genuine hang.

**3. `scan()` raises instead of returning empty.** `subprocess.run(timeout=)` kills the child, so a timed-out scanner leaves no results file. Without this, the scan reported zero findings for that scanner and exited 0 — a security tool silently reporting "clean" because it was killed. `ScannerError` now names the scanner, the timeout, and the config key to raise.

Also in this push: the timeout is applied at the six `scan()` overrides that call `_run_subprocess` themselves (`cfn_nag`, `npm-audit`, `syft`, `trivy`, `snyk`, `ferret`) — a `scan_timeout` option that silently does nothing for six scanners is a defect whatever its default. And `detect_secrets_scanner` had its own `scan_timeout: int = 300` shadowing the base field, without the `ge=1` bound, giving one scanner a different contract from every other; removed.

The npm-audit `--version` probe is left unbounded on purpose — it is a liveness check, not a scan.