### PR TITLE
fix(bedrock): drop inference parameters a model reports as deprecated

### DIFF
--- a/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_pipeline.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_pipeline.py
@@ -10,6 +10,7 @@ Three focused classes replace the monolithic reporter internals:
 """
 
 import logging
+import re
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
@@ -17,6 +18,51 @@ from typing import Any, Dict, List, Optional
 import botocore.exceptions
 
 from automated_security_helper.utils.log import ASH_LOGGER
+
+# Bedrock reports a rejected inference parameter by name, e.g.
+# "The model returned the following errors: `temperature` is deprecated for this
+# model." Reading the name out of the error is what lets a request be repaired
+# from the response instead of from a hardcoded table of which models deprecate
+# what -- a table that is wrong the day a model ships, and whose failure mode is
+# the one already reported: a silent fallback to a different model.
+_DEPRECATED_PARAM_PATTERN = re.compile(
+    r"`(?P<name>[A-Za-z0-9_]+)`\s+is\s+deprecated", re.IGNORECASE
+)
+
+
+def _normalize_param_name(name: str) -> str:
+    """Compare parameter names across spellings.
+
+    Bedrock names ``top_k`` with an underscore while the inferenceConfig key is
+    ``topP`` in camelCase, so a literal comparison finds one and misses the
+    other. Missing it would resend an identical request until the retry bound
+    gave up.
+    """
+    return name.replace("_", "").lower()
+
+
+def _drop_parameter(converse_args: Dict[str, Any], name: str) -> bool:
+    """Remove one named inference parameter. Returns whether anything changed.
+
+    The return value is load-bearing: it is what stops the retry loop from
+    resending a byte-identical request when the parameter Bedrock named is not
+    one we sent.
+    """
+    target = _normalize_param_name(name)
+    for container_key in ("inferenceConfig", "additionalModelRequestFields"):
+        container = converse_args.get(container_key)
+        if not isinstance(container, dict):
+            continue
+        for key in list(container):
+            if _normalize_param_name(key) != target:
+                continue
+            del container[key]
+            # Bedrock rejects an empty additionalModelRequestFields, so drop the
+            # container once its last entry is gone.
+            if not container:
+                converse_args.pop(container_key, None)
+            return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -76,45 +122,83 @@ class BedrockModelClient:
         if "claude" in self._model_id.lower():
             converse_args["additionalModelRequestFields"] = {"top_k": 200}
 
-        try:
-            ASH_LOGGER.debug(f"Invoking Bedrock model {self._model_id}")
-            response = self._runtime.converse(**converse_args)
+        # A model can reject more than one parameter, and it reports them one at a
+        # time: the issue saw temperature rejected, then top_k on the next call.
+        # One attempt per parameter that could be dropped, plus the first, so the
+        # loop terminates even if every one of them is refused.
+        max_attempts = (
+            1
+            + len(inference_config)
+            + len(converse_args.get("additionalModelRequestFields") or {})
+        )
 
-            if response and "output" in response and "message" in response["output"]:
-                message = response["output"]["message"]
-                content_list = message.get("content", [])
-                full_text = "".join(
-                    item["text"] for item in content_list if "text" in item
+        for _ in range(max_attempts):
+            try:
+                ASH_LOGGER.debug(f"Invoking Bedrock model {self._model_id}")
+                response = self._runtime.converse(**converse_args)
+
+                if (
+                    response
+                    and "output" in response
+                    and "message" in response["output"]
+                ):
+                    message = response["output"]["message"]
+                    content_list = message.get("content", [])
+                    full_text = "".join(
+                        item["text"] for item in content_list if "text" in item
+                    )
+                    if full_text:
+                        ASH_LOGGER.debug(
+                            f"Model {self._model_id} responded successfully"
+                        )
+                        return full_text
+
+                ASH_LOGGER.warning(
+                    f"Invalid or empty response from model {self._model_id}"
                 )
-                if full_text:
-                    ASH_LOGGER.debug(f"Model {self._model_id} responded successfully")
-                    return full_text
+                return "*Error: Unable to generate content from Bedrock response.*"
 
-            ASH_LOGGER.warning(f"Invalid or empty response from model {self._model_id}")
-            return "*Error: Unable to generate content from Bedrock response.*"
+            except botocore.exceptions.ClientError as exc:
+                code = exc.response.get("Error", {}).get("Code", "")
+                msg = exc.response.get("Error", {}).get("Message", str(exc))
+                ASH_LOGGER.warning(
+                    f"Bedrock API error ({code}) with model {self._model_id}: {msg}"
+                )
+                if code == "AccessDeniedException":
+                    return f"*Error: Access denied to model {self._model_id}. Check IAM permissions.*"
+                if code == "ResourceNotFoundException":
+                    return f"*Error: Model {self._model_id} not found. Check model ID and region.*"
+                if code == "ValidationException":
+                    # Retry only when the model named a parameter we actually
+                    # sent. Anything else -- an over-long prompt, say -- cannot be
+                    # fixed by dropping a field, so retrying only adds latency.
+                    match = _DEPRECATED_PARAM_PATTERN.search(msg)
+                    if match and _drop_parameter(converse_args, match.group("name")):
+                        ASH_LOGGER.verbose(
+                            f"Model {self._model_id} rejected "
+                            f"'{match.group('name')}' as deprecated; retrying "
+                            "without it"
+                        )
+                        continue
+                    return (
+                        f"*Error: Validation error with model {self._model_id}: {msg}*"
+                    )
+                if code in ("ThrottlingException", "TooManyRequestsException"):
+                    return f"*Error: Rate limit exceeded for model {self._model_id}. Try again later.*"
+                return f"*Error: {msg}*"
 
-        except botocore.exceptions.ClientError as exc:
-            code = exc.response.get("Error", {}).get("Code", "")
-            msg = exc.response.get("Error", {}).get("Message", str(exc))
-            ASH_LOGGER.warning(
-                f"Bedrock API error ({code}) with model {self._model_id}: {msg}"
-            )
-            if code == "AccessDeniedException":
-                return f"*Error: Access denied to model {self._model_id}. Check IAM permissions.*"
-            if code == "ResourceNotFoundException":
-                return f"*Error: Model {self._model_id} not found. Check model ID and region.*"
-            if code == "ValidationException":
-                return f"*Error: Validation error with model {self._model_id}: {msg}*"
-            if code in ("ThrottlingException", "TooManyRequestsException"):
-                return f"*Error: Rate limit exceeded for model {self._model_id}. Try again later.*"
-            return f"*Error: {msg}*"
+            except Exception as exc:
+                error_type = type(exc).__name__
+                ASH_LOGGER.warning(
+                    f"Error calling Bedrock model {self._model_id}: {error_type}: {exc}",
+                )
+                return f"*Error generating content with model {self._model_id}: {error_type}: {exc}*"
 
-        except Exception as exc:
-            error_type = type(exc).__name__
-            ASH_LOGGER.warning(
-                f"Error calling Bedrock model {self._model_id}: {error_type}: {exc}",
-            )
-            return f"*Error generating content with model {self._model_id}: {error_type}: {exc}*"
+        # Every droppable parameter was refused in turn.
+        return (
+            f"*Error: Model {self._model_id} rejected every supported inference "
+            "parameter as deprecated.*"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -139,9 +223,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         return (
             f"Generate an executive summary for a security scan with the following results:\n\n"
             f"SCAN OVERVIEW:\n"
@@ -152,9 +234,7 @@ class BedrockPromptBuilder:
             f"Provide a concise executive summary that highlights the most important aspects of the scan results.\n"
         )
 
-    def severity_analysis(
-        self, findings: List[Dict[str, Any]], severity: str
-    ) -> str:
+    def severity_analysis(self, findings: List[Dict[str, Any]], severity: str) -> str:
         if not findings:
             return f"No findings with {severity} level severity."
 
@@ -234,9 +314,7 @@ class BedrockPromptBuilder:
         remaining = [f for f in findings if f not in severe]
         severe.extend(remaining[: max(0, max_findings - len(severe))])
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         lines = [
             f"Based on the security scan with the following results:\n\n"
             f"FINDINGS BY SEVERITY:\n{counts_str}\n\n"
@@ -271,13 +349,17 @@ class BedrockPromptBuilder:
         if not findings:
             return "No findings to analyze."
 
-        lines = ["Generate a detailed technical analysis of the following security findings:\n"]
+        lines = [
+            "Generate a detailed technical analysis of the following security findings:\n"
+        ]
         for i, finding in enumerate(findings[:max_findings]):
             msg = self._extract_message(finding)
             rule_id = self._extract_rule_id(finding)
             level = finding.get("level", "none")
             locations = self._extract_locations(finding)
-            code_snippets = self._extract_code_snippets(finding) if include_code_snippets else []
+            code_snippets = (
+                self._extract_code_snippets(finding) if include_code_snippets else []
+            )
 
             lines.append(
                 f"\nFINDING {i + 1}:\n"
@@ -287,7 +369,9 @@ class BedrockPromptBuilder:
                 f"- Locations: {', '.join(locations) if locations else 'Unknown'}\n"
             )
             if code_snippets and include_code_snippets:
-                lines.append("- Code Snippet:\n```\n" + "\n".join(code_snippets[:3]) + "\n```\n")
+                lines.append(
+                    "- Code Snippet:\n```\n" + "\n".join(code_snippets[:3]) + "\n```\n"
+                )
 
         lines.append(
             "\nProvide a detailed technical analysis including:\n"
@@ -310,9 +394,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         lines = [
             f"Generate a risk assessment based on the following security scan results:\n\n"
             f"FINDINGS BY SEVERITY:\n{counts_str}\n\n"
@@ -354,9 +436,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         fw_str = ", ".join(compliance_frameworks)
         lines = [
             f"Generate a compliance impact analysis for the following security scan results:\n\n"
@@ -442,7 +522,9 @@ class BedrockPromptBuilder:
             if industry_context:
                 context_info += f"- Industry: {industry_context}\n"
             if compliance_frameworks:
-                context_info += f"- Compliance frameworks: {', '.join(compliance_frameworks)}\n"
+                context_info += (
+                    f"- Compliance frameworks: {', '.join(compliance_frameworks)}\n"
+                )
             if custom_context:
                 context_info += f"\n{custom_context}"
             user_message += context_info

--- a/tests/unit/plugin_modules/ash_aws_plugins/test_bedrock_deprecated_params.py
+++ b/tests/unit/plugin_modules/ash_aws_plugins/test_bedrock_deprecated_params.py
@@ -1,0 +1,211 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Newer Anthropic models reject inference parameters that older ones require.
+
+Why this file exists
+--------------------
+Configuring a recent model made the reporter fall back to Nova Pro, which
+defeats the point of naming a model. Bedrock rejected the request:
+
+    ValidationException: The model returned the following errors:
+    `temperature` is deprecated for this model.
+
+and once temperature was removed by hand, the next call failed the same way on
+``top_k``. BedrockModelClient sent both unconditionally: temperature in
+inferenceConfig, and top_k in additionalModelRequestFields for any model id
+containing "claude".
+
+Why strip-and-retry rather than a model table
+---------------------------------------------
+The obvious alternative is a lookup of which models deprecate which parameters.
+That table is wrong the day a model ships, and the failure it produces is the one
+already reported: a silent fallback to a different model. Bedrock names the
+offending parameter in the error, so the request can be repaired from the
+response instead of from a list somebody has to maintain.
+
+That also means a parameter deprecated in future needs no code change here.
+
+What is deliberately not retried
+--------------------------------
+Only ValidationExceptions that name a deprecated parameter. Access denied, model
+not found and throttling are unchanged, and a ValidationException about anything
+else still returns immediately rather than retrying a request that cannot
+succeed.
+"""
+
+import botocore.exceptions
+import pytest
+
+from automated_security_helper.plugin_modules.ash_aws_plugins.bedrock_pipeline import (
+    BedrockModelClient,
+)
+
+
+def _validation_error(message: str) -> botocore.exceptions.ClientError:
+    return botocore.exceptions.ClientError(
+        {"Error": {"Code": "ValidationException", "Message": message}},
+        "Converse",
+    )
+
+
+def _deprecated(param: str) -> botocore.exceptions.ClientError:
+    """The wording Bedrock actually returns, quoted from the issue."""
+    return _validation_error(
+        f"The model returned the following errors: `{param}` is deprecated for this model."
+    )
+
+
+def _ok_response(text: str = "summary text"):
+    return {"output": {"message": {"content": [{"text": text}]}}}
+
+
+class _FakeRuntime:
+    """Rejects named parameters the way Bedrock does, then succeeds."""
+
+    def __init__(self, reject: list[str]):
+        self._reject = list(reject)
+        self.calls: list[dict] = []
+
+    def converse(self, **kwargs):
+        self.calls.append(
+            {
+                "inferenceConfig": dict(kwargs.get("inferenceConfig") or {}),
+                "additionalModelRequestFields": dict(
+                    kwargs.get("additionalModelRequestFields") or {}
+                ),
+            }
+        )
+        sent = {
+            **(kwargs.get("inferenceConfig") or {}),
+            **(kwargs.get("additionalModelRequestFields") or {}),
+        }
+        normalized = {k.replace("_", "").lower() for k in sent}
+        for param in self._reject:
+            if param.replace("_", "").lower() in normalized:
+                raise _deprecated(param)
+        return _ok_response()
+
+
+def _client(runtime, model_id="global.anthropic.claude-opus-4-7"):
+    return BedrockModelClient(
+        bedrock_runtime=runtime,
+        model_id=model_id,
+        temperature=0.5,
+        max_tokens=4096,
+        top_p=0.9,
+    )
+
+
+class TestDeprecatedParametersAreDropped:
+    def test_temperature_is_dropped_and_the_call_succeeds(self):
+        runtime = _FakeRuntime(reject=["temperature"])
+
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert result == "summary text"
+        assert "temperature" in runtime.calls[0]["inferenceConfig"]
+        assert "temperature" not in runtime.calls[-1]["inferenceConfig"]
+
+    def test_both_reported_parameters_are_dropped_in_turn(self):
+        """The reported sequence: temperature first, then top_k on the next call."""
+        runtime = _FakeRuntime(reject=["temperature", "top_k"])
+
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert result == "summary text"
+        final = runtime.calls[-1]
+        assert "temperature" not in final["inferenceConfig"]
+        assert "top_k" not in final["additionalModelRequestFields"]
+        # One call per rejection, plus the one that succeeds.
+        assert len(runtime.calls) == 3
+
+    def test_surviving_parameters_are_kept(self):
+        """Only what Bedrock objected to is removed.
+
+        Stripping the whole inferenceConfig would work around the error while
+        silently discarding maxTokens, which changes the output rather than
+        fixing the request.
+        """
+        runtime = _FakeRuntime(reject=["temperature"])
+
+        _client(runtime).try_call("prompt", "system")
+
+        final = runtime.calls[-1]["inferenceConfig"]
+        assert final.get("maxTokens") == 4096
+        assert final.get("topP") == 0.9
+
+    def test_underscore_and_camel_spellings_both_match(self):
+        """Bedrock names top_k with an underscore and topP in camelCase.
+
+        A literal key comparison would fail to find one of them, and the retry
+        would resend the same request until the bound gave up.
+        """
+        runtime = _FakeRuntime(reject=["top_p"])
+
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert result == "summary text"
+        assert "topP" not in runtime.calls[-1]["inferenceConfig"]
+
+
+class TestOtherErrorsAreUnchanged:
+    @pytest.mark.parametrize(
+        "code,expected",
+        [
+            ("AccessDeniedException", "Access denied"),
+            ("ResourceNotFoundException", "not found"),
+            ("ThrottlingException", "Rate limit exceeded"),
+        ],
+    )
+    def test_non_validation_errors_return_immediately(self, code, expected):
+        class _Runtime:
+            calls = 0
+
+            def converse(self, **kwargs):
+                type(self).calls += 1
+                raise botocore.exceptions.ClientError(
+                    {"Error": {"Code": code, "Message": "nope"}}, "Converse"
+                )
+
+        runtime = _Runtime()
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert expected in result
+        assert _Runtime.calls == 1
+
+    def test_unrelated_validation_error_is_not_retried(self):
+        """Retrying a request that cannot succeed just multiplies the latency."""
+
+        class _Runtime:
+            calls = 0
+
+            def converse(self, **kwargs):
+                type(self).calls += 1
+                raise _validation_error("Input is too long for requested model.")
+
+        runtime = _Runtime()
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert "Validation error" in result
+        assert _Runtime.calls == 1
+
+    def test_retry_is_bounded_when_stripping_never_helps(self):
+        """A model that keeps naming a parameter already gone must not loop.
+
+        Guards the retry loop itself: if the strip cannot find the named key, the
+        next request is byte-identical and would fail the same way forever.
+        """
+
+        class _Runtime:
+            calls = 0
+
+            def converse(self, **kwargs):
+                type(self).calls += 1
+                raise _deprecated("somethingNotSent")
+
+        runtime = _Runtime()
+        result = _client(runtime).try_call("prompt", "system")
+
+        assert "Error" in result
+        assert _Runtime.calls == 1


