### PR TITLE
feat(workspace): resolve a .code-workspace into a validated execution plan (phase 1)

### DIFF
--- a/automated_security_helper/cli/scan.py
+++ b/automated_security_helper/cli/scan.py
@@ -3,7 +3,7 @@
 
 import os
 from rich import print
-from typing import Annotated, List, Optional
+from typing import Annotated, List, NoReturn, Optional
 import typer
 from pathlib import Path
 
@@ -17,11 +17,91 @@ from automated_security_helper.core.enums import (
     ExecutionStrategy,
     RunMode,
 )
+from automated_security_helper.core.exceptions import (
+    ASHConfigValidationError,
+    WorkspaceDefinitionError,
+)
 from automated_security_helper.interactions.run_ash_scan import (
     run_ash_scan,
 )
 from automated_security_helper.core.enums import ExportFormat
+from automated_security_helper.models.workspace import WorkspaceExitCode
 from automated_security_helper.utils.get_ash_version import get_ash_version
+from automated_security_helper.workspace.resolver import resolve_workspace
+from automated_security_helper.workspace.workspace_file import (
+    WORKSPACE_AUTO,
+    discover_workspace_file,
+)
+
+
+def _fail_workspace(
+    message: str,
+    code: WorkspaceExitCode = WorkspaceExitCode.WORKSPACE_ERROR,
+) -> NoReturn:
+    """Report a workspace-mode refusal and exit with its contract code.
+
+    Written with ``typer.echo`` rather than the Rich ``print`` imported above,
+    because these messages quote operator-supplied paths and Rich would read a
+    bracketed fragment in one as a style name and fail while rendering the error.
+    """
+    typer.echo(message, err=True)
+    raise typer.Exit(code)
+
+
+def _handle_workspace_mode(
+    workspace: str,
+    source_dir: str | None,
+    allow_missing_projects: bool,
+    dry_run: bool,
+) -> NoReturn:
+    """Resolve a workspace, print the plan, and exit. Never scans.
+
+    Phase 1 of workspace mode resolves and validates only, so every path out of
+    this function is an exit: 0 after printing a plan for ``--dry-run``, 2 for a
+    workspace definition or policy problem, 3 for a project whose own config is
+    invalid.
+
+    Argument validation happens before any filesystem work, so an operator who
+    passed a contradictory pair of flags is told that rather than being sent to
+    debug their workspace file first.
+    """
+    if source_dir is not None:
+        _fail_workspace(
+            "--workspace and --source-dir are mutually exclusive. In workspace "
+            "mode the directory holding the workspace file is the scan root, so "
+            "honouring both would leave it ambiguous which tree was scanned. "
+            "Note that --source-dir is also set by the ASH_SOURCE_DIR "
+            "environment variable, which counts as setting it."
+        )
+
+    if not dry_run:
+        # Falling through to a single-directory scan would scan the workspace
+        # root as one project and exit 0, reporting a result for a scan nobody
+        # asked for.
+        _fail_workspace(
+            "Workspace mode currently resolves and validates a workspace but "
+            "does not run the scans; execution arrives in a later release. "
+            "Re-run with '--dry-run' to inspect the resolved plan, or scan a "
+            "single directory with '--source-dir'."
+        )
+
+    try:
+        workspace_file = (
+            discover_workspace_file(Path.cwd())
+            if workspace == WORKSPACE_AUTO
+            else Path(workspace)
+        )
+        plan = resolve_workspace(
+            workspace_file, allow_missing_projects=allow_missing_projects
+        )
+    except WorkspaceDefinitionError as exc:
+        _fail_workspace(str(exc))
+    except ASHConfigValidationError as exc:
+        _fail_workspace(str(exc), code=WorkspaceExitCode.INVALID_PROJECT_CONFIG)
+    else:
+        typer.echo(plan.render())
+
+    raise typer.Exit(WorkspaceExitCode.SUCCESS)
 
 
 def run_ash_scan_cli_command(
@@ -228,6 +308,29 @@ def run_ash_scan_cli_command(
             envvar="ASH_BASE_REF",
         ),
     ] = "origin/main",
+    ### WORKSPACE-RELATED OPTIONS
+    workspace: Annotated[
+        str | None,
+        typer.Option(
+            "--workspace",
+            help="Path to a '.code-workspace' file whose folders are scanned as separate, independently-scoped projects. Pass 'auto' to use the single '*.code-workspace' file in the current directory. Mutually exclusive with --source-dir.",
+            envvar="ASH_WORKSPACE",
+        ),
+    ] = None,
+    allow_missing_projects: Annotated[
+        bool,
+        typer.Option(
+            "--allow-missing-projects",
+            help="In workspace mode, skip project folders that are absent or unreadable instead of failing. Skipped projects are recorded in the plan. Without this, a missing project fails the whole workspace, so a typo or an un-cloned repository cannot pass as a clean scan.",
+        ),
+    ] = False,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="In workspace mode, print the resolved execution plan and exit without scanning anything.",
+        ),
+    ] = False,
     ### CONTAINER-RELATED OPTIONS
     build: Annotated[
         bool,
@@ -316,6 +419,33 @@ def run_ash_scan_cli_command(
     if version:
         typer.echo(f"awslabs/automated-security-helper v{get_ash_version()}")
         raise typer.Exit()
+
+    # Workspace mode is handled before any cwd-based default is applied, because
+    # --workspace and --source-dir are mutually exclusive and defaulting
+    # source_dir first would make every invocation look like it had both.
+    if workspace is None and (dry_run or allow_missing_projects):
+        # Neither flag means anything outside workspace mode. Silently ignoring
+        # --dry-run would run a full scan for someone who asked for none.
+        offending = [
+            flag
+            for flag, given in (
+                ("--dry-run", dry_run),
+                ("--allow-missing-projects", allow_missing_projects),
+            )
+            if given
+        ]
+        _fail_workspace(
+            f"{' and '.join(offending)} only applies in workspace mode; pass "
+            f"'--workspace <file>' or '--workspace auto' as well."
+        )
+
+    if workspace is not None:
+        _handle_workspace_mode(
+            workspace=workspace,
+            source_dir=source_dir,
+            allow_missing_projects=allow_missing_projects,
+            dry_run=dry_run,
+        )
 
     # Rebind list defaults to fresh empty lists at call time so each CLI
     # invocation gets its own collection (typer will populate them if the

--- a/automated_security_helper/cli/scan.py
+++ b/automated_security_helper/cli/scan.py
@@ -57,9 +57,10 @@ def _handle_workspace_mode(
     """Resolve a workspace, print the plan, and exit. Never scans.
 
     Phase 1 of workspace mode resolves and validates only, so every path out of
-    this function is an exit: 0 after printing a plan for ``--dry-run``, 2 for a
+    this function is an exit: 0 after printing a plan for ``--dry-run``, 4 for a
     workspace definition or policy problem, 3 for a project whose own config is
-    invalid.
+    invalid. Never 2 -- that code means a scan ran and found actionable findings,
+    which is the opposite of what any exit from here reports.
 
     Argument validation happens before any filesystem work, so an operator who
     passed a contradictory pair of flags is told that rather than being sent to

--- a/automated_security_helper/core/exceptions.py
+++ b/automated_security_helper/core/exceptions.py
@@ -26,3 +26,23 @@ class WorkspacePatternError(ASHValidationError):
     """
 
     pass
+
+
+class WorkspaceDefinitionError(ASHValidationError):
+    """Exception raised when a workspace definition cannot be used as given.
+
+    Covers the whole fail-closed set: a malformed or unreadable
+    ``.code-workspace`` file, a folder entry that does not exist, escapes the
+    workspace root, is a symlink, or overlaps another entry, and two projects
+    whose scanner version pins cannot both be satisfied.
+
+    Maps to ``WorkspaceExitCode.WORKSPACE_ERROR`` (2). Kept distinct from
+    ASHConfigValidationError, which maps to ``INVALID_PROJECT_CONFIG`` (3),
+    because the two route to different people: 2 means the operator's workspace
+    file is wrong and nothing could run, 3 means one project is misconfigured.
+
+    The message is expected to name every offending entry rather than the first,
+    so an operator with three typos fixes three in one pass.
+    """
+
+    pass

--- a/automated_security_helper/workspace/__init__.py
+++ b/automated_security_helper/workspace/__init__.py
@@ -25,6 +25,17 @@ What this package deliberately does NOT do
   versions is refused rather than run with one project's requirement quietly
   ignored.
 
+Module map
+----------
+* :mod:`~automated_security_helper.workspace.workspace_file` -- parse and
+  discover the ``.code-workspace`` definition.
+* :mod:`~automated_security_helper.workspace.scanner_pins` -- decide whether
+  two version pins for the same scanner can both be satisfied.
+* :mod:`~automated_security_helper.workspace.plan` -- the execution plan
+  produced by resolution, and its rendering.
+* :mod:`~automated_security_helper.workspace.resolver` -- validate every entry
+  and build the plan.
+
 Exit codes and failure modes are the ones modelled in
 :mod:`automated_security_helper.models.workspace`; this package raises
 ``WorkspaceDefinitionError`` for code 2 and lets ``ASHConfigValidationError``

--- a/automated_security_helper/workspace/__init__.py
+++ b/automated_security_helper/workspace/__init__.py
@@ -38,8 +38,10 @@ Module map
 
 Exit codes and failure modes are the ones modelled in
 :mod:`automated_security_helper.models.workspace`; this package raises
-``WorkspaceDefinitionError`` for code 2 and lets ``ASHConfigValidationError``
-through for code 3, and never returns a partially-valid plan.
+``WorkspaceDefinitionError`` for code 4 and lets ``ASHConfigValidationError``
+through for code 3, and never returns a partially-valid plan. Code 4 rather than
+the 2 an earlier draft used: 2 already means "a scan ran and found actionable
+findings", and a workspace that never ran must not be reported the same way.
 
 There are deliberately no re-exports here. Callers import from the submodule they
 need, which keeps ``workspace_file`` importable without dragging in config

--- a/automated_security_helper/workspace/__init__.py
+++ b/automated_security_helper/workspace/__init__.py
@@ -1,0 +1,36 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workspace mode: resolve a multi-project workspace into an execution plan.
+
+Why this package exists
+-----------------------
+A workspace is N project directories scanned as N independently-scoped
+executions and aggregated with per-project attribution. Deciding *which*
+projects those are, and refusing a definition ASH cannot honour, is a separate
+concern from running the scans -- separate enough that it can be inspected on
+its own with ``--dry-run`` before anything is executed. This package is only
+the deciding half.
+
+What this package deliberately does NOT do
+------------------------------------------
+* It does not scan. Nothing here starts a scanner, writes an output directory,
+  or reads a source file. Execution is a later phase.
+* It does not read policy out of the ``.code-workspace`` file's ``settings``
+  block. ASH policy lives in ASH's own config; taking it from another tool's
+  schema would mean two sources of truth for the same decision, with VS Code
+  free to change its own without warning.
+* It does not isolate scanner tool versions per project. One ASH run installs
+  one version of each tool, so a workspace whose projects demand incompatible
+  versions is refused rather than run with one project's requirement quietly
+  ignored.
+
+Exit codes and failure modes are the ones modelled in
+:mod:`automated_security_helper.models.workspace`; this package raises
+``WorkspaceDefinitionError`` for code 2 and lets ``ASHConfigValidationError``
+through for code 3, and never returns a partially-valid plan.
+
+There are deliberately no re-exports here. Callers import from the submodule they
+need, which keeps ``workspace_file`` importable without dragging in config
+resolution and pydantic models along with it.
+"""

--- a/automated_security_helper/workspace/plan.py
+++ b/automated_security_helper/workspace/plan.py
@@ -1,0 +1,335 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The workspace execution plan: what would be scanned, and how it was decided.
+
+Why this module exists
+----------------------
+Workspace resolution makes a series of decisions an operator cannot otherwise
+see: which directories became projects, what key each was given, which config
+file was found for it, which scanners that config enables, and which projects
+were dropped and why. ``--dry-run`` exists so those decisions can be inspected
+before a scan runs, and this module is the artifact it prints. Phase 2 executes
+from the same object, so what an operator inspects is what will run rather than a
+separate description of it that can drift.
+
+Naming, and why three names are not two
+---------------------------------------
+Each project carries three strings, and conflating any pair of them causes a real
+defect:
+
+* ``relative_path`` -- the project's path below the workspace root
+  (``services/api``). The coordinate system aggregated findings live in.
+* ``key`` -- that path with separators replaced by dashes (``services-api``).
+  The only thing used for output paths and for uniqueness. It is a path
+  *derived* value, not a path: it never goes back through the filesystem.
+* ``label`` and ``display_label`` -- what a human reads. Never a uniqueness key,
+  because two projects may legitimately carry the same ``project_name``, and
+  never a path.
+
+``display_label`` is stored rather than computed on demand because it depends on
+the whole sibling set: a label is decorated with its key only when another
+project in the same workspace shares it. The resolver settles it once, when it
+has that set in hand.
+
+The skipped-projects payload
+----------------------------
+``skipped_projects`` is derived from the per-project skip fields rather than
+stored alongside them, so the two cannot disagree. It is a
+``@computed_field``, which means it appears in ``model_dump()``: a skip has to
+reach downstream consumers, and a log line does not, because nothing downstream
+reads stderr.
+
+One deliberate divergence from Phase 0. ``SkippedProject.project`` is documented
+in :mod:`automated_security_helper.models.workspace` as the workspace-relative
+*path*, and is populated here with the *key*. The field's stated purpose is to be
+"the key it is attributed under elsewhere in the results", and the key is what
+attribution actually uses, so populating the path would produce a payload that
+does not join to anything. The two coincide for a top-level project and differ
+for a nested one.
+
+Failure modes and known limitations
+-----------------------------------
+* Paths are POSIX strings, not ``Path`` objects, so the plan serialises to JSON
+  without a custom encoder and reads identically on every platform. Anything
+  that needs a real path must reconstruct it.
+* A skipped project still occupies an entry in ``projects``, with no config and
+  no scanners. Dropping it would make the plan silently shorter than the
+  workspace file it came from, which is the disclosure problem this phase exists
+  to avoid.
+* ``render()`` is for humans and its layout is not a contract. Consumers that
+  need structure should read ``model_dump()``.
+* Nothing here validates. A plan is only ever built by
+  :func:`automated_security_helper.workspace.resolver.resolve_workspace`, which
+  has already refused anything unusable; a plan constructed by hand can hold
+  states resolution would never produce.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Dict, List, Optional
+
+from pydantic import BaseModel, Field, computed_field
+
+from automated_security_helper.models.workspace import (
+    SkippedProject,
+    SkippedProjectReason,
+)
+
+# Rendering widths, chosen so the longest label below lines up.
+_FIELD_WIDTH = 12
+_INDENT = "      "
+
+
+class ProjectPlan(BaseModel):
+    """One project's resolved place in the workspace."""
+
+    key: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description=(
+                "Workspace-relative path with separators replaced by dashes. "
+                "The only value used for output paths and uniqueness."
+            ),
+        ),
+    ]
+    relative_path: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description=(
+                "Workspace-relative path, forward-slash separated, as findings "
+                "are attributed."
+            ),
+        ),
+    ]
+    path: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description="Canonical absolute path of the project directory, POSIX-shaped.",
+        ),
+    ]
+    label: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description=(
+                "AshConfig.project_name when the project's config declares one, "
+                "otherwise the project key. Not unique."
+            ),
+        ),
+    ]
+    display_label: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description=(
+                "The label, suffixed with the key when another project in the "
+                "same workspace shares the label."
+            ),
+        ),
+    ]
+    config_source: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "Path of the config file resolved for this project, or null when "
+                "the project has none and took ASH's default config."
+            ),
+        ),
+    ] = None
+    scanners: Annotated[
+        List[str],
+        Field(
+            default_factory=list,
+            description="Scanner names this project's config enables, sorted.",
+        ),
+    ]
+    severity_threshold: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "The project's own global_settings.severity_threshold. A "
+                "workspace-level ceiling is a later phase; when one exists the "
+                "effective value becomes severity_ladder.stricter_of(this, "
+                "ceiling)."
+            ),
+        ),
+    ] = None
+    scanner_pins: Annotated[
+        Dict[str, str],
+        Field(
+            default_factory=dict,
+            description=(
+                "Effective tool_version constraint per scanner, including those "
+                "inherited from a scanner's built-in default."
+            ),
+        ),
+    ]
+    skipped: Annotated[
+        bool,
+        Field(
+            False,
+            description="True when this project will not be scanned.",
+        ),
+    ] = False
+    skip_reason: Annotated[
+        Optional[SkippedProjectReason],
+        Field(None, description="Why the project was skipped, when it was."),
+    ] = None
+    skip_detail: Annotated[
+        Optional[str],
+        Field(None, description="Human-readable explanation of the skip."),
+    ] = None
+
+    def as_skipped_project(self) -> Optional[SkippedProject]:
+        """This project as a ``skipped_projects`` payload entry, or None.
+
+        Returns None for a project that will be scanned, so callers can build
+        the payload by filtering.
+        """
+        if not self.skipped or self.skip_reason is None:
+            return None
+        return SkippedProject(
+            project=self.key,
+            reason=self.skip_reason,
+            detail=self.skip_detail,
+        )
+
+
+class WorkspacePlan(BaseModel):
+    """Everything resolution decided about one workspace.
+
+    This is the whole output of Phase 1. It describes work; it does not perform
+    any.
+    """
+
+    workspace_file: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description="Canonical absolute path of the .code-workspace file.",
+        ),
+    ]
+    workspace_root: Annotated[
+        str,
+        Field(
+            ...,
+            min_length=1,
+            description=(
+                "Canonical absolute path of the directory holding the workspace "
+                "file. This is the scan's source_dir, and in container mode it "
+                "is what gets mounted at /src, so every project path has to sit "
+                "below it."
+            ),
+        ),
+    ]
+    projects: Annotated[
+        List[ProjectPlan],
+        Field(
+            default_factory=list,
+            description=(
+                "Every folder entry that passed containment, in workspace-file "
+                "order, including skipped ones."
+            ),
+        ),
+    ]
+    allow_missing_projects: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether the operator opted out of failing on a missing or "
+                "unreadable project."
+            ),
+        ),
+    ] = False
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def skipped_projects(self) -> List[SkippedProject]:
+        """The Phase 0 ``skipped_projects`` payload, derived from the projects.
+
+        A computed field so it serialises: a downstream consumer reading the plan
+        must be able to see that a project was dropped, and cannot read stderr.
+        """
+        entries = (project.as_skipped_project() for project in self.projects)
+        return [entry for entry in entries if entry is not None]
+
+    @property
+    def active_projects(self) -> List[ProjectPlan]:
+        """The projects that would actually be scanned."""
+        return [project for project in self.projects if not project.skipped]
+
+    def render(self) -> str:
+        """Render the plan for a human reading ``--dry-run`` output.
+
+        Layout is not a contract; consumers wanting structure should use
+        ``model_dump()``.
+        """
+        skipped = self.skipped_projects
+        lines: List[str] = [
+            "Workspace execution plan",
+            f"{_INDENT}{'file:':<{_FIELD_WIDTH}}{self.workspace_file}",
+            f"{_INDENT}{'root:':<{_FIELD_WIDTH}}{self.workspace_root}",
+            f"{_INDENT}{'projects:':<{_FIELD_WIDTH}}"
+            f"{len(self.active_projects)} to scan, {len(skipped)} skipped",
+            f"{_INDENT}{'missing ok:':<{_FIELD_WIDTH}}"
+            f"{'yes' if self.allow_missing_projects else 'no'}",
+            "",
+        ]
+
+        for position, project in enumerate(self.projects, start=1):
+            suffix = ""
+            if project.skipped:
+                reason = (
+                    project.skip_reason.value if project.skip_reason else "unspecified"
+                )
+                suffix = f"  [skipped: {reason}]"
+            lines.append(f"  {position}. {project.key}{suffix}")
+            lines.append(f"{_INDENT}{'label:':<{_FIELD_WIDTH}}{project.display_label}")
+            lines.append(f"{_INDENT}{'path:':<{_FIELD_WIDTH}}{project.path}")
+            lines.append(
+                f"{_INDENT}{'relative:':<{_FIELD_WIDTH}}{project.relative_path}"
+            )
+            if project.skipped:
+                lines.append(
+                    f"{_INDENT}{'reason:':<{_FIELD_WIDTH}}"
+                    f"{project.skip_detail or 'not stated'}"
+                )
+                lines.append("")
+                continue
+            lines.append(
+                f"{_INDENT}{'config:':<{_FIELD_WIDTH}}"
+                f"{project.config_source or 'ASH default config'}"
+            )
+            lines.append(
+                f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}"
+                f"{project.severity_threshold or 'none'}"
+            )
+            lines.append(
+                f"{_INDENT}{'scanners:':<{_FIELD_WIDTH}}"
+                f"{', '.join(project.scanners) or 'none enabled'}"
+            )
+            if project.scanner_pins:
+                pins = ", ".join(
+                    f"{scanner} {pin}"
+                    for scanner, pin in sorted(project.scanner_pins.items())
+                )
+                lines.append(f"{_INDENT}{'pins:':<{_FIELD_WIDTH}}{pins}")
+            lines.append("")
+
+        lines.append(
+            "Nothing has been scanned. This is a resolution and validation pass only."
+        )
+        return "\n".join(lines)