### PR DESCRIPTION
## Problem

Configuring a recent Anthropic model made the reporter fall back to Nova Pro, which defeats the point of naming a model. Bedrock rejected the request:

```
ValidationException: The model returned the following errors: `temperature` is deprecated for this model.
```

and once `temperature` was removed by hand, the next call failed the same way on `top_k`. `BedrockModelClient` sent both unconditionally — `temperature` in `inferenceConfig`, `top_k` in `additionalModelRequestFields` for any model id containing `"claude"`.

## Fix: repair the request from the response, not from a table

I took option 1 from the issue. Bedrock names the offending parameter in the error, so it is read out, dropped, and the call retried.

The alternative was a lookup of which models deprecate which parameters. That table is wrong the day a model ships, and its failure mode is exactly what was reported: a silent fallback to a different model. This way a parameter deprecated in future needs no change here.

Three details worth reviewing:

- **Name matching ignores underscores and case.** Bedrock says `top_k`; the `inferenceConfig` key is `topP`. A literal comparison finds one and misses the other, and missing it would resend an identical request until the bound gave up. There is a test for the `top_p`/`topP` case specifically.
- **`_drop_parameter` returns whether it changed anything.** That return value is what stops a retry when the named parameter was never sent — otherwise the next request is byte-identical.
- **Retries are bounded** at one per droppable parameter plus the first attempt, so a model that refuses everything terminates with a clear message instead of looping.

Only `ValidationException`s naming a deprecated parameter are retried. Access denied, model-not-found and throttling are untouched, and a `ValidationException` about anything else (an over-long prompt) still returns immediately, since dropping a field cannot fix it. Tests pin all of those.

## Verification

- 9 new tests. 3 fail on `main`, all pass here. The other 6 pin behaviour that must not change; they pass on both.
- `tests/unit/plugin_modules/ash_aws_plugins/`: **145 passed**, no regressions.
- Schemas regenerate with no diff, docs freshness 7/7, ruff clean apart from two F401s (`logging`, `dataclasses.field`) that are present **identically on `main`** and left alone.

Fixes #354