--- a/automated_security_helper/workspace/resolver.py
+++ b/automated_security_helper/workspace/resolver.py
@@ -1,0 +1,582 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Turn a workspace definition into a validated execution plan, or refuse it.
+
+Why this module exists
+----------------------
+Between "the operator named a workspace file" and "N scans run" sits a set of
+decisions that can each go wrong quietly: which directories are really projects,
+whether any of them escapes the tree the operator authorised, whether two of them
+are the same directory under different names, what each one is called in output,
+and whether their configs demand tool versions that cannot coexist. Making those
+decisions in one pass, before anything executes, is what lets ``--dry-run``
+exist and what keeps the failure modes in one place instead of spread across the
+execution path.
+
+Fail-closed, and why that is not the obvious choice
+--------------------------------------------------
+An earlier draft of this design had a missing project warn and skip. That is
+fail-OPEN, and it fails in the worst available direction for a security tool: a
+typo in the workspace file, or a repository that was never cloned on this runner,
+means a project is not scanned, ASH exits 0, and CI goes green. Worse, the other
+projects' passing results supply the reassurance -- the output looks like a
+successful multi-project scan, just with one fewer project than the operator
+believes. Nobody reads a warning in a green build.
+
+So the default is refusal, and it is refusal for the whole workspace rather than
+for the offending project, because a partial scan is exactly the outcome above.
+``--allow-missing-projects`` exists for the legitimate case (a workspace shared
+between developers who clone different subsets), and when it is used the skip is
+recorded in the plan payload rather than only logged: a downstream consumer
+reading results cannot see stderr.
+
+The opt-out is deliberately narrow. It covers a project that is absent or
+unreadable -- facts about this machine. It does not cover a path that escapes the
+workspace root, is a symlink, overlaps another entry, or collides on its key,
+because those are facts about the definition and are wrong on every machine.
+
+Order of checks, which is load-bearing
+--------------------------------------
+1. Parse the definition. A malformed file has no entries to check.
+2. Containment, via :mod:`automated_security_helper.utils.path_containment`. No
+   opt-out.
+3. Reject an entry naming the workspace root itself.
+4. Overlap, on canonicalised real paths. No opt-out.
+5. Key uniqueness. No opt-out.
+6. Existence and readability. This is the opt-out-able step, and it comes last of
+   the path checks so that a symlinked or escaping entry is reported as such
+   rather than as merely missing.
+7. Refuse if nothing is left to scan.
+8. Resolve each project's config independently.
+9. Compare scanner pins across the projects that will actually run.
+
+Steps 2 to 6 each collect every offending entry before raising, so an operator
+with three bad entries fixes three in one pass instead of one per run.
+
+Why an entry naming the workspace root is refused
+-------------------------------------------------
+The spec settles the case where ``.`` appears alongside another entry -- it
+overlaps everything below it -- but not the case where it is the only entry. Two
+readings were available. Taking the relative path literally makes the project key
+``.``, which then appears in output paths; inventing a key from the root
+directory's name invents a name the definition never stated. Neither is
+defensible, and the case is degenerate anyway: a workspace whose only project is
+the workspace root is a single-directory scan, which ``--source-dir`` already
+does. So it is refused, with a message that says so.
+
+Why overlaps are refused rather than de-duplicated
+--------------------------------------------------
+Two entries resolving to one real directory would have that directory's findings
+attributed twice and its suppressions applied twice, and would produce two
+projects with the same key writing to the same output path. De-duplicating would
+silently change what the operator asked for. Note that overlap is judged on
+resolved real paths, which is what catches an alias: Phase 0's containment check
+accepts ``alias/sub`` when only ``alias`` is a symlink, and comparing real paths
+is the only thing that notices it is the same directory as ``api/sub``. A nested
+git repository or submodule inside a project is not an overlap unless it is also
+listed as its own entry.
+
+Why key collisions are refused
+------------------------------
+Replacing separators with dashes is not injective. ``a/b`` and a directory
+literally named ``a-b`` both key to ``a-b``, so "unique by construction" does not
+hold once overlaps are excluded. Two projects sharing a key would share an output
+path, so the collision is refused, naming both paths.
+
+Failure modes and known limitations
+-----------------------------------
+* Validation is point-in-time. Every path is checked here and used later; a
+  directory can be replaced by a symlink in between. This module cannot close
+  that window, and does not pretend to.
+* An unreadable project is detected with ``os.access``, which consults the real
+  uid rather than the effective one and which a root user always satisfies. A
+  process that can read the directory but not its contents is reported as
+  readable, and the failure surfaces during the scan instead.
+* Scanner pins are compared as *effective* values, including the constraint a
+  scanner plugin declares as its own default. That is deliberate: bandit's
+  built-in ``>=1.7.0,<2.0.0`` really does constrain a project that never
+  mentioned bandit, so a sibling pinning ``>=2.0.0`` really is a conflict. Since
+  the default is identical for every project it can never manufacture one.
+* Pins are compared pairwise. With three projects the message names the pairs
+  that clash, not a minimal explanation of the whole clash.
+* A project's config is loaded to read its scanner set and threshold. That runs
+  the ordinary config-resolution path, so a config that emits resolution warnings
+  emits them here too, during what the operator asked to be a dry run.
+"""
+
+from __future__ import annotations
+
+import os
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.config.resolve_config import (
+    find_config_file,
+    resolve_config,
+)
+from automated_security_helper.core.exceptions import (
+    ASHConfigValidationError,
+    WorkspaceDefinitionError,
+)
+from automated_security_helper.models.workspace import SkippedProjectReason
+from automated_security_helper.utils.path_containment import validate_contained_path
+from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.scanner_pins import PinVerdict, compare_pins
+from automated_security_helper.workspace.workspace_file import (
+    WorkspaceDefinition,
+    load_workspace_file,
+)
+
+PathLike = Union[str, Path]
+
+#: Separator used to turn a workspace-relative path into a project key.
+KEY_SEPARATOR = "-"
+
+
+class _Candidate:
+    """A folder entry part-way through resolution.
+
+    Mutable and internal: resolution fills fields in as each check passes, and
+    the immutable :class:`ProjectPlan` is built from it at the end.
+    """
+
+    __slots__ = ("entry", "resolved", "relative", "key", "skip_reason", "skip_detail")
+
+    def __init__(self, entry: str, resolved: Path, relative: Path, key: str) -> None:
+        self.entry = entry
+        self.resolved = resolved
+        self.relative = relative
+        self.key = key
+        self.skip_reason: Optional[SkippedProjectReason] = None
+        self.skip_detail: Optional[str] = None
+
+    @property
+    def skipped(self) -> bool:
+        return self.skip_reason is not None
+
+
+def _refuse(headline: str, problems: List[str]) -> WorkspaceDefinitionError:
+    """Build a refusal naming every problem, not just the first."""
+    joined = "\n  - ".join(problems)
+    return WorkspaceDefinitionError(f"{headline}\n  - {joined}")
+
+
+def _field(container: Any, name: str, default: Any = None) -> Any:
+    """Read *name* from a pydantic model or from a plain dict.
+
+    Scanner entries arrive either as typed config models or, for a
+    plugin-provided scanner, as whatever landed in ``__pydantic_extra__`` -- which
+    is a dict. Both shapes have to be readable without the caller caring which it
+    got.
+    """
+    if isinstance(container, dict):
+        return container.get(name, default)
+    return getattr(container, name, default)
+
+
+def _scanner_display_name(field_name: str, config: AshConfig) -> str:
+    """The name an operator would type for a scanner config field.
+
+    Prefers the field's declared alias (``cdk-nag``) over the Python field name
+    (``cdk_nag``), because the alias is what ``--scanners`` and the config file
+    accept.
+    """
+    field_info = type(config.scanners).model_fields.get(field_name)
+    if field_info is not None and field_info.alias:
+        return field_info.alias
+    return field_name.replace("_", "-")
+
+
+def _scanner_state(config: AshConfig) -> Tuple[List[str], Dict[str, str]]:
+    """Return the project's enabled scanner names and its effective pins.
+
+    Walks the declared fields and then anything a plugin contributed via
+    ``extra="allow"``, so a scanner ASH does not ship is still accounted for.
+    """
+    segment = config.scanners
+    declared = list(type(segment).model_fields.keys())
+    extra = list(getattr(segment, "__pydantic_extra__", None) or {})
+
+    enabled: List[str] = []
+    pins: Dict[str, str] = {}
+
+    for field_name in declared + [name for name in extra if name not in declared]:
+        entry = _field(segment, field_name)
+        if entry is None:
+            continue
+        name = (
+            _scanner_display_name(field_name, config)
+            if field_name in declared
+            else field_name
+        )
+        if _field(entry, "enabled", True):
+            enabled.append(name)
+        pin = _field(_field(entry, "options"), "tool_version")
+        if isinstance(pin, str) and pin.strip():
+            pins[name] = pin
+    return sorted(enabled), pins
+
+
+def _project_label(config: AshConfig, key: str) -> str:
+    """The project's display label.
+
+    ``AshConfig.project_name`` is never absent -- it defaults to ``ash-scan``, or
+    to ``ASH_PROJECT_NAME`` when that is set -- so "when present" cannot mean
+    "the field is set". It has to mean "the project's config declared one", which
+    is decided by comparing against the field's own default rather than against a
+    hardcoded string, so the comparison follows the environment variable.
+
+    A project that genuinely sets ``project_name`` to the default value is
+    treated as not having declared one. The consequence is that its label is its
+    key, which is what it would have been anyway.
+    """
+    default = AshConfig.model_fields["project_name"].default
+    declared = getattr(config, "project_name", None)
+    if isinstance(declared, str) and declared.strip() and declared != default:
+        return declared
+    return key
+
+
+def _validate_containment(
+    definition: WorkspaceDefinition,
+) -> List[_Candidate]:
+    """Run Phase 0's containment check over every entry, collecting rejections."""
+    problems: List[str] = []
+    candidates: List[_Candidate] = []
+
+    for folder in definition.folders:
+        result = validate_contained_path(folder.path, definition.root)
+        if not result.ok:
+            # Parentheses, not brackets: these messages are echoed by callers
+            # that may render Rich markup, where '[outside-root]' would be read
+            # as a style name and fail at render time.
+            problems.append(f"{result.error.message} ({result.error.violation.value})")
+            continue
+        resolved = result.resolved
+        relative = resolved.relative_to(definition.root)
+        if not relative.parts:
+            # The entry names the workspace root. See the module docstring.
+            problems.append(
+                f"'{folder.path}' names the workspace root itself. A workspace "
+                f"project must be a directory below the root; to scan a single "
+                f"directory use '--source-dir' instead of '--workspace'."
+            )
+            continue
+        candidates.append(
+            _Candidate(
+                entry=folder.path,
+                resolved=resolved,
+                relative=relative,
+                key=KEY_SEPARATOR.join(relative.parts),
+            )
+        )
+
+    if problems:
+        raise _refuse(
+            f"Workspace '{definition.path.as_posix()}' lists folder entries that "
+            f"cannot be used:",
+            problems,
+        )
+    return candidates
+
+
+def _validate_no_overlap(
+    definition: WorkspaceDefinition, candidates: List[_Candidate]
+) -> None:
+    """Reject entries that are the same directory, or nested one inside another.
+
+    Compares canonicalised real paths, which is what catches a symlink alias that
+    containment validation accepts.
+    """
+    problems: List[str] = []
+    for first, second in combinations(candidates, 2):
+        if first.resolved == second.resolved:
+            problems.append(
+                f"'{first.entry}' and '{second.entry}' resolve to the same "
+                f"directory '{first.resolved.as_posix()}'; findings would be "
+                f"attributed twice and suppressions applied twice"
+            )
+        elif second.resolved.is_relative_to(first.resolved):
+            problems.append(
+                f"'{second.entry}' is inside '{first.entry}' "
+                f"('{second.resolved.as_posix()}' is below "
+                f"'{first.resolved.as_posix()}'); overlapping projects would be "
+                f"scanned twice"
+            )
+        elif first.resolved.is_relative_to(second.resolved):
+            problems.append(
+                f"'{first.entry}' is inside '{second.entry}' "
+                f"('{first.resolved.as_posix()}' is below "
+                f"'{second.resolved.as_posix()}'); overlapping projects would be "
+                f"scanned twice"
+            )
+
+    if problems:
+        raise _refuse(
+            f"Workspace '{definition.path.as_posix()}' has overlapping folder entries:",
+            problems,
+        )
+
+
+def _validate_unique_keys(
+    definition: WorkspaceDefinition, candidates: List[_Candidate]
+) -> None:
+    """Reject two distinct projects that would share a project key."""
+    by_key: Dict[str, List[_Candidate]] = {}
+    for candidate in candidates:
+        by_key.setdefault(candidate.key, []).append(candidate)
+
+    problems: List[str] = []
+    for key, group in by_key.items():
+        if len(group) < 2:
+            continue
+        listed = ", ".join(f"'{member.relative.as_posix()}'" for member in group)
+        problems.append(
+            f"{listed} all reduce to the same project key '{key}', so they "
+            f"would share an output path"
+        )
+
+    if problems:
+        raise _refuse(
+            f"Workspace '{definition.path.as_posix()}' has colliding project keys:",
+            problems,
+        )
+
+
+def _apply_existence_checks(
+    definition: WorkspaceDefinition,
+    candidates: List[_Candidate],
+    allow_missing_projects: bool,
+) -> None:
+    """Mark or reject entries that do not exist or cannot be read.
+
+    This is the only check ``--allow-missing-projects`` opts out of, and the opt
+    out marks the project skipped rather than dropping it, so the plan still
+    accounts for every entry in the definition.
+    """
+    problems: List[str] = []
+    for candidate in candidates:
+        if not candidate.resolved.is_dir():
+            detail = (
+                f"'{candidate.entry}' does not exist as a directory at "
+                f"'{candidate.resolved.as_posix()}'"
+            )
+        elif not os.access(candidate.resolved, os.R_OK | os.X_OK):
+            detail = (
+                f"'{candidate.entry}' at '{candidate.resolved.as_posix()}' is "
+                f"not readable by this process"
+            )
+        else:
+            continue
+
+        if allow_missing_projects:
+            candidate.skip_reason = SkippedProjectReason.ERROR
+            candidate.skip_detail = detail
+        else:
+            problems.append(detail)
+
+    if problems:
+        raise _refuse(
+            f"Workspace '{definition.path.as_posix()}' names projects that "
+            f"cannot be scanned. Nothing was scanned, because scanning the rest "
+            f"and exiting 0 would report a clean result for code that was never "
+            f"examined. Pass '--allow-missing-projects' to skip them instead:",
+            problems,
+        )
+
+
+def _resolve_project_config(
+    candidate: _Candidate,
+) -> Tuple[AshConfig, Optional[Path]]:
+    """Load one project's config through ASH's ordinary resolution path.
+
+    The config file is located once and passed back in, rather than letting
+    resolution search again, so the file the plan reports is definitionally the
+    file that was loaded and the two cannot disagree.
+
+    Returns:
+        The resolved config, and the config file it came from -- ``None`` when the
+        project has none and took ASH's default config.
+
+    Raises:
+        ASHConfigValidationError: When the project's own config is invalid. Left
+            as this type, not wrapped as a workspace error, because it maps to a
+            different exit code (3, not 2) and routes to a different person. The
+            message is re-issued with the project key so the operator knows which
+            of N projects to look at.
+    """
+    config_path = find_config_file(candidate.resolved)
+    try:
+        config = resolve_config(
+            config_path=config_path,
+            source_dir=candidate.resolved,
+            fallback_to_default=True,
+        )
+        return config, config_path
+    except ASHConfigValidationError as exc:
+        raise ASHConfigValidationError(
+            f"Project '{candidate.key}' at '{candidate.resolved.as_posix()}' has "
+            f"an invalid configuration: {exc}"
+        ) from exc
+
+
+def _validate_scanner_pins(
+    definition: WorkspaceDefinition, projects: List[ProjectPlan]
+) -> None:
+    """Refuse a workspace whose projects demand irreconcilable tool versions.
+
+    Only projects that will actually be scanned are compared: a skipped project
+    cannot conflict with one that runs.
+
+    An undecidable comparison is refused alongside an incompatible one. Assuming
+    compatibility would mean a project could be scanned by a tool version it
+    excluded, and the exclusion is usually there because that version was known
+    to miss something.
+    """
+    by_scanner: Dict[str, Dict[str, List[str]]] = {}
+    for project in projects:
+        for scanner, pin in project.scanner_pins.items():
+            by_scanner.setdefault(scanner, {}).setdefault(pin, []).append(project.key)
+
+    problems: List[str] = []
+    for scanner, by_pin in sorted(by_scanner.items()):
+        for first_pin, second_pin in combinations(sorted(by_pin), 2):
+            verdict = compare_pins(first_pin, second_pin)
+            if verdict is PinVerdict.COMPATIBLE:
+                continue
+            explanation = (
+                "no version satisfies both"
+                if verdict is PinVerdict.INCOMPATIBLE
+                else "ASH cannot prove any version satisfies both"
+            )
+            problems.append(
+                f"scanner '{scanner}': "
+                f"'{first_pin}' (required by "
+                f"{', '.join(sorted(by_pin[first_pin]))}) and "
+                f"'{second_pin}' (required by "
+                f"{', '.join(sorted(by_pin[second_pin]))}) -- {explanation}"
+            )
+
+    if problems:
+        raise _refuse(
+            f"Workspace '{definition.path.as_posix()}' cannot be scanned: its "
+            f"projects pin incompatible scanner tool versions. One ASH run "
+            f"installs one version of each tool, and per-project tool isolation "
+            f"is not supported, so scanning would silently ignore one project's "
+            f"constraint. Reconcile the pins, or scan the projects separately:",
+            problems,
+        )
+
+
+def _assign_display_labels(projects: List[ProjectPlan]) -> None:
+    """Decorate a label with its project key when a sibling shares the label.
+
+    Two projects may legitimately carry the same ``project_name``, so the label
+    is never a uniqueness key. Decorating only the ambiguous ones keeps the
+    common case readable.
+    """
+    counts: Dict[str, int] = {}
+    for project in projects:
+        counts[project.label] = counts.get(project.label, 0) + 1
+    for project in projects:
+        project.display_label = (
+            f"{project.label} ({project.key})"
+            if counts[project.label] > 1
+            else project.label
+        )
+
+
+def resolve_workspace(
+    workspace_file: PathLike,
+    *,
+    allow_missing_projects: bool = False,
+) -> WorkspacePlan:
+    """Resolve and validate a workspace, returning an inspectable plan.
+
+    Scans nothing. Reads the workspace definition and each project's config, and
+    either returns a plan describing what would run or raises.
+
+    Args:
+        workspace_file: Path to the ``.code-workspace`` definition.
+        allow_missing_projects: Opt out of failing when a project directory is
+            absent or unreadable. Those projects are marked skipped and recorded
+            in the plan's ``skipped_projects`` payload. Does not opt out of any
+            other check -- see "Fail-closed" in the module docstring.
+
+    Returns:
+        A :class:`~automated_security_helper.workspace.plan.WorkspacePlan` with
+        one entry per folder in the definition, skipped ones included.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 2. The definition is malformed, or an
+            entry escapes the workspace root, is a symlink, names the root, does
+            not exist, is unreadable, overlaps another entry, collides on its
+            key, or pins a scanner version irreconcilable with another project's.
+            The message names every offending entry.
+        ASHConfigValidationError: Exit code 3. The workspace is fine but one
+            project's own config is invalid. The message names the project.
+    """
+    definition = load_workspace_file(workspace_file)
+
+    candidates = _validate_containment(definition)
+    _validate_no_overlap(definition, candidates)
+    _validate_unique_keys(definition, candidates)
+    _apply_existence_checks(definition, candidates, allow_missing_projects)
+
+    if all(candidate.skipped for candidate in candidates):
+        raise WorkspaceDefinitionError(
+            f"Workspace '{definition.path.as_posix()}' has no project left to "
+            f"scan: every folder it lists was skipped. Exiting 0 here would "
+            f"report a clean result for a workspace nothing examined."
+        )
+
+    projects: List[ProjectPlan] = []
+    for candidate in candidates:
+        if candidate.skipped:
+            projects.append(
+                ProjectPlan(
+                    key=candidate.key,
+                    relative_path=candidate.relative.as_posix(),
+                    path=candidate.resolved.as_posix(),
+                    label=candidate.key,
+                    display_label=candidate.key,
+                    skipped=True,
+                    skip_reason=candidate.skip_reason,
+                    skip_detail=candidate.skip_detail,
+                )
+            )
+            continue
+
+        config, config_path = _resolve_project_config(candidate)
+        scanners, pins = _scanner_state(config)
+        label = _project_label(config, candidate.key)
+        projects.append(
+            ProjectPlan(
+                key=candidate.key,
+                relative_path=candidate.relative.as_posix(),
+                path=candidate.resolved.as_posix(),
+                label=label,
+                # Settled below by _assign_display_labels, which needs the whole
+                # sibling set to know whether this label is ambiguous.
+                display_label=label,
+                config_source=config_path.resolve().as_posix() if config_path else None,
+                scanners=scanners,
+                severity_threshold=config.global_settings.severity_threshold,
+                scanner_pins=pins,
+            )
+        )
+
+    _validate_scanner_pins(
+        definition, [project for project in projects if not project.skipped]
+    )
+    _assign_display_labels(projects)
+
+    return WorkspacePlan(
+        workspace_file=definition.path.as_posix(),
+        workspace_root=definition.root.as_posix(),
+        projects=projects,
+        allow_missing_projects=allow_missing_projects,
+    )

--- a/automated_security_helper/workspace/resolver.py
+++ b/automated_security_helper/workspace/resolver.py
@@ -84,6 +84,22 @@ literally named ``a-b`` both key to ``a-b``, so "unique by construction" does no
 hold once overlaps are excluded. Two projects sharing a key would share an output
 path, so the collision is refused, naming both paths.
 
+Nothing may escape as anything but a workspace error
+----------------------------------------------------
+Folder entries are untrusted text from a file, handed to pathlib. Which inputs
+pathlib refuses, and with which exception type, has changed across the Python
+versions this project supports (3.10 through 3.13) -- a null byte, for instance,
+raised ``ValueError`` straight out of ``os.lstat``, escaped uncaught, and turned
+a malformed workspace file into a traceback and exit 1 rather than exit 2. So the
+containment call is wrapped, and any ``OSError`` or ``ValueError`` from it becomes
+a named entry in the exit-2 list. Only the exception's type is reported, never its
+message, because the message is the platform's wording and differs by version.
+
+The wrap is a net, not the mechanism: inputs known to be unusable are rejected
+from their raw text in
+:mod:`automated_security_helper.workspace.workspace_file`, where the verdict does
+not depend on the interpreter at all.
+
 Failure modes and known limitations
 -----------------------------------
 * Validation is point-in-time. Every path is checked here and used later; a
@@ -248,7 +264,20 @@ def _validate_containment(
     candidates: List[_Candidate] = []
 
     for folder in definition.folders:
-        result = validate_contained_path(folder.path, definition.root)
+        try:
+            result = validate_contained_path(folder.path, definition.root)
+        except (OSError, ValueError) as exc:
+            # Folder entries are untrusted text handed to pathlib, and which
+            # inputs pathlib refuses -- and with what exception type -- has
+            # changed between the Python versions this project supports. Any
+            # surprise has to land on exit 2 naming the entry rather than as a
+            # traceback and exit 1. Only the exception's type is reported: its
+            # message is the platform's wording and differs across versions.
+            problems.append(
+                f"'{folder.path}' could not be resolved as a path "
+                f"({type(exc).__name__} from the filesystem layer)"
+            )
+            continue
         if not result.ok:
             # Parentheses, not brackets: these messages are echoed by callers
             # that may render Rich markup, where '[outside-root]' would be read

--- a/automated_security_helper/workspace/resolver.py
+++ b/automated_security_helper/workspace/resolver.py
@@ -90,9 +90,9 @@ Folder entries are untrusted text from a file, handed to pathlib. Which inputs
 pathlib refuses, and with which exception type, has changed across the Python
 versions this project supports (3.10 through 3.13) -- a null byte, for instance,
 raised ``ValueError`` straight out of ``os.lstat``, escaped uncaught, and turned
-a malformed workspace file into a traceback and exit 1 rather than exit 2. So the
+a malformed workspace file into a traceback and exit 1 rather than exit 4. So the
 containment call is wrapped, and any ``OSError`` or ``ValueError`` from it becomes
-a named entry in the exit-2 list. Only the exception's type is reported, never its
+a named entry in the exit-4 list. Only the exception's type is reported, never its
 message, because the message is the platform's wording and differs by version.
 
 The wrap is a net, not the mechanism: inputs known to be unusable are rejected
@@ -270,7 +270,7 @@ def _validate_containment(
             # Folder entries are untrusted text handed to pathlib, and which
             # inputs pathlib refuses -- and with what exception type -- has
             # changed between the Python versions this project supports. Any
-            # surprise has to land on exit 2 naming the entry rather than as a
+            # surprise has to land on exit 4 naming the entry rather than as a
             # traceback and exit 1. Only the exception's type is reported: its
             # message is the platform's wording and differs across versions.
             problems.append(
@@ -540,7 +540,7 @@ def resolve_workspace(
         one entry per folder in the definition, skipped ones included.
 
     Raises:
-        WorkspaceDefinitionError: Exit code 2. The definition is malformed, or an
+        WorkspaceDefinitionError: Exit code 4. The definition is malformed, or an
             entry escapes the workspace root, is a symlink, names the root, does
             not exist, is unreadable, overlaps another entry, collides on its
             key, or pins a scanner version irreconcilable with another project's.

--- a/automated_security_helper/workspace/scanner_pins.py
+++ b/automated_security_helper/workspace/scanner_pins.py
@@ -1,0 +1,344 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decide whether two scanner version pins can both be satisfied.
+
+Why this module exists
+----------------------
+A project pins the version of a scanner tool through
+``scanners.<name>.options.tool_version``, a PEP 440 specifier set such as
+``">=1.125.0,<2.0.0"``. One ASH run installs one version of each tool, and
+per-project tool isolation is out of scope, so a workspace whose projects demand
+disjoint version ranges cannot be honoured for both. The only two honest
+responses are to refuse the workspace or to scan a project with a tool version it
+explicitly excluded -- and for a security scanner the second is not acceptable,
+because the operator's stated reason for the exclusion (a false-negative in that
+version, say) is silently overridden and nothing in the output says so.
+
+So this module answers exactly one question -- "does any version satisfy both
+pins?" -- and answers it in three values rather than two, because "I cannot
+tell" is a real outcome that must not be collapsed into either verdict.
+
+Why not use ``packaging``
+-------------------------
+``packaging.specifiers.SpecifierSet`` would parse these strings correctly, and it
+is present in the environment as a transitive dependency. It is not a declared
+dependency of ASH and nothing in ASH imports it today, so depending on it here
+would make ASH's behaviour hostage to another package's dependency tree. It also
+would not finish the job: ``SpecifierSet`` can test whether a *given* version
+satisfies a set, but exposes no intersection-emptiness operation, which is the
+question actually being asked. The subset modelled below is small enough to
+implement against the standard library and to test exhaustively.
+
+The modelled subset, and what falls outside it
+----------------------------------------------
+Modelled: the operators ``==``, ``!=``, ``>=``, ``<=``, ``>``, ``<``, ``~=`` and
+``===``, over versions consisting only of a release segment (``1``, ``1.4``,
+``1.125.0``), plus ``.*`` prefix matching on ``==`` and ``!=``.
+
+Outside it, and therefore UNDECIDABLE: pre-releases (``1.0rc1``), post-releases
+(``1.0.post1``), dev releases (``1.0.dev0``), local versions (``1.0+abc``),
+explicit epochs (``1!1.0``), any operator not in the list, and any text that is
+not a specifier at all. ``===X`` is modelled only when ``X`` is itself a plain
+release version; PEP 440 defines it as arbitrary string equality, so
+``===some-build`` names a version this module cannot order.
+
+UNDECIDABLE is refused by the caller, not assumed compatible. The asymmetry is
+the same one that runs through workspace mode: refusing a workspace that would
+have been fine costs the operator an error message they can act on, while
+accepting one that is not fine produces a scan whose result is quietly wrong.
+
+How emptiness is decided
+------------------------
+Both pins are converted to constraint lists and a witness is searched for: a
+version satisfying every constraint on both sides. The search is over candidates
+derived from the boundary versions mentioned by either pin -- each boundary
+itself, one step above and below it, and the same boundary with a deeper release
+segment appended. This is sufficient because every constraint's boundary lies in
+that set, so a non-empty feasible region must contain either a boundary or a
+point in an open interval between two consecutive ones, and an appended segment
+lands inside such an interval.
+
+Two candidates cover the unbounded ends: ``0`` for a region open below, and one
+past the largest major seen for a region open above.
+
+Failure modes and known limitations
+-----------------------------------
+* The witness search is not complete for boundaries nested more than two release
+  segments deep. Pins of the form ``>1.0, <1.0.0.1`` have a feasible region
+  (``1.0.0.0.1`` satisfies both) that the candidate set does not reach, and the
+  verdict comes back INCOMPATIBLE. That errs toward refusal, which is the safe
+  direction, and no real scanner pin has that shape.
+* Ordering ignores everything but the release segment, which is exactly why
+  anything carrying a pre/post/dev/local marker is rejected as UNDECIDABLE
+  rather than compared on its release segment alone -- ``1.0rc1`` and ``1.0``
+  have the same release segment and are different versions.
+* Two textually identical pins are COMPATIBLE without being parsed at all. That
+  is not just an optimisation: it means a project using an exotic pin is not
+  refused merely because every project in the workspace inherited the same
+  exotic pin from the same default.
+* A verdict says nothing about whether the version exists on any index. A pin of
+  ``==99.0.0`` is compatible with ``<100`` and will still fail to install.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import List, Optional, Set, Tuple
+
+#: A version reduced to its release segment, as a tuple of integers.
+ReleaseTuple = Tuple[int, ...]
+
+# Operators are matched longest-first so "==" is not read as "=" and ">=" is not
+# read as ">".
+_OPERATORS = ("===", "==", "!=", "~=", ">=", "<=", ">", "<")
+
+_SPECIFIER_RE = re.compile(
+    r"^\s*(===|==|!=|~=|>=|<=|>|<)\s*(\S.*?)\s*$",
+)
+
+# A version this module can order: release segment only, no epoch, no pre/post/
+# dev release, no local version.
+_RELEASE_RE = re.compile(r"^\d+(?:\.\d+)*$")
+
+_PREFIX_SUFFIX = ".*"
+
+
+class PinVerdict(str, Enum):
+    """Whether two pins can both be satisfied.
+
+    Three values rather than two: UNDECIDABLE means the pins fall outside the
+    modelled subset, which the caller must treat as a refusal rather than
+    resolve in either direction.
+    """
+
+    COMPATIBLE = "compatible"
+    INCOMPATIBLE = "incompatible"
+    UNDECIDABLE = "undecidable"
+
+
+class _Op(str, Enum):
+    """The modelled comparison kinds, after ``~=`` and ``===`` are expanded."""
+
+    EQUAL = "=="
+    NOT_EQUAL = "!="
+    PREFIX_EQUAL = "==prefix"
+    PREFIX_NOT_EQUAL = "!=prefix"
+    GREATER_EQUAL = ">="
+    GREATER = ">"
+    LESS_EQUAL = "<="
+    LESS = "<"
+
+
+@dataclass(frozen=True)
+class _Constraint:
+    """One modelled constraint: a comparison kind and a release tuple."""
+
+    op: _Op
+    version: ReleaseTuple
+
+
+def _pad(value: ReleaseTuple, length: int) -> ReleaseTuple:
+    """Zero-extend *value* to *length* components.
+
+    PEP 440 compares versions as if the shorter were zero-padded, so ``1.4`` and
+    ``1.4.0`` are the same version. Every comparison here pads first.
+    """
+    return value + (0,) * (length - len(value))
+
+
+def _compare(left: ReleaseTuple, right: ReleaseTuple) -> int:
+    """Three-way comparison of two release tuples, zero-padded to equal length."""
+    length = max(len(left), len(right))
+    padded_left = _pad(left, length)
+    padded_right = _pad(right, length)
+    if padded_left < padded_right:
+        return -1
+    if padded_left > padded_right:
+        return 1
+    return 0
+
+
+def _parse_release(text: str) -> Optional[ReleaseTuple]:
+    """Parse a plain release version, or return None if it is outside the subset."""
+    if not _RELEASE_RE.match(text):
+        return None
+    return tuple(int(part) for part in text.split("."))
+
+
+def _expand_compatible_release(version: ReleaseTuple) -> Optional[List[_Constraint]]:
+    """Expand ``~=X.Y[.Z]`` into ``>=X.Y[.Z]`` plus a prefix match.
+
+    ``~=1.4.5`` means ``>=1.4.5, ==1.4.*``: the last component is free to move
+    and everything above it is pinned. It needs at least two components, since
+    ``~=1`` has no component to free and PEP 440 rejects it.
+    """
+    if len(version) < 2:
+        return None
+    return [
+        _Constraint(_Op.GREATER_EQUAL, version),
+        _Constraint(_Op.PREFIX_EQUAL, version[:-1]),
+    ]
+
+
+def _parse_specifier(specifier: str) -> Optional[List[_Constraint]]:
+    """Parse one specifier into constraints, or None if outside the subset."""
+    match = _SPECIFIER_RE.match(specifier)
+    if match is None:
+        return None
+    operator, version_text = match.group(1), match.group(2)
+
+    is_prefix = version_text.endswith(_PREFIX_SUFFIX)
+    if is_prefix:
+        if operator not in ("==", "!="):
+            # ".*" is only meaningful for equality; anywhere else PEP 440
+            # rejects it and so does this module.
+            return None
+        version_text = version_text[: -len(_PREFIX_SUFFIX)]
+
+    version = _parse_release(version_text)
+    if version is None:
+        return None
+
+    if operator == "==":
+        return [_Constraint(_Op.PREFIX_EQUAL if is_prefix else _Op.EQUAL, version)]
+    if operator == "!=":
+        return [
+            _Constraint(_Op.PREFIX_NOT_EQUAL if is_prefix else _Op.NOT_EQUAL, version)
+        ]
+    if operator == "===":
+        # Arbitrary equality. Modelled only because the version text happened to
+        # be an orderable release version; see the module docstring.
+        return [_Constraint(_Op.EQUAL, version)]
+    if operator == "~=":
+        return _expand_compatible_release(version)
+    if operator == ">=":
+        return [_Constraint(_Op.GREATER_EQUAL, version)]
+    if operator == ">":
+        return [_Constraint(_Op.GREATER, version)]
+    if operator == "<=":
+        return [_Constraint(_Op.LESS_EQUAL, version)]
+    if operator == "<":
+        return [_Constraint(_Op.LESS, version)]
+    return None  # pragma: no cover - _OPERATORS and the branches above agree
+
+
+def _parse_pin(pin: str) -> Optional[List[_Constraint]]:
+    """Parse a whole specifier set, or None if any part is outside the subset.
+
+    An empty pin parses to an empty constraint list, which every version
+    satisfies. That is the right reading: a project that sets ``tool_version``
+    to an empty string has expressed no constraint.
+    """
+    constraints: List[_Constraint] = []
+    for part in pin.split(","):
+        if not part.strip():
+            continue
+        parsed = _parse_specifier(part)
+        if parsed is None:
+            return None
+        constraints.extend(parsed)
+    return constraints
+
+
+def _matches_prefix(candidate: ReleaseTuple, prefix: ReleaseTuple) -> bool:
+    """True when *candidate* starts with *prefix* once zero-padded.
+
+    ``==1.4.*`` matches ``1.4`` as well as ``1.4.0`` and ``1.4.9``, because the
+    shorter version is padded before the comparison.
+    """
+    padded = _pad(candidate, max(len(candidate), len(prefix)))
+    return padded[: len(prefix)] == prefix
+
+
+def _satisfies(candidate: ReleaseTuple, constraint: _Constraint) -> bool:
+    """True when *candidate* satisfies one constraint."""
+    if constraint.op is _Op.PREFIX_EQUAL:
+        return _matches_prefix(candidate, constraint.version)
+    if constraint.op is _Op.PREFIX_NOT_EQUAL:
+        return not _matches_prefix(candidate, constraint.version)
+
+    order = _compare(candidate, constraint.version)
+    if constraint.op is _Op.EQUAL:
+        return order == 0
+    if constraint.op is _Op.NOT_EQUAL:
+        return order != 0
+    if constraint.op is _Op.GREATER_EQUAL:
+        return order >= 0
+    if constraint.op is _Op.GREATER:
+        return order > 0
+    if constraint.op is _Op.LESS_EQUAL:
+        return order <= 0
+    return order < 0  # _Op.LESS
+
+
+def _candidates(constraints: List[_Constraint]) -> Set[ReleaseTuple]:
+    """Build the witness search space from the boundaries the pins mention.
+
+    For each boundary: the boundary itself, one step above and below it in its
+    last component, and the boundary with a deeper release segment appended --
+    the last of these is what reaches inside an open interval between two
+    consecutive boundaries. A prefix boundary also contributes the start of the
+    next prefix, which is where its range ends.
+
+    ``0`` and one past the largest major cover regions open below and above.
+    """
+    # Seeded so a pair of unconstrained pins still has something to test.
+    candidates: Set[ReleaseTuple] = {(0,), (1,)}
+
+    boundaries = [constraint.version for constraint in constraints]
+    for boundary in boundaries:
+        candidates.add(boundary)
+        candidates.add(boundary + (1,))
+        candidates.add(boundary + (0, 1))
+        candidates.add(boundary[:-1] + (boundary[-1] + 1,))
+        if boundary[-1] > 0:
+            candidates.add(boundary[:-1] + (boundary[-1] - 1,))
+
+    largest_major = max((boundary[0] for boundary in boundaries), default=0)
+    candidates.add((largest_major + 1,))
+    return candidates
+
+
+def _normalise(pin: str) -> Tuple[str, ...]:
+    """Reduce a pin to a comparable form, ignoring whitespace and ordering.
+
+    A specifier set is a conjunction, so the order of its parts carries no
+    meaning: ``"<2.0.0,>=1.7.0"`` and ``">=1.7.0, <2.0.0"`` are the same pin and
+    must not reach the solver as different ones.
+    """
+    return tuple(sorted(part.strip() for part in pin.split(",") if part.strip()))
+
+
+def compare_pins(first: str, second: str) -> PinVerdict:
+    """Decide whether *first* and *second* can both be satisfied.
+
+    Args:
+        first: A PEP 440 specifier set, e.g. ``">=1.125.0,<2.0.0"``. An empty
+            string means no constraint.
+        second: The other specifier set.
+
+    Returns:
+        ``COMPATIBLE`` when some version satisfies both, ``INCOMPATIBLE`` when
+        the modelled search proves none does, and ``UNDECIDABLE`` when either pin
+        falls outside the modelled subset. Callers must treat ``UNDECIDABLE`` as
+        a refusal; see the module docstring for why it is not COMPATIBLE.
+
+    The result does not depend on argument order.
+    """
+    if _normalise(first) == _normalise(second):
+        # Also the path that keeps a shared exotic default from being refused.
+        return PinVerdict.COMPATIBLE
+
+    first_constraints = _parse_pin(first)
+    second_constraints = _parse_pin(second)
+    if first_constraints is None or second_constraints is None:
+        return PinVerdict.UNDECIDABLE
+
+    combined = first_constraints + second_constraints
+    for candidate in _candidates(combined):
+        if all(_satisfies(candidate, constraint) for constraint in combined):
+            return PinVerdict.COMPATIBLE
+    return PinVerdict.INCOMPATIBLE

--- a/automated_security_helper/workspace/workspace_file.py
+++ b/automated_security_helper/workspace/workspace_file.py
@@ -1,0 +1,307 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parse and discover a VS Code ``.code-workspace`` definition.
+
+Why this module exists
+----------------------
+Workspace mode takes its project list from the file editors already keep for
+exactly that purpose, so an operator does not maintain a second list that can
+drift from the first. That file belongs to another tool, though, which makes the
+boundary worth stating precisely and in one place: this module reads the
+``folders`` array and nothing else, and hands back the raw text of each entry
+for the resolver to validate. It performs no filesystem checks on the entries
+themselves -- see :mod:`automated_security_helper.utils.path_containment` for
+those.
+
+The shape read
+--------------
+::
+
+    { "folders": [ { "path": "kiro-bootstrap" }, { "path": "shared-infra" } ],
+      "settings": {} }
+
+Folder paths are interpreted relative to the directory holding the workspace
+file, which is the workspace root. Absolute paths are accepted here and passed
+through; whether they are permissible is a containment question the resolver
+answers.
+
+What this module deliberately ignores, and why
+----------------------------------------------
+* ``settings`` -- entirely. It is tempting to let a workspace set an ASH
+  severity threshold or suppression list there, and it would work. It would also
+  put ASH policy in a file owned by another tool, whose schema ASH does not
+  control and whose keys VS Code may repurpose. ASH policy lives in ASH's own
+  config file, where ``ash config lint`` can see it.
+* A folder entry's ``name`` -- also entirely. VS Code uses it as a display name
+  in the sidebar, and reading it would make ASH's per-project attribution label
+  depend on an editor preference. The resolver derives labels from
+  ``AshConfig.project_name`` or the project key instead, both of which are ASH's
+  own.
+* Any other top-level key (``extensions``, ``launch``, ``tasks``, ...). Ignored
+  rather than rejected, because a real workspace file will carry them and
+  rejecting an unknown key would make ASH refuse ordinary files.
+
+Every rejection here is exit code 2
+-----------------------------------
+The file is either usable or it is not; there is nothing to partially accept, so
+every problem below raises ``WorkspaceDefinitionError`` and nothing is scanned:
+the file is absent, is a directory, is unreadable, is not valid JSON, is not a
+JSON object, has no ``folders`` key, has a ``folders`` value that is not a list,
+has an empty ``folders`` list, or has an entry that is not an object with a
+non-blank string ``path``.
+
+An empty ``folders`` list is a refusal rather than a no-op scan for the reason
+that runs through all of workspace mode: a scan of zero projects exits 0, which
+in CI is indistinguishable from a scan that found nothing wrong.
+
+Failure modes and known limitations
+-----------------------------------
+* JSON only, not JSONC. VS Code tolerates ``//`` comments and trailing commas in
+  ``.code-workspace`` files; :mod:`json` does not, so a commented file is
+  rejected. The error message says so explicitly, because "Expecting value:
+  line 2 column 3" sends the reader looking for the wrong problem. Stripping
+  comments was considered and rejected: doing it correctly requires a real
+  tokeniser, since ``//`` inside a string literal is data, and a naive stripper
+  silently corrupts paths like ``https://...``. Rejecting with an actionable
+  message is the honest failure.
+* Duplicate ``folders`` entries are not detected here. Two entries naming the
+  same directory -- textually, or via a symlink -- are caught by the resolver's
+  overlap detection, which compares canonicalised real paths and therefore
+  catches aliases a textual check would miss.
+* Parsing is a point-in-time read. The file can change between this call and the
+  scan; this module cannot close that window.
+* The whole file is read into memory. Workspace definitions are a few hundred
+  bytes, so this is not worth streaming.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, List, Tuple, Union
+
+from automated_security_helper.core.exceptions import WorkspaceDefinitionError
+
+PathLike = Union[str, Path]
+
+#: The suffix that identifies a workspace definition, as VS Code writes it.
+WORKSPACE_FILE_SUFFIX = ".code-workspace"
+
+#: The value of ``--workspace`` that means "find the definition yourself".
+WORKSPACE_AUTO = "auto"
+
+_FOLDERS_KEY = "folders"
+_PATH_KEY = "path"
+
+# Substrings that mean "this is probably JSONC, not JSON". Used only to improve
+# the error message after json has already refused the content, never to decide
+# whether the content is valid.
+_COMMENT_MARKERS = ("//", "/*")
+
+
+@dataclass(frozen=True)
+class WorkspaceFolder:
+    """One ``folders`` entry, carrying only what ASH acts on.
+
+    ``path`` is the raw text exactly as written in the file. It is kept
+    unnormalised so error messages can echo back what the operator typed, and so
+    the resolver -- not this module -- decides what it resolves to.
+
+    There is deliberately no ``name`` field; see the module docstring.
+    """
+
+    path: str
+
+
+@dataclass(frozen=True)
+class WorkspaceDefinition:
+    """A parsed workspace definition.
+
+    Attributes:
+        path: Canonical absolute path of the ``.code-workspace`` file.
+        root: Canonical absolute directory holding it. This is the workspace
+            root: folder entries resolve against it, containment is judged
+            against it, and in container mode it is what gets mounted at
+            ``/src``.
+        folders: The ``folders`` entries in file order. Order is preserved
+            because it is the operator's stated order and shows up in
+            ``--dry-run`` output; nothing depends on it semantically.
+    """
+
+    path: Path
+    root: Path
+    folders: Tuple[WorkspaceFolder, ...]
+
+
+def _reject(message: str) -> WorkspaceDefinitionError:
+    return WorkspaceDefinitionError(message)
+
+
+def _read_json(workspace_file: Path) -> Any:
+    """Read and parse the workspace file, or raise with an actionable message."""
+    try:
+        raw = workspace_file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _reject(
+            f"workspace file '{workspace_file.as_posix()}' could not be read: {exc}"
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise _reject(
+            f"workspace file '{workspace_file.as_posix()}' is not valid UTF-8: {exc}"
+        ) from exc
+
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        hint = ""
+        if any(marker in raw for marker in _COMMENT_MARKERS):
+            hint = (
+                " It appears to contain comments; ASH reads strict JSON, so "
+                "remove any '//' or '/* */' comments and trailing commas."
+            )
+        raise _reject(
+            f"workspace file '{workspace_file.as_posix()}' is not valid JSON: "
+            f"{exc}.{hint}"
+        ) from exc
+
+
+def _parse_folders(document: Any, workspace_file: Path) -> Tuple[WorkspaceFolder, ...]:
+    """Extract the ``folders`` array, rejecting every unusable shape."""
+    location = workspace_file.as_posix()
+
+    if not isinstance(document, dict):
+        raise _reject(
+            f"workspace file '{location}' must contain a JSON object at the top "
+            f"level, found {type(document).__name__}"
+        )
+
+    if _FOLDERS_KEY not in document:
+        raise _reject(
+            f"workspace file '{location}' has no '{_FOLDERS_KEY}' key; a "
+            f"workspace must list at least one folder to scan"
+        )
+
+    raw_folders = document[_FOLDERS_KEY]
+    if not isinstance(raw_folders, list):
+        raise _reject(
+            f"workspace file '{location}' has a '{_FOLDERS_KEY}' value that is "
+            f"not a list, found {type(raw_folders).__name__}"
+        )
+
+    if not raw_folders:
+        # A zero-project scan would exit 0 having examined nothing, which in CI
+        # is indistinguishable from a clean scan.
+        raise _reject(
+            f"workspace file '{location}' lists no folders; a workspace must "
+            f"name at least one folder to scan"
+        )
+
+    folders: List[WorkspaceFolder] = []
+    problems: List[str] = []
+    for index, entry in enumerate(raw_folders):
+        if not isinstance(entry, dict):
+            problems.append(
+                f"entry {index} is not a JSON object, found {type(entry).__name__}"
+            )
+            continue
+        value = entry.get(_PATH_KEY)
+        if not isinstance(value, str) or not value.strip():
+            problems.append(
+                f"entry {index} has no usable '{_PATH_KEY}'; it must be a "
+                f"non-empty string, found {value!r}"
+            )
+            continue
+        folders.append(WorkspaceFolder(path=value))
+
+    if problems:
+        # Report every bad entry: an operator with three malformed entries
+        # should not have to run ASH three times to find them.
+        joined = "\n  - ".join(problems)
+        raise _reject(
+            f"workspace file '{location}' has unusable folder entries:\n  - {joined}"
+        )
+
+    return tuple(folders)
+
+
+def load_workspace_file(workspace_file: PathLike) -> WorkspaceDefinition:
+    """Parse *workspace_file* into a :class:`WorkspaceDefinition`.
+
+    Args:
+        workspace_file: Path to a ``.code-workspace`` file. The suffix is not
+            enforced -- an operator who passes ``--workspace ./my.json`` gets
+            their file read -- because the content, not the name, decides
+            whether it is usable.
+
+    Returns:
+        The parsed definition, with the workspace root resolved.
+
+    Raises:
+        WorkspaceDefinitionError: For every unusable input. See "Every rejection
+            here is exit code 2" in the module docstring for the full list.
+    """
+    candidate = Path(workspace_file)
+
+    if not candidate.exists():
+        raise _reject(f"workspace file '{candidate.as_posix()}' does not exist")
+    if not candidate.is_file():
+        raise _reject(f"workspace file '{candidate.as_posix()}' is not a file")
+
+    resolved = candidate.resolve()
+    document = _read_json(resolved)
+    folders = _parse_folders(document, resolved)
+
+    return WorkspaceDefinition(
+        path=resolved,
+        root=resolved.parent,
+        folders=folders,
+    )
+
+
+def discover_workspace_file(search_dir: PathLike) -> Path:
+    """Find the single ``*.code-workspace`` file in *search_dir*.
+
+    Non-recursive by design. Recursing would let ASH pick up a definition from a
+    vendored dependency or a nested checkout, and the operator would have no
+    obvious way to tell which file was chosen.
+
+    Args:
+        search_dir: The directory to look in -- the process working directory,
+            when reached via ``--workspace auto``.
+
+    Returns:
+        The canonical absolute path of the one candidate found.
+
+    Raises:
+        WorkspaceDefinitionError: When there is no candidate, or more than one.
+            Ambiguity is refused rather than resolved by sort order or mtime,
+            both of which would silently pick a different file as the directory
+            changes. The message lists every candidate so the operator can name
+            one explicitly.
+    """
+    directory = Path(search_dir)
+    candidates = sorted(
+        entry
+        for entry in directory.glob(f"*{WORKSPACE_FILE_SUFFIX}")
+        # A directory can carry the suffix; it is not a definition.
+        if entry.is_file()
+    )
+
+    if not candidates:
+        raise _reject(
+            f"No '*{WORKSPACE_FILE_SUFFIX}' file found in "
+            f"'{directory.as_posix()}'. Pass '--workspace <file>' to name one "
+            f"explicitly, or drop '--workspace' to scan a single directory."
+        )
+
+    if len(candidates) > 1:
+        listed = "\n  - ".join(candidate.as_posix() for candidate in candidates)
+        raise _reject(
+            f"Found {len(candidates)} '*{WORKSPACE_FILE_SUFFIX}' files in "
+            f"'{directory.as_posix()}'; '--workspace auto' needs exactly one. "
+            f"Pass '--workspace <file>' to choose:\n  - {listed}"
+        )
+
+    return candidates[0].resolve()

--- a/automated_security_helper/workspace/workspace_file.py
+++ b/automated_security_helper/workspace/workspace_file.py
@@ -55,6 +55,24 @@ An empty ``folders`` list is a refusal rather than a no-op scan for the reason
 that runs through all of workspace mode: a scan of zero projects exits 0, which
 in CI is indistinguishable from a scan that found nothing wrong.
 
+A null character is judged on the raw text, not by pathlib
+----------------------------------------------------------
+An entry containing ``\\x00`` is rejected here, by inspecting the string, rather
+than being left for the filesystem to refuse. Two reasons, and the second is the
+one that matters:
+
+1. ``os.lstat`` raises ``ValueError`` rather than ``OSError`` for a null byte,
+   and ``ValueError`` is not part of this package's contract. It escaped
+   ``resolve_workspace`` uncaught, so a malformed workspace file produced a
+   traceback and exit 1 -- an internal error -- instead of the exit 2 that says
+   "your workspace file is wrong".
+2. The wording is version-dependent: Python 3.10 says ``embedded null byte``
+   and 3.13 says ``lstat: embedded null character in path``. Anything asserting
+   on it passes on one supported interpreter and fails on another. This project
+   supports 3.10 through 3.13, so no behaviour may rest on pathlib's handling of
+   an unusual input; such inputs are decided from the raw string, where the
+   answer is the same everywhere.
+
 Failure modes and known limitations
 -----------------------------------
 * JSON only, not JSONC. VS Code tolerates ``//`` comments and trailing commas in
@@ -94,6 +112,9 @@ WORKSPACE_AUTO = "auto"
 
 _FOLDERS_KEY = "folders"
 _PATH_KEY = "path"
+
+# Rejected from the raw text, before any pathlib call. See the module docstring.
+_NULL_CHARACTER = "\x00"
 
 # Substrings that mean "this is probably JSONC, not JSON". Used only to improve
 # the error message after json has already refused the content, never to decide
@@ -211,6 +232,14 @@ def _parse_folders(document: Any, workspace_file: Path) -> Tuple[WorkspaceFolder
             problems.append(
                 f"entry {index} has no usable '{_PATH_KEY}'; it must be a "
                 f"non-empty string, found {value!r}"
+            )
+            continue
+        if _NULL_CHARACTER in value:
+            # Decided on the raw text so the verdict cannot depend on the
+            # interpreter's pathlib. See the module docstring.
+            problems.append(
+                f"entry {index} contains a null character in its "
+                f"'{_PATH_KEY}'; no filesystem accepts one"
             )
             continue
         folders.append(WorkspaceFolder(path=value))

--- a/automated_security_helper/workspace/workspace_file.py
+++ b/automated_security_helper/workspace/workspace_file.py
@@ -42,7 +42,7 @@ What this module deliberately ignores, and why
   rather than rejected, because a real workspace file will carry them and
   rejecting an unknown key would make ASH refuse ordinary files.
 
-Every rejection here is exit code 2
+Every rejection here is exit code 4
 -----------------------------------
 The file is either usable or it is not; there is nothing to partially accept, so
 every problem below raises ``WorkspaceDefinitionError`` and nothing is scanned:
@@ -64,7 +64,7 @@ one that matters:
 1. ``os.lstat`` raises ``ValueError`` rather than ``OSError`` for a null byte,
    and ``ValueError`` is not part of this package's contract. It escaped
    ``resolve_workspace`` uncaught, so a malformed workspace file produced a
-   traceback and exit 1 -- an internal error -- instead of the exit 2 that says
+   traceback and exit 1 -- an internal error -- instead of the exit 4 that says
    "your workspace file is wrong".
 2. The wording is version-dependent: Python 3.10 says ``embedded null byte``
    and 3.13 says ``lstat: embedded null character in path``. Anything asserting
@@ -269,7 +269,7 @@ def load_workspace_file(workspace_file: PathLike) -> WorkspaceDefinition:
 
     Raises:
         WorkspaceDefinitionError: For every unusable input. See "Every rejection
-            here is exit code 2" in the module docstring for the full list.
+            here is exit code 4" in the module docstring for the full list.
     """
     candidate = Path(workspace_file)
 

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -115,6 +115,46 @@ ash [options]
 | `--use-existing`              | Use existing results file                               | `False`               |                         |
 | `--phases`                    | Phases to run: `convert`, `scan`, `report`, `inspect`   | `convert,scan,report` |                         |
 | `--inspect`                   | Enable inspection of SARIF fields                       | `False`               |                         |
+| `--workspace`                 | Path to a `.code-workspace` file, or `auto` to find the one in the current directory. Mutually exclusive with `--source-dir` | None | `ASH_WORKSPACE` |
+| `--allow-missing-projects`    | Skip workspace projects that are absent or unreadable   | `False`               |                         |
+| `--dry-run`                   | Print the resolved workspace plan and exit without scanning | `False`           |                         |
+
+### Workspace Mode
+
+A [VS Code workspace file](https://code.visualstudio.com/docs/editor/workspaces) lists several project folders. Passing it to `--workspace` tells ASH to treat each folder as its own project, with its own configuration, rather than as one directory tree:
+
+```json
+{
+  "folders": [
+    { "path": "services/api" },
+    { "path": "shared-infra" }
+  ]
+}
+```
+
+Folder paths are relative to the directory holding the workspace file, which becomes the workspace root. Each project gets a key derived from its path below that root — `services/api` becomes `services-api` — and that key is what output paths and per-project attribution use. ASH reads only the `folders` array; the `settings` block is ignored, because ASH configuration belongs in ASH's own config file.
+
+`--workspace` and `--source-dir` cannot be combined. Note that `ASH_SOURCE_DIR` counts as setting `--source-dir`.
+
+`--dry-run` resolves and validates the workspace, prints the resulting plan, and exits 0 without scanning anything. In this release that is the only supported use of `--workspace`; running the scans arrives in a later release.
+
+#### Fail-closed validation
+
+Workspace resolution refuses the whole workspace rather than scanning part of it, because a partial scan exits 0 and the projects that did run supply a passing result for code nothing examined. A workspace is refused when:
+
+- a folder does not exist, or exists but is not readable
+- a folder resolves outside the workspace root, or a path contains `..`
+- a folder entry is a symlink
+- two entries resolve to the same directory, or one is nested inside another
+- two entries reduce to the same project key
+- two projects pin incompatible `tool_version` constraints for the same scanner
+- the `folders` list is empty, or the file is not valid JSON
+
+`--allow-missing-projects` opts out of the first item only. Projects skipped that way are recorded in the plan's `skipped_projects` payload with a reason, not just logged. Nothing opts out of the others: they are problems with the definition rather than with the machine, so they are wrong everywhere.
+
+Workspace mode uses its own exit codes: `0` success, `1` internal error, `2` workspace definition or policy error, `3` a project whose own configuration is invalid.
+
+Comments are not supported in the workspace file. VS Code tolerates them; ASH reads strict JSON and reports a commented file as malformed.
 
 ### Examples
 
@@ -139,6 +179,15 @@ ash --mode precommit
 
 # Scan with custom plugins
 ash --ash-plugin-modules my_custom_plugin_module
+
+# Inspect the plan for a workspace, without scanning
+ash --workspace ./dev.code-workspace --dry-run
+
+# Use the single .code-workspace file in the current directory
+ash --workspace auto --dry-run
+
+# Tolerate project folders that have not been cloned on this machine
+ash --workspace ./dev.code-workspace --allow-missing-projects --dry-run
 ```
 
 ## Config Command

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -152,7 +152,7 @@ Workspace resolution refuses the whole workspace rather than scanning part of it
 
 `--allow-missing-projects` opts out of the first item only. Projects skipped that way are recorded in the plan's `skipped_projects` payload with a reason, not just logged. Nothing opts out of the others: they are problems with the definition rather than with the machine, so they are wrong everywhere.
 
-Workspace mode uses its own exit codes: `0` success, `1` internal error, `2` workspace definition or policy error, `3` a project whose own configuration is invalid.
+Workspace mode does not introduce a separate exit-code vocabulary; it uses the codes in [Exit Codes](#exit-codes). Every refusal listed above is code `4` — the workspace definition could not be used, so nothing was scanned. That is deliberately distinct from code `2`, which means a scan ran and found issues above the threshold.
 
 Comments are not supported in the workspace file. VS Code tolerates them; ASH reads strict JSON and reports a commented file as malformed.
 

--- a/tests/unit/cli/test_scan_workspace.py
+++ b/tests/unit/cli/test_scan_workspace.py
@@ -1,0 +1,364 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the workspace-mode CLI surface of ``ash scan``.
+
+Phase 1 resolves and validates; it never scans. These tests assert that from
+the outside -- by checking that the scan entry point is not reached and that no
+output directory appears -- rather than by reading the implementation.
+
+Exit codes come from ``models.workspace.WorkspaceExitCode``: 2 for a workspace
+definition or policy error, 3 for a project whose own config is invalid.
+"""
+
+import json
+
+import pytest
+from typer.testing import CliRunner
+
+from automated_security_helper.cli.main import app
+from automated_security_helper.models.workspace import WorkspaceExitCode
+
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clear_ash_env(monkeypatch):
+    """ASH_SOURCE_DIR would otherwise make --source-dir look explicitly set."""
+    for name in ("ASH_SOURCE_DIR", "ASH_OUTPUT_DIR", "ASH_CONFIG", "ASH_WORKSPACE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture
+def no_scan(monkeypatch):
+    """Replace the scan entry point with a recorder, so reaching it is visible."""
+    calls = []
+
+    def _record(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(
+        "automated_security_helper.cli.scan.run_ash_scan", _record, raising=True
+    )
+    return calls
+
+
+def _workspace(root, folders, name="dev.code-workspace"):
+    path = root / name
+    path.write_text(
+        json.dumps({"folders": [{"path": p} for p in folders]}), encoding="utf-8"
+    )
+    return path
+
+
+def _project(root, relative, config=None):
+    project = root / relative
+    project.mkdir(parents=True, exist_ok=True)
+    if config is not None:
+        (project / ".ash").mkdir(exist_ok=True)
+        (project / ".ash" / "ash.yaml").write_text(config, encoding="utf-8")
+    return project
+
+
+def _invoke(*args):
+    return runner.invoke(app, ["scan", *args])
+
+
+def _all_output(result, capsys):
+    """Everything the operator would see, from whichever stream captured it.
+
+    ``pytest.ini`` sets ``log_cli = True``, and pytest's live-logging handler
+    suspends and resumes global capture around every record it emits. Resuming
+    re-points ``sys.stdout``/``sys.stderr`` at pytest's capture objects, which
+    overwrites the streams ``CliRunner`` installed, so anything written after a
+    log record lands in pytest's capture rather than in ``result.output``. Any
+    test whose path emits a log record at INFO or above has to read both.
+    """
+    captured = capsys.readouterr()
+    return result.output + captured.out + captured.err
+
+
+# ---------------------------------------------------------------------------
+# 7. --workspace and --source-dir are mutually exclusive
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_with_source_dir_is_an_error(tmp_path, no_scan):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    result = _invoke(
+        "--workspace", str(workspace), "--source-dir", str(tmp_path), "--dry-run"
+    )
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "--source-dir" in result.output
+    assert not no_scan
+
+
+def test_source_dir_from_the_environment_also_conflicts(tmp_path, no_scan, monkeypatch):
+    """Silently preferring one would hide which tree was scanned."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    monkeypatch.setenv("ASH_SOURCE_DIR", str(tmp_path))
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "ASH_SOURCE_DIR" in result.output
+    assert not no_scan
+
+
+# ---------------------------------------------------------------------------
+# 8. and 9. --workspace auto
+# ---------------------------------------------------------------------------
+
+
+def test_auto_discovery_uses_the_single_candidate(tmp_path, no_scan, monkeypatch):
+    _project(tmp_path, "api")
+    _workspace(tmp_path, ["api"])
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke("--workspace", "auto", "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.SUCCESS, result.output
+    assert "api" in result.output
+    assert not no_scan
+
+
+def test_auto_discovery_with_two_candidates_lists_both(tmp_path, no_scan, monkeypatch):
+    _project(tmp_path, "api")
+    _workspace(tmp_path, ["api"], name="alpha.code-workspace")
+    _workspace(tmp_path, ["api"], name="beta.code-workspace")
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke("--workspace", "auto", "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "alpha.code-workspace" in result.output
+    assert "beta.code-workspace" in result.output
+    assert not no_scan
+
+
+def test_auto_discovery_with_no_candidate_is_an_error(tmp_path, no_scan, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke("--workspace", "auto", "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "code-workspace" in result.output
+    assert not no_scan
+
+
+def test_a_file_literally_named_auto_is_still_treated_as_discovery(
+    tmp_path, no_scan, monkeypatch
+):
+    """``auto`` is a reserved word for this flag; a file of that name does not
+    silently take priority."""
+    (tmp_path / "auto").write_text("{}", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    result = _invoke("--workspace", "auto", "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "code-workspace" in result.output
+
+
+# ---------------------------------------------------------------------------
+# 1. and 12. Fail-closed definition errors surface as exit 2
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_exits_two_and_names_the_path(tmp_path, no_scan):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "not-cloned-yet"])
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "not-cloned-yet" in result.output
+    assert not no_scan
+
+
+def test_allow_missing_projects_opts_out_and_discloses_the_skip(tmp_path, no_scan):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "not-cloned-yet"])
+
+    result = _invoke(
+        "--workspace", str(workspace), "--allow-missing-projects", "--dry-run"
+    )
+
+    assert result.exit_code == WorkspaceExitCode.SUCCESS, result.output
+    assert "not-cloned-yet" in result.output
+    assert "skipped" in result.output.lower()
+    assert not no_scan
+
+
+def test_empty_folders_list_exits_two(tmp_path, no_scan):
+    workspace = tmp_path / "dev.code-workspace"
+    workspace.write_text(json.dumps({"folders": []}), encoding="utf-8")
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert not no_scan
+
+
+def test_malformed_workspace_file_exits_two(tmp_path, no_scan):
+    workspace = tmp_path / "dev.code-workspace"
+    workspace.write_text("{not json", encoding="utf-8")
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert not no_scan
+
+
+def test_absent_workspace_file_exits_two(tmp_path, no_scan):
+    result = _invoke("--workspace", str(tmp_path / "gone.code-workspace"), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert not no_scan
+
+
+def test_incompatible_scanner_pins_exit_two(tmp_path, no_scan):
+    _project(
+        tmp_path,
+        "api",
+        'project_name: api\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=1.125.0,<2.0.0"\n',
+    )
+    _project(
+        tmp_path,
+        "web",
+        'project_name: web\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=2.0.0"\n',
+    )
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "semgrep" in result.output
+    assert not no_scan
+
+
+def test_an_invalid_project_config_exits_three(tmp_path, no_scan, capsys):
+    """A distinct code, because it routes to a different person than exit 2."""
+    _project(tmp_path, "api", "project_name: api\nglobal_settings: 7\n")
+    workspace = _workspace(tmp_path, ["api"])
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.INVALID_PROJECT_CONFIG
+    # Config resolution logs at ERROR on this path, so see _all_output.
+    output = _all_output(result, capsys)
+    assert "api" in output
+    assert "invalid configuration" in output
+    assert not no_scan
+
+
+# ---------------------------------------------------------------------------
+# 14. --dry-run prints the plan, exits 0, and runs nothing
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_the_plan_and_exits_zero(tmp_path, no_scan):
+    _project(tmp_path, "services/api", "project_name: Payments API\n")
+    _project(tmp_path, "shared-infra")
+    workspace = _workspace(tmp_path, ["services/api", "shared-infra"])
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.SUCCESS, result.output
+    assert "services-api" in result.output
+    assert "Payments API" in result.output
+    assert "shared-infra" in result.output
+
+
+def test_dry_run_invokes_no_scanner(tmp_path, no_scan):
+    """Asserted from behaviour: the scan entry point is never reached, and no
+    output directory appears anywhere under the workspace."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    before = sorted(p.name for p in tmp_path.rglob("*"))
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.SUCCESS, result.output
+    assert no_scan == []
+    assert sorted(p.name for p in tmp_path.rglob("*")) == before
+    assert not list(tmp_path.rglob("ash_aggregated_results.json"))
+    assert not list(tmp_path.rglob("ash_output"))
+
+
+def test_dry_run_works_through_the_default_callback_too(tmp_path, no_scan):
+    """``ash --workspace ... --dry-run`` with no subcommand takes the callback
+    path, which is a separate registration in cli/main.py."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    result = runner.invoke(app, ["--workspace", str(workspace), "--dry-run"])
+
+    assert result.exit_code == WorkspaceExitCode.SUCCESS, result.output
+    assert "api" in result.output
+    assert not no_scan
+
+
+# ---------------------------------------------------------------------------
+# Workspace mode without --dry-run must not fall through to a single-dir scan
+# ---------------------------------------------------------------------------
+
+
+def test_workspace_without_dry_run_refuses_rather_than_scanning_one_directory(
+    tmp_path, no_scan
+):
+    """Phase 1 ships no execution. Falling through would scan the workspace
+    root as one project and exit 0, reporting a result for a scan nobody asked
+    for."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    result = _invoke("--workspace", str(workspace))
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "--dry-run" in result.output
+    assert not no_scan
+
+
+def test_dry_run_without_workspace_is_an_error(tmp_path, no_scan):
+    """Ignoring it would run a full scan for someone who asked for none."""
+    result = _invoke("--source-dir", str(tmp_path), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "--workspace" in result.output
+    assert not no_scan
+
+
+def test_allow_missing_projects_without_workspace_is_an_error(tmp_path, no_scan):
+    result = _invoke("--source-dir", str(tmp_path), "--allow-missing-projects")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert "--workspace" in result.output
+    assert not no_scan
+
+
+# ---------------------------------------------------------------------------
+# A normal scan is untouched by any of this
+# ---------------------------------------------------------------------------
+
+
+def test_a_scan_without_workspace_flags_still_reaches_the_scan_entry_point(
+    tmp_path, no_scan
+):
+    _project(tmp_path, "api")
+
+    result = _invoke("--source-dir", str(tmp_path / "api"))
+
+    assert result.exit_code == 0, result.output
+    assert len(no_scan) == 1
+    assert no_scan[0]["source_dir"] == str(tmp_path / "api")

--- a/tests/unit/cli/test_scan_workspace.py
+++ b/tests/unit/cli/test_scan_workspace.py
@@ -7,8 +7,13 @@ Phase 1 resolves and validates; it never scans. These tests assert that from
 the outside -- by checking that the scan entry point is not reached and that no
 output directory appears -- rather than by reading the implementation.
 
-Exit codes come from ``models.workspace.WorkspaceExitCode``: 2 for a workspace
-definition or policy error, 3 for a project whose own config is invalid.
+Exit codes come from ``models.workspace.WorkspaceExitCode``: 4 for a workspace
+definition or policy error, 3 for a project whose own config is invalid. Every
+assertion below names the enum member rather than the integer, so a test cannot
+keep passing while meaning the wrong thing if the contract moves again -- which
+it already has once, from 2 to 4. The one place the literal value is pinned is
+``test_a_workspace_error_is_not_the_findings_exit_code``, which exists to catch
+the specific regression of collapsing 4 back onto 2.
 """
 
 import json
@@ -82,6 +87,36 @@ def _all_output(result, capsys):
     """
     captured = capsys.readouterr()
     return result.output + captured.out + captured.err
+
+
+# ---------------------------------------------------------------------------
+# The exit-code contract itself
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_error_is_not_the_findings_exit_code(tmp_path, no_scan):
+    """The one place in this file that pins the literal value.
+
+    Everything else names the enum member, which is what keeps those tests
+    meaningful if the contract moves. But an enum-only assertion cannot catch the
+    specific regression this code exists to prevent: collapsing the
+    workspace-error code back onto 2. Exit 2 means a scan ran and found
+    actionable findings; a workspace refusal means nothing was scanned at all. A
+    CI job reading 2 as "review the findings" would treat a workspace that never
+    ran as a successful scan with issues, which is fail-open.
+
+    Asserted through the real CLI rather than off the enum, so it covers the
+    value the process actually returns.
+    """
+    workspace = tmp_path / "dev.code-workspace"
+    workspace.write_text(json.dumps({"folders": []}), encoding="utf-8")
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == 4
+    assert result.exit_code != WorkspaceExitCode.ACTIONABLE_FINDINGS
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert not no_scan
 
 
 # ---------------------------------------------------------------------------
@@ -171,11 +206,11 @@ def test_a_file_literally_named_auto_is_still_treated_as_discovery(
 
 
 # ---------------------------------------------------------------------------
-# 1. and 12. Fail-closed definition errors surface as exit 2
+# 1. and 12. Fail-closed definition errors surface as exit 4
 # ---------------------------------------------------------------------------
 
 
-def test_missing_project_exits_two_and_names_the_path(tmp_path, no_scan):
+def test_missing_project_is_a_workspace_error_and_names_the_path(tmp_path, no_scan):
     _project(tmp_path, "api")
     workspace = _workspace(tmp_path, ["api", "not-cloned-yet"])
 
@@ -200,7 +235,7 @@ def test_allow_missing_projects_opts_out_and_discloses_the_skip(tmp_path, no_sca
     assert not no_scan
 
 
-def test_empty_folders_list_exits_two(tmp_path, no_scan):
+def test_empty_folders_list_is_a_workspace_error(tmp_path, no_scan):
     workspace = tmp_path / "dev.code-workspace"
     workspace.write_text(json.dumps({"folders": []}), encoding="utf-8")
 
@@ -210,7 +245,7 @@ def test_empty_folders_list_exits_two(tmp_path, no_scan):
     assert not no_scan
 
 
-def test_malformed_workspace_file_exits_two(tmp_path, no_scan):
+def test_malformed_workspace_file_is_a_workspace_error(tmp_path, no_scan):
     workspace = tmp_path / "dev.code-workspace"
     workspace.write_text("{not json", encoding="utf-8")
 
@@ -220,7 +255,7 @@ def test_malformed_workspace_file_exits_two(tmp_path, no_scan):
     assert not no_scan
 
 
-def test_a_null_character_folder_entry_exits_two(tmp_path, no_scan):
+def test_a_null_character_folder_entry_is_a_workspace_error(tmp_path, no_scan):
     """Not exit 1 with a traceback, which is what pathlib's ValueError produced."""
     _project(tmp_path, "api")
     workspace = _workspace(tmp_path, ["api", "bad\x00entry"])
@@ -231,14 +266,14 @@ def test_a_null_character_folder_entry_exits_two(tmp_path, no_scan):
     assert not no_scan
 
 
-def test_absent_workspace_file_exits_two(tmp_path, no_scan):
+def test_absent_workspace_file_is_a_workspace_error(tmp_path, no_scan):
     result = _invoke("--workspace", str(tmp_path / "gone.code-workspace"), "--dry-run")
 
     assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
     assert not no_scan
 
 
-def test_incompatible_scanner_pins_exit_two(tmp_path, no_scan):
+def test_incompatible_scanner_pins_are_a_workspace_error(tmp_path, no_scan):
     _project(
         tmp_path,
         "api",
@@ -258,8 +293,11 @@ def test_incompatible_scanner_pins_exit_two(tmp_path, no_scan):
     assert not no_scan
 
 
-def test_an_invalid_project_config_exits_three(tmp_path, no_scan, capsys):
-    """A distinct code, because it routes to a different person than exit 2."""
+def test_an_invalid_project_config_is_an_invalid_config_error(
+    tmp_path, no_scan, capsys
+):
+    """A distinct code, because it routes to a different person than a
+    workspace definition error: the workspace is fine, one project is not."""
     _project(tmp_path, "api", "project_name: api\nglobal_settings: 7\n")
     workspace = _workspace(tmp_path, ["api"])
 

--- a/tests/unit/cli/test_scan_workspace.py
+++ b/tests/unit/cli/test_scan_workspace.py
@@ -220,6 +220,17 @@ def test_malformed_workspace_file_exits_two(tmp_path, no_scan):
     assert not no_scan
 
 
+def test_a_null_character_folder_entry_exits_two(tmp_path, no_scan):
+    """Not exit 1 with a traceback, which is what pathlib's ValueError produced."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "bad\x00entry"])
+
+    result = _invoke("--workspace", str(workspace), "--dry-run")
+
+    assert result.exit_code == WorkspaceExitCode.WORKSPACE_ERROR
+    assert not no_scan
+
+
 def test_absent_workspace_file_exits_two(tmp_path, no_scan):
     result = _invoke("--workspace", str(tmp_path / "gone.code-workspace"), "--dry-run")
 

--- a/tests/unit/workspace/__init__.py
+++ b/tests/unit/workspace/__init__.py
@@ -1,0 +1,2 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/unit/workspace/test_resolver.py
+++ b/tests/unit/workspace/test_resolver.py
@@ -523,12 +523,12 @@ def test_malformed_workspace_file_is_refused(tmp_path):
 
 
 def test_a_null_character_entry_is_a_workspace_error_not_a_value_error(tmp_path):
-    """Exit 2, on every supported Python version.
+    """Exit 4, on every supported Python version.
 
     Left to pathlib this raised an uncaught ValueError, which the CLI does not
     catch -- so a malformed workspace file produced a traceback and exit 1
-    instead of the fail-closed exit 2, with a message that differed between 3.10
-    and 3.13.
+    instead of the fail-closed workspace-error code, with a message that
+    differed between 3.10 and 3.13.
     """
     _project(tmp_path, "api")
     workspace = _workspace(tmp_path, ["api", "bad\x00entry"])
@@ -544,7 +544,7 @@ def test_an_unexpected_path_error_is_reported_as_a_workspace_error(
 
     Folder entries are untrusted text handed to pathlib, and pathlib's set of
     refusals has changed between supported Python versions. Any surprise from
-    the containment check has to land on exit 2 naming the entry, rather than as
+    the containment check has to land on exit 4 naming the entry, rather than as
     a traceback and exit 1.
     """
     _project(tmp_path, "api")

--- a/tests/unit/workspace/test_resolver.py
+++ b/tests/unit/workspace/test_resolver.py
@@ -518,6 +518,58 @@ def test_malformed_workspace_file_is_refused(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Cross-version behaviour: no input may escape as anything but a workspace error
+# ---------------------------------------------------------------------------
+
+
+def test_a_null_character_entry_is_a_workspace_error_not_a_value_error(tmp_path):
+    """Exit 2, on every supported Python version.
+
+    Left to pathlib this raised an uncaught ValueError, which the CLI does not
+    catch -- so a malformed workspace file produced a traceback and exit 1
+    instead of the fail-closed exit 2, with a message that differed between 3.10
+    and 3.13.
+    """
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "bad\x00entry"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="null character"):
+        resolve_workspace(workspace)
+
+
+def test_an_unexpected_path_error_is_reported_as_a_workspace_error(
+    tmp_path, monkeypatch
+):
+    """The fail-closed net behind the explicit checks.
+
+    Folder entries are untrusted text handed to pathlib, and pathlib's set of
+    refusals has changed between supported Python versions. Any surprise from
+    the containment check has to land on exit 2 naming the entry, rather than as
+    a traceback and exit 1.
+    """
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    def _explode(candidate, root, **kwargs):
+        raise ValueError("some future pathlib refusal")
+
+    monkeypatch.setattr(
+        "automated_security_helper.workspace.resolver.validate_contained_path",
+        _explode,
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "api" in message
+    assert "ValueError" in message
+    # The platform's wording is deliberately not quoted, so the message is
+    # identical on every supported Python version.
+    assert "some future pathlib refusal" not in message
+
+
+# ---------------------------------------------------------------------------
 # 13. Config resolution per project
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/workspace/test_resolver.py
+++ b/tests/unit/workspace/test_resolver.py
@@ -1,0 +1,657 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for workspace resolution and the execution plan.
+
+These are the acceptance criteria for Phase 1. The bias throughout is
+fail-closed: a workspace ASH cannot fully understand is refused rather than
+partly scanned, because a partly-scanned workspace exits 0 and reports the
+projects it did reach, which reads in CI as a clean bill of health for code
+nothing examined.
+"""
+
+import json
+
+import pytest
+
+from automated_security_helper.core.exceptions import (
+    ASHConfigValidationError,
+    WorkspaceDefinitionError,
+)
+from automated_security_helper.models.workspace import SkippedProjectReason
+from automated_security_helper.workspace.resolver import resolve_workspace
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _symlink_or_skip(link, target, target_is_directory=True):
+    """Create a symlink, skipping the test where the platform forbids it."""
+    try:
+        link.symlink_to(target, target_is_directory=target_is_directory)
+    except (OSError, NotImplementedError) as exc:  # pragma: no cover - Windows
+        pytest.skip(f"symlink creation unavailable on this platform: {exc}")
+
+
+def _workspace(root, folders, name="dev.code-workspace"):
+    """Write a workspace file listing *folders* and return its path."""
+    path = root / name
+    path.write_text(
+        json.dumps({"folders": [{"path": p} for p in folders]}), encoding="utf-8"
+    )
+    return path
+
+
+def _project(root, relative, config=None):
+    """Create a project directory, optionally with an ``.ash/ash.yaml``."""
+    project = root / relative
+    project.mkdir(parents=True, exist_ok=True)
+    if config is not None:
+        ash_dir = project / ".ash"
+        ash_dir.mkdir(exist_ok=True)
+        (ash_dir / "ash.yaml").write_text(config, encoding="utf-8")
+    return project
+
+
+def _by_key(plan):
+    return {project.key: project for project in plan.projects}
+
+
+# ---------------------------------------------------------------------------
+# 1. A missing project path is fatal by default, and every one is named
+# ---------------------------------------------------------------------------
+
+
+def test_missing_project_is_fatal_by_default(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    assert "absent" in str(excinfo.value)
+
+
+def test_every_unresolved_path_is_named_not_just_the_first(tmp_path):
+    """A definition with three typos must report three, or the operator fixes
+    one per run."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["gone-a", "api", "gone-b", "gone-c"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "gone-a" in message
+    assert "gone-b" in message
+    assert "gone-c" in message
+
+
+def test_a_file_where_a_directory_was_expected_is_missing(tmp_path):
+    (tmp_path / "api").write_text("not a directory", encoding="utf-8")
+    workspace = _workspace(tmp_path, ["api"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="api"):
+        resolve_workspace(workspace)
+
+
+def test_unreadable_project_is_fatal_by_default(tmp_path):
+    project = _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    project.chmod(0o000)
+    try:
+        if project.is_dir() and _is_readable(project):  # pragma: no cover - root
+            pytest.skip("running as a user that ignores directory permissions")
+        with pytest.raises(WorkspaceDefinitionError, match="readable|api"):
+            resolve_workspace(workspace)
+    finally:
+        project.chmod(0o755)
+
+
+def _is_readable(path):
+    import os
+
+    return os.access(path, os.R_OK | os.X_OK)
+
+
+# ---------------------------------------------------------------------------
+# 2. --allow-missing-projects skips, and the skip is disclosed in the payload
+# ---------------------------------------------------------------------------
+
+
+def test_allow_missing_projects_skips_and_records_the_skip(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+
+    assert [p.key for p in plan.projects] == ["api", "absent"]
+    assert [p.key for p in plan.active_projects] == ["api"]
+
+    skipped = plan.skipped_projects
+    assert len(skipped) == 1
+    assert skipped[0].project == "absent"
+    assert skipped[0].reason is SkippedProjectReason.ERROR
+    assert skipped[0].detail
+    assert "absent" in skipped[0].detail
+
+
+def test_skipped_projects_survive_serialisation(tmp_path):
+    """A log line is not disclosure -- downstream consumers cannot read stderr."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    payload = resolve_workspace(workspace, allow_missing_projects=True).model_dump()
+
+    assert [entry["project"] for entry in payload["skipped_projects"]] == ["absent"]
+    assert payload["skipped_projects"][0]["reason"] == SkippedProjectReason.ERROR.value
+
+
+def test_allow_missing_projects_still_refuses_when_nothing_is_left(tmp_path):
+    """Skipping every project would exit 0 having scanned nothing."""
+    workspace = _workspace(tmp_path, ["gone-a", "gone-b"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="no project"):
+        resolve_workspace(workspace, allow_missing_projects=True)
+
+
+# ---------------------------------------------------------------------------
+# 3. Incompatible scanner pins refuse the workspace
+# ---------------------------------------------------------------------------
+
+
+def test_incompatible_scanner_pins_refuse_and_name_both_constraints(tmp_path):
+    _project(
+        tmp_path,
+        "api",
+        "project_name: api\nscanners:\n  semgrep:\n"
+        '    options:\n      tool_version: ">=1.125.0,<2.0.0"\n',
+    )
+    _project(
+        tmp_path,
+        "web",
+        "project_name: web\nscanners:\n  semgrep:\n"
+        '    options:\n      tool_version: ">=2.0.0"\n',
+    )
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "semgrep" in message
+    assert "api" in message
+    assert "web" in message
+    assert ">=1.125.0,<2.0.0" in message
+    assert ">=2.0.0" in message
+
+
+def test_compatible_but_different_pins_are_accepted_and_recorded(tmp_path):
+    _project(
+        tmp_path,
+        "api",
+        'project_name: api\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=1.125.0,<2.0.0"\n',
+    )
+    _project(
+        tmp_path,
+        "web",
+        'project_name: web\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=1.130.0"\n',
+    )
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    plan = resolve_workspace(workspace)
+
+    projects = _by_key(plan)
+    assert projects["api"].scanner_pins["semgrep"] == ">=1.125.0,<2.0.0"
+    assert projects["web"].scanner_pins["semgrep"] == ">=1.130.0"
+
+
+def test_pins_that_cannot_be_proven_compatible_are_refused(tmp_path):
+    """Undecidable is refused, not assumed compatible: a project scanned by a
+    version it excluded is the outcome worth designing against."""
+    _project(
+        tmp_path,
+        "api",
+        'project_name: api\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=1.125.0rc1"\n',
+    )
+    _project(
+        tmp_path,
+        "web",
+        'project_name: web\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=2.0.0"\n',
+    )
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    assert "semgrep" in str(excinfo.value)
+
+
+def test_a_single_project_pin_is_never_a_conflict(tmp_path):
+    """One project declaring an exotic pin has nothing to conflict with."""
+    _project(
+        tmp_path,
+        "api",
+        'project_name: api\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=1.125.0rc1"\n',
+    )
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    plan = resolve_workspace(workspace)
+
+    assert _by_key(plan)["api"].scanner_pins["semgrep"] == ">=1.125.0rc1"
+    assert "semgrep" not in _by_key(plan)["web"].scanner_pins
+
+
+def test_shared_default_pins_do_not_conflict(tmp_path):
+    """Every project inherits bandit's built-in pin; that must not refuse."""
+    _project(tmp_path, "api")
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    plan = resolve_workspace(workspace)
+
+    projects = _by_key(plan)
+    assert projects["api"].scanner_pins == projects["web"].scanner_pins
+
+
+def test_pins_from_a_skipped_project_are_not_compared(tmp_path):
+    """A project that will not be scanned cannot conflict with one that will."""
+    _project(
+        tmp_path,
+        "api",
+        'project_name: api\nscanners:\n  semgrep:\n    options:\n      tool_version: ">=2.0.0"\n',
+    )
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+
+    assert _by_key(plan)["api"].scanner_pins["semgrep"] == ">=2.0.0"
+
+
+# ---------------------------------------------------------------------------
+# 4. Overlapping entries, including symlink aliases
+# ---------------------------------------------------------------------------
+
+
+def test_duplicate_entries_are_rejected(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "api"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="same directory|overlap"):
+        resolve_workspace(workspace)
+
+
+def test_nested_entries_are_rejected(tmp_path):
+    _project(tmp_path, "api/inner")
+    workspace = _workspace(tmp_path, ["api", "api/inner"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "api" in message
+    assert "inner" in message
+
+
+def test_nested_entries_are_rejected_in_either_order(tmp_path):
+    _project(tmp_path, "api/inner")
+    workspace = _workspace(tmp_path, ["api/inner", "api"])
+
+    with pytest.raises(WorkspaceDefinitionError):
+        resolve_workspace(workspace)
+
+
+def test_symlink_aliased_entries_resolving_to_one_real_path_are_rejected(tmp_path):
+    """Phase 0's containment check accepts ``alias/sub``; overlap detection on
+    the canonicalised real path is what catches the alias."""
+    _project(tmp_path, "api/sub")
+    _symlink_or_skip(tmp_path / "alias", tmp_path / "api")
+    workspace = _workspace(tmp_path, ["api/sub", "alias/sub"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="same directory|overlap"):
+        resolve_workspace(workspace)
+
+
+def test_a_nested_git_repo_that_is_not_its_own_entry_is_not_an_overlap(tmp_path):
+    project = _project(tmp_path, "api")
+    (project / "vendor" / "submodule" / ".git").mkdir(parents=True)
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert [p.key for p in plan.projects] == ["api"]
+
+
+def test_sibling_prefix_directories_are_not_an_overlap(tmp_path):
+    """``api`` and ``api-v2`` share a string prefix but neither contains the
+    other."""
+    _project(tmp_path, "api")
+    _project(tmp_path, "api-v2")
+    workspace = _workspace(tmp_path, ["api", "api-v2"])
+
+    plan = resolve_workspace(workspace)
+
+    assert sorted(p.key for p in plan.projects) == ["api", "api-v2"]
+
+
+def test_an_entry_naming_the_workspace_root_is_rejected(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["."])
+
+    with pytest.raises(WorkspaceDefinitionError, match="workspace root"):
+        resolve_workspace(workspace)
+
+
+# ---------------------------------------------------------------------------
+# 5. and 6. Containment: outside the root, and symlinked entries
+# ---------------------------------------------------------------------------
+
+
+def test_entry_outside_the_workspace_root_is_rejected(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    _project(root, "api")
+    (tmp_path / "outside").mkdir()
+    workspace = _workspace(root, ["api", "../outside"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="outside|'\\.\\.'"):
+        resolve_workspace(workspace)
+
+
+def test_absolute_entry_outside_the_workspace_root_is_rejected(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    _project(root, "api")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = _workspace(root, ["api", outside.as_posix()])
+
+    with pytest.raises(WorkspaceDefinitionError, match="outside"):
+        resolve_workspace(workspace)
+
+
+def test_absolute_entry_inside_the_workspace_root_is_accepted(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    project = _project(root, "api")
+    workspace = _workspace(root, [project.as_posix()])
+
+    plan = resolve_workspace(workspace)
+
+    assert [p.key for p in plan.projects] == ["api"]
+
+
+def test_symlinked_folder_entry_is_rejected(tmp_path):
+    _project(tmp_path, "api")
+    _symlink_or_skip(tmp_path / "link", tmp_path / "api")
+    workspace = _workspace(tmp_path, ["link"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="symlink"):
+        resolve_workspace(workspace)
+
+
+def test_symlinked_entry_is_rejected_even_with_allow_missing_projects(tmp_path):
+    """--allow-missing-projects opts out of missing, never out of containment."""
+    _project(tmp_path, "api")
+    _symlink_or_skip(tmp_path / "link", tmp_path / "api")
+    workspace = _workspace(tmp_path, ["api", "link"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="symlink"):
+        resolve_workspace(workspace, allow_missing_projects=True)
+
+
+def test_outside_root_entry_is_rejected_even_with_allow_missing_projects(tmp_path):
+    root = tmp_path / "workspace"
+    root.mkdir()
+    _project(root, "api")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace = _workspace(root, ["api", outside.as_posix()])
+
+    with pytest.raises(WorkspaceDefinitionError, match="outside"):
+        resolve_workspace(workspace, allow_missing_projects=True)
+
+
+# ---------------------------------------------------------------------------
+# 10. and 11. Project keys and display labels
+# ---------------------------------------------------------------------------
+
+
+def test_nested_paths_become_dash_separated_keys(tmp_path):
+    _project(tmp_path, "services/api")
+    workspace = _workspace(tmp_path, ["services/api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert [p.key for p in plan.projects] == ["services-api"]
+    assert plan.projects[0].relative_path == "services/api"
+
+
+def test_same_basename_in_different_parents_yields_distinct_keys(tmp_path):
+    _project(tmp_path, "foo/api")
+    _project(tmp_path, "bar/api")
+    workspace = _workspace(tmp_path, ["foo/api", "bar/api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert sorted(p.key for p in plan.projects) == ["bar-api", "foo-api"]
+
+
+def test_a_key_collision_between_distinct_paths_is_refused(tmp_path):
+    """Replacing separators with dashes is not injective: ``a/b`` and a
+    directory literally named ``a-b`` both key to ``a-b``. They would share an
+    output path, so the workspace is refused rather than silently merged."""
+    _project(tmp_path, "a/b")
+    _project(tmp_path, "a-b")
+    workspace = _workspace(tmp_path, ["a/b", "a-b"])
+
+    with pytest.raises(WorkspaceDefinitionError, match="same project key"):
+        resolve_workspace(workspace)
+
+
+def test_label_uses_project_name_when_the_config_declares_one(tmp_path):
+    _project(tmp_path, "api", "project_name: Payments API\n")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert plan.projects[0].label == "Payments API"
+    assert plan.projects[0].key == "api"
+
+
+def test_label_falls_back_to_the_key_without_a_config(tmp_path):
+    _project(tmp_path, "services/api")
+    workspace = _workspace(tmp_path, ["services/api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert plan.projects[0].label == "services-api"
+
+
+def test_duplicate_labels_are_disambiguated_by_key(tmp_path):
+    """Two projects may legitimately carry the same project_name; the label is
+    never a uniqueness key."""
+    _project(tmp_path, "foo/api", "project_name: API\n")
+    _project(tmp_path, "bar/api", "project_name: API\n")
+    workspace = _workspace(tmp_path, ["foo/api", "bar/api"])
+
+    plan = resolve_workspace(workspace)
+
+    labels = sorted(p.display_label for p in plan.projects)
+    assert labels == ["API (bar-api)", "API (foo-api)"]
+    # The raw label is untouched; only the rendered form disambiguates.
+    assert {p.label for p in plan.projects} == {"API"}
+
+
+def test_a_unique_label_is_not_decorated(tmp_path):
+    _project(tmp_path, "foo/api", "project_name: API\n")
+    _project(tmp_path, "bar/web", "project_name: Web\n")
+    workspace = _workspace(tmp_path, ["foo/api", "bar/web"])
+
+    plan = resolve_workspace(workspace)
+
+    assert sorted(p.display_label for p in plan.projects) == ["API", "Web"]
+
+
+# ---------------------------------------------------------------------------
+# 12. Empty folders and a malformed file are refused by the resolver too
+# ---------------------------------------------------------------------------
+
+
+def test_empty_folders_list_is_refused(tmp_path):
+    path = tmp_path / "dev.code-workspace"
+    path.write_text(json.dumps({"folders": []}), encoding="utf-8")
+
+    with pytest.raises(WorkspaceDefinitionError, match="at least one folder"):
+        resolve_workspace(path)
+
+
+def test_malformed_workspace_file_is_refused(tmp_path):
+    path = tmp_path / "dev.code-workspace"
+    path.write_text("{not json", encoding="utf-8")
+
+    with pytest.raises(WorkspaceDefinitionError, match="not valid JSON"):
+        resolve_workspace(path)
+
+
+# ---------------------------------------------------------------------------
+# 13. Config resolution per project
+# ---------------------------------------------------------------------------
+
+
+def test_project_without_a_config_gets_the_default_config(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    project = plan.projects[0]
+    assert project.config_source is None
+    assert project.severity_threshold == "MEDIUM"
+    assert "bandit" in project.scanners
+
+
+def test_each_project_config_is_resolved_independently(tmp_path):
+    _project(
+        tmp_path,
+        "api",
+        "project_name: api\nglobal_settings:\n  severity_threshold: CRITICAL\n",
+    )
+    _project(
+        tmp_path,
+        "web",
+        "project_name: web\nglobal_settings:\n  severity_threshold: ALL\n",
+    )
+    workspace = _workspace(tmp_path, ["api", "web"])
+
+    plan = resolve_workspace(workspace)
+
+    projects = _by_key(plan)
+    assert projects["api"].severity_threshold == "CRITICAL"
+    assert projects["web"].severity_threshold == "ALL"
+
+
+def test_config_source_names_the_file_that_was_used(tmp_path):
+    project = _project(tmp_path, "api", "project_name: api\n")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert (
+        plan.projects[0].config_source
+        == (project / ".ash" / "ash.yaml").resolve().as_posix()
+    )
+
+
+def test_a_disabled_scanner_is_absent_from_the_scanner_set(tmp_path):
+    _project(
+        tmp_path,
+        "api",
+        "project_name: api\nscanners:\n  bandit:\n    enabled: false\n",
+    )
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert "bandit" not in plan.projects[0].scanners
+    assert "checkov" in plan.projects[0].scanners
+
+
+def test_an_invalid_project_config_is_an_invalid_config_error_naming_the_project(
+    tmp_path,
+):
+    """Exit code 3, not 2: the workspace is fine, one project is not."""
+    _project(tmp_path, "api", "project_name: api\nglobal_settings: 7\n")
+    workspace = _workspace(tmp_path, ["api"])
+
+    with pytest.raises(ASHConfigValidationError) as excinfo:
+        resolve_workspace(workspace)
+
+    assert "api" in str(excinfo.value)
+
+
+def test_a_skipped_project_has_no_config_or_scanners(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+
+    skipped = _by_key(plan)["absent"]
+    assert skipped.skipped is True
+    assert skipped.config_source is None
+    assert skipped.scanners == []
+    assert skipped.severity_threshold is None
+
+
+# ---------------------------------------------------------------------------
+# Plan shape
+# ---------------------------------------------------------------------------
+
+
+def test_plan_records_the_workspace_root_as_the_scan_source(tmp_path):
+    """Container mode mounts this directory at /src, so the plan has to name
+    it explicitly rather than leave it implied by the project paths."""
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert plan.workspace_root == tmp_path.resolve().as_posix()
+    assert plan.workspace_file == workspace.resolve().as_posix()
+
+
+def test_plan_records_absolute_project_paths(tmp_path):
+    project = _project(tmp_path, "services/api")
+    workspace = _workspace(tmp_path, ["services/api"])
+
+    plan = resolve_workspace(workspace)
+
+    assert plan.projects[0].path == project.resolve().as_posix()
+
+
+def test_plan_records_whether_missing_projects_were_allowed(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+
+    assert resolve_workspace(workspace).allow_missing_projects is False
+    assert (
+        resolve_workspace(workspace, allow_missing_projects=True).allow_missing_projects
+        is True
+    )
+
+
+def test_plan_renders_every_project_and_its_skip_status(tmp_path):
+    _project(tmp_path, "api", "project_name: Payments API\n")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+    rendered = plan.render()
+
+    assert "api" in rendered
+    assert "Payments API" in rendered
+    assert "absent" in rendered
+    assert "skipped" in rendered.lower()
+    assert rendered.isascii()

--- a/tests/unit/workspace/test_scanner_pins.py
+++ b/tests/unit/workspace/test_scanner_pins.py
@@ -1,0 +1,166 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for scanner version-pin compatibility.
+
+The interesting cases are the ones where the verdict has to be UNDECIDABLE
+rather than a guess, and the ones where two pins overlap only at a single
+version. Both directions matter: a wrong COMPATIBLE lets a project be scanned
+by a tool version it excluded, a wrong INCOMPATIBLE only costs an error message.
+"""
+
+import pytest
+
+from automated_security_helper.workspace.scanner_pins import (
+    PinVerdict,
+    compare_pins,
+)
+
+
+# ---------------------------------------------------------------------------
+# Identical and trivially-overlapping pins
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pin",
+    [
+        ">=1.7.0,<2.0.0",
+        "==1.2.3",
+        "~=1.4.5",
+        ">=1.0",
+        "!=1.5.0",
+        # An unparseable pin still compares equal to itself without a solver.
+        ">=1.0.0rc1",
+        "@some-nonsense",
+    ],
+)
+def test_identical_pins_are_compatible(pin):
+    assert compare_pins(pin, pin) is PinVerdict.COMPATIBLE
+
+
+def test_whitespace_only_difference_is_compatible():
+    assert compare_pins(">=1.7.0, <2.0.0", ">=1.7.0,<2.0.0") is PinVerdict.COMPATIBLE
+
+
+def test_specifier_order_only_difference_is_compatible():
+    assert compare_pins("<2.0.0,>=1.7.0", ">=1.7.0,<2.0.0") is PinVerdict.COMPATIBLE
+
+
+# ---------------------------------------------------------------------------
+# Compatible but different
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # A tighter lower bound still leaves the whole upper range.
+        (">=1.0", ">=2.0"),
+        (">=1.7.0,<2.0.0", ">=1.8.0"),
+        # Overlapping windows.
+        (">=1.0,<2.0", ">=1.5,<3.0"),
+        # Exactly one version in common.
+        ("<=1.5.0", ">=1.5.0"),
+        ("==1.5.0", ">=1.0,<2.0"),
+        # Compatible-release operator against a range it sits inside.
+        ("~=1.4.5", ">=1.0,<2.0"),
+        # A hole that does not empty the range.
+        ("!=1.5.0", ">=1.0,<2.0"),
+        # Prefix match inside a wider window.
+        ("==1.4.*", ">=1.0,<2.0"),
+        # Strict inequalities that leave room only for a deeper release
+        # segment: 1.0.0.1 satisfies both.
+        (">1.0.0", "<1.0.1"),
+        # An empty pin constrains nothing.
+        ("", ">=2.0"),
+    ],
+)
+def test_overlapping_pins_are_compatible(a, b):
+    assert compare_pins(a, b) is PinVerdict.COMPATIBLE
+    assert compare_pins(b, a) is PinVerdict.COMPATIBLE
+
+
+# ---------------------------------------------------------------------------
+# Incompatible
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # Disjoint major ranges -- the motivating real case.
+        (">=1.7.0,<2.0.0", ">=2.0.0"),
+        (">=2.0.0,<3.0.0", ">=1.0.0,<2.0.0"),
+        # Two different exact pins.
+        ("==1.2.3", "==1.2.4"),
+        # An exact pin excluded by the other side.
+        ("==1.5.0", "!=1.5.0"),
+        ("==1.5.0", ">1.5.0"),
+        # Prefix matches on different prefixes.
+        ("==1.4.*", "==1.5.*"),
+        # Compatible-release against a major it forbids.
+        ("~=1.4.5", ">=2.0"),
+        # Bounds that cross.
+        ("<1.0", ">=2.0"),
+        # A single-point range with the point punched out.
+        (">=1.5.0,<=1.5.0", "!=1.5.0"),
+    ],
+)
+def test_disjoint_pins_are_incompatible(a, b):
+    assert compare_pins(a, b) is PinVerdict.INCOMPATIBLE
+    assert compare_pins(b, a) is PinVerdict.INCOMPATIBLE
+
+
+# ---------------------------------------------------------------------------
+# Undecidable -- must not be guessed either way
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # Pre-release, post-release, dev-release and local segments are outside
+        # the modelled subset.
+        (">=1.0.0rc1", ">=2.0"),
+        (">=1.0.post1", "<2.0"),
+        (">=1.0.dev0", "<2.0"),
+        ("==1.0+local", ">=1.0"),
+        # An explicit epoch.
+        (">=1!1.0", ">=1.0"),
+        # Not a specifier at all.
+        ("latest", ">=1.0"),
+        ("1.2.3", ">=1.0"),
+        # An operator outside the modelled set.
+        ("~1.2.3", ">=1.0"),
+        # Arbitrary equality against a non-release string.
+        ("===weird-build", ">=1.0"),
+    ],
+)
+def test_unmodelled_pins_are_undecidable(a, b):
+    assert compare_pins(a, b) is PinVerdict.UNDECIDABLE
+    assert compare_pins(b, a) is PinVerdict.UNDECIDABLE
+
+
+def test_arbitrary_equality_on_a_release_version_is_modelled():
+    """``===1.2.3`` names one release version, so it can be compared."""
+    assert compare_pins("===1.2.3", ">=1.0,<2.0") is PinVerdict.COMPATIBLE
+    assert compare_pins("===1.2.3", ">=2.0") is PinVerdict.INCOMPATIBLE
+
+
+def test_verdict_is_symmetric_over_a_grid():
+    """Whatever the verdict, it must not depend on argument order."""
+    pins = [
+        ">=1.7.0,<2.0.0",
+        ">=2.0.0",
+        "==1.2.3",
+        "~=1.4.5",
+        "!=1.5.0",
+        "<1.0",
+        "==1.4.*",
+        ">=1.0.0rc1",
+        "",
+    ]
+    for a in pins:
+        for b in pins:
+            assert compare_pins(a, b) is compare_pins(b, a), (a, b)

--- a/tests/unit/workspace/test_workspace_file.py
+++ b/tests/unit/workspace/test_workspace_file.py
@@ -1,0 +1,252 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for parsing and discovering a ``.code-workspace`` definition.
+
+Everything here is about refusing a definition ASH cannot act on, and about the
+two blocks the parser deliberately ignores -- ``settings`` and a folder's
+``name`` -- because reading either would put ASH policy in another tool's file.
+"""
+
+import json
+
+import pytest
+
+from automated_security_helper.core.exceptions import WorkspaceDefinitionError
+from automated_security_helper.workspace.workspace_file import (
+    discover_workspace_file,
+    load_workspace_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write(root, payload, name="dev.code-workspace"):
+    """Write *payload* as a workspace file and return its path."""
+    path = root / name
+    if isinstance(payload, str):
+        path.write_text(payload, encoding="utf-8")
+    else:
+        path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+# ---------------------------------------------------------------------------
+# Parsing a well-formed definition
+# ---------------------------------------------------------------------------
+
+
+def test_folders_are_read_in_file_order(tmp_path):
+    path = _write(
+        tmp_path,
+        {"folders": [{"path": "kiro-bootstrap"}, {"path": "shared-infra"}]},
+    )
+
+    definition = load_workspace_file(path)
+
+    assert [f.path for f in definition.folders] == ["kiro-bootstrap", "shared-infra"]
+    assert definition.root == tmp_path.resolve()
+    assert definition.path == path.resolve()
+
+
+def test_settings_block_is_ignored(tmp_path):
+    """ASH policy lives in ASH's config, never in another tool's schema."""
+    path = _write(
+        tmp_path,
+        {
+            "folders": [{"path": "api"}],
+            "settings": {
+                "ash.severity_threshold": "CRITICAL",
+                "files.exclude": {"**/node_modules": True},
+            },
+        },
+    )
+
+    definition = load_workspace_file(path)
+
+    assert [f.path for f in definition.folders] == ["api"]
+    assert not hasattr(definition, "settings")
+
+
+def test_folder_name_field_is_ignored(tmp_path):
+    """VS Code's display name must not become ASH's attribution label."""
+    path = _write(
+        tmp_path,
+        {"folders": [{"path": "api", "name": "The API Service"}]},
+    )
+
+    definition = load_workspace_file(path)
+
+    assert [f.path for f in definition.folders] == ["api"]
+    assert not any(
+        getattr(folder, "name", None) == "The API Service"
+        for folder in definition.folders
+    )
+
+
+def test_extra_top_level_keys_are_ignored(tmp_path):
+    path = _write(
+        tmp_path,
+        {"folders": [{"path": "api"}], "extensions": {"recommendations": []}},
+    )
+
+    assert [f.path for f in load_workspace_file(path).folders] == ["api"]
+
+
+def test_workspace_file_is_read_as_utf8(tmp_path):
+    """Explicit encoding, so the parse does not depend on the host locale."""
+    # Built with chr() so this test file itself stays pure ASCII.
+    name = "caf" + chr(0xE9) + "-api"
+    path = tmp_path / "dev.code-workspace"
+    path.write_text(
+        json.dumps({"folders": [{"path": name}]}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    assert [f.path for f in load_workspace_file(path).folders] == [name]
+
+
+# ---------------------------------------------------------------------------
+# Malformed definitions -- every one of these is exit code 2
+# ---------------------------------------------------------------------------
+
+
+def test_empty_folders_list_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": []})
+
+    with pytest.raises(WorkspaceDefinitionError, match="at least one folder"):
+        load_workspace_file(path)
+
+
+def test_missing_folders_key_is_rejected(tmp_path):
+    path = _write(tmp_path, {"settings": {}})
+
+    with pytest.raises(WorkspaceDefinitionError, match="folders"):
+        load_workspace_file(path)
+
+
+def test_invalid_json_is_rejected(tmp_path):
+    path = _write(tmp_path, '{"folders": [{"path": "api"}')
+
+    with pytest.raises(WorkspaceDefinitionError, match="not valid JSON"):
+        load_workspace_file(path)
+
+
+def test_json_comments_are_rejected_with_an_actionable_message(tmp_path):
+    """VS Code tolerates comments; ASH does not, and says so rather than guessing."""
+    path = _write(
+        tmp_path,
+        '{\n  // the API\n  "folders": [{"path": "api"}]\n}',
+    )
+
+    with pytest.raises(WorkspaceDefinitionError, match="comments"):
+        load_workspace_file(path)
+
+
+def test_top_level_array_is_rejected(tmp_path):
+    path = _write(tmp_path, [{"path": "api"}])
+
+    with pytest.raises(WorkspaceDefinitionError, match="JSON object"):
+        load_workspace_file(path)
+
+
+def test_folders_not_a_list_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": {"path": "api"}})
+
+    with pytest.raises(WorkspaceDefinitionError, match="list"):
+        load_workspace_file(path)
+
+
+def test_folder_entry_not_an_object_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": ["api"]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="JSON object"):
+        load_workspace_file(path)
+
+
+def test_folder_entry_without_path_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": [{"name": "api"}]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="'path'"):
+        load_workspace_file(path)
+
+
+def test_folder_entry_with_non_string_path_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": [{"path": 7}]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="'path'"):
+        load_workspace_file(path)
+
+
+def test_folder_entry_with_blank_path_is_rejected(tmp_path):
+    path = _write(tmp_path, {"folders": [{"path": "   "}]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="'path'"):
+        load_workspace_file(path)
+
+
+def test_missing_workspace_file_is_rejected(tmp_path):
+    with pytest.raises(WorkspaceDefinitionError, match="does not exist"):
+        load_workspace_file(tmp_path / "absent.code-workspace")
+
+
+def test_directory_given_instead_of_a_file_is_rejected(tmp_path):
+    with pytest.raises(WorkspaceDefinitionError, match="not a file"):
+        load_workspace_file(tmp_path)
+
+
+def test_rejection_message_names_the_offending_file(tmp_path):
+    path = _write(tmp_path, {"folders": []})
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        load_workspace_file(path)
+
+    assert path.name in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Auto-discovery
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_finds_exactly_one_candidate(tmp_path):
+    path = _write(tmp_path, {"folders": [{"path": "api"}]})
+
+    assert discover_workspace_file(tmp_path) == path.resolve()
+
+
+def test_discovery_with_two_candidates_lists_both(tmp_path):
+    first = _write(tmp_path, {"folders": [{"path": "api"}]}, name="a.code-workspace")
+    second = _write(tmp_path, {"folders": [{"path": "web"}]}, name="b.code-workspace")
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        discover_workspace_file(tmp_path)
+
+    message = str(excinfo.value)
+    assert first.name in message
+    assert second.name in message
+
+
+def test_discovery_with_no_candidate_is_rejected(tmp_path):
+    with pytest.raises(WorkspaceDefinitionError, match="No '\\*.code-workspace'"):
+        discover_workspace_file(tmp_path)
+
+
+def test_discovery_does_not_recurse_into_subdirectories(tmp_path):
+    nested = tmp_path / "nested"
+    nested.mkdir()
+    _write(nested, {"folders": [{"path": "api"}]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="No '\\*.code-workspace'"):
+        discover_workspace_file(tmp_path)
+
+
+def test_discovery_ignores_directories_with_the_workspace_suffix(tmp_path):
+    """A directory named ``x.code-workspace`` is not a definition."""
+    (tmp_path / "decoy.code-workspace").mkdir()
+    real = _write(tmp_path, {"folders": [{"path": "api"}]})
+
+    assert discover_workspace_file(tmp_path) == real.resolve()

--- a/tests/unit/workspace/test_workspace_file.py
+++ b/tests/unit/workspace/test_workspace_file.py
@@ -188,6 +188,34 @@ def test_folder_entry_with_blank_path_is_rejected(tmp_path):
         load_workspace_file(path)
 
 
+@pytest.mark.parametrize("entry", ["api\x00evil", "\x00", "\x00api"])
+def test_folder_entry_containing_a_null_character_is_rejected(tmp_path, entry):
+    """Caught from the raw text, before pathlib sees it.
+
+    A null byte reaches ``os.lstat`` and raises ValueError, whose message differs
+    between Python versions ("embedded null byte" on 3.10, "lstat: embedded null
+    character in path" on 3.13). Letting it through would turn a malformed
+    workspace file into an unhandled exception and exit 1 rather than exit 2, and
+    would do it with a version-dependent message.
+    """
+    path = _write(tmp_path, {"folders": [{"path": entry}]})
+
+    with pytest.raises(WorkspaceDefinitionError, match="null character"):
+        load_workspace_file(path)
+
+
+def test_a_null_character_rejection_does_not_quote_the_platform_error(tmp_path):
+    """The message must be identical on every supported Python version."""
+    path = _write(tmp_path, {"folders": [{"path": "api\x00evil"}]})
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        load_workspace_file(path)
+
+    message = str(excinfo.value)
+    assert "embedded null byte" not in message
+    assert "lstat" not in message
+
+
 def test_missing_workspace_file_is_rejected(tmp_path):
     with pytest.raises(WorkspaceDefinitionError, match="does not exist"):
         load_workspace_file(tmp_path / "absent.code-workspace")

--- a/tests/unit/workspace/test_workspace_file.py
+++ b/tests/unit/workspace/test_workspace_file.py
@@ -110,7 +110,7 @@ def test_workspace_file_is_read_as_utf8(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Malformed definitions -- every one of these is exit code 2
+# Malformed definitions -- every one of these is exit code 4
 # ---------------------------------------------------------------------------
 
 
@@ -195,7 +195,7 @@ def test_folder_entry_containing_a_null_character_is_rejected(tmp_path, entry):
     A null byte reaches ``os.lstat`` and raises ValueError, whose message differs
     between Python versions ("embedded null byte" on 3.10, "lstat: embedded null
     character in path" on 3.13). Letting it through would turn a malformed
-    workspace file into an unhandled exception and exit 1 rather than exit 2, and
+    workspace file into an unhandled exception and exit 1 rather than exit 4, and
     would do it with a version-dependent message.
     """
     path = _write(tmp_path, {"folders": [{"path": entry}]})


### PR DESCRIPTION
Second of six PRs implementing workspace mode. **Stacked on #456** (phase 0) — review that first; this PR's diff is only its own five commits.

Phase 1 resolves and validates a workspace definition and prints an inspectable execution plan. **It does not scan.** Execution arrives in the next PR.

## What you can do after this

```bash
ash --workspace ./my-project.code-workspace --dry-run
ash --workspace auto --dry-run
ash --workspace ./ws.code-workspace --allow-missing-projects --dry-run
```

`--workspace` accepts a VS Code `.code-workspace` file. Folder paths resolve relative to the workspace file. The `settings` block is ignored entirely — ASH policy belongs in ASH's own file, not overloaded onto another tool's schema.

## Fail-closed by default

This is the substance of the phase. An earlier draft of the design said a missing project should warn and skip. That is fail-open: a typo or an un-cloned repo means a project is never scanned and ASH still exits 0, so CI goes green for a repository nothing examined, and the other projects' passing results supply the false reassurance. For a security tool that is the worst available failure mode.

Verified end to end against a real fixture:

| Condition | Exit | Opt-out |
| --- | --- | --- |
| Folder does not exist | 2, naming every unresolved path | `--allow-missing-projects` |
| Folder unreadable | 2 | `--allow-missing-projects` |
| Folder outside the workspace root | 2 | none |
| Folder entry is a symlink | 2 | none |
| Two entries resolving to one real path via symlink | 2 | none |
| One entry nested inside another | 2 | none |
| Empty `folders` list | 2 | none |
| Malformed workspace file | 2 | none |
| Incompatible scanner pins across projects | 2, naming both constraints | none |
| `--workspace` with `--source-dir` | 2 | none |
| `--workspace auto` with several candidates | 2, listing them | none |

Two more refusals worth calling out, both chosen so nothing happens silently:

- **`--workspace` without `--dry-run` exits 2.** Falling through to a single-directory scan would scan the workspace root as one tree, which is precisely the behaviour workspace mode exists to replace. Refusing beats silently doing the wrong scan.
- **`--dry-run` or `--allow-missing-projects` without `--workspace` exits 2.** Neither means anything outside workspace mode, and silently ignoring `--dry-run` would run a full scan for someone who asked for none.

Skipped projects are recorded in the plan payload with a reason, not just logged, because downstream consumers cannot see stderr.

## Project identity

The project key is the folder's path relative to the workspace root with separators replaced by `-`, so `services/api` becomes `services-api`. It is unique by construction, because overlapping and duplicate entries are already rejected. Using the folder basename would collide: `foo/api` and `bar/api` both reduce to `api`.

`AshConfig.project_name` is a display label only. It is never a path and never a uniqueness key, because two projects may legitimately carry the same `project_name`; where they do, reports disambiguate by appending the key.

## Incompatible scanner pins are refused, not reconciled

If two projects declare incompatible version constraints for the same scanner, the workspace is refused with both constraints named. The alternative — pick one and log a warning — means a project is scanned by a tool version it explicitly excluded, with rule behaviour that may differ across majors, and a log line as the only control. Per-project tool isolation is out of scope, so refusal is the honest behaviour until it exists.

## Verification

- Full unit suite on 3.13: 3690 passed, 22 skipped, 0 failures. 134 of those are new.
- Python 3.10: the new test files, 134 passed, 0 failures. Checked explicitly because `PureWindowsPath.drive` behaviour differs between 3.11 and 3.12, which broke #456's first CI run; this code decides separator handling from raw text rather than from pathlib parsing.
- ASH self-scan of the tree: 0 actionable findings across every scanner.
- `ruff check` and `ruff format --check` clean on all 12 changed files.
- `scripts/verify_docs_freshness.py` 7/7, with `docs/content/docs/cli-reference.md` updated for the new flags.
- The fail-closed table above exercised through the real CLI against a fixture with symlinks, an alias, nested folders, same-basename projects and a malformed file.

## Not in this PR

No execution, no aggregation, no reporter changes, no workspace-level config. `--workspace-config` is deliberately absent: the workspace-policy file and its distinct-from-project-config rule belong with the config work in a later PR.
