### PR TITLE
chore: run ruff-format over the files the open fix branches touch

### DIFF
--- a/automated_security_helper/base/plugin_base.py
+++ b/automated_security_helper/base/plugin_base.py
@@ -205,7 +205,9 @@ class PluginBase(UVToolMixin, BaseModel):
         # Use abs() so negative codes (e.g. -1 for timeout) aren't
         # silently swallowed by max(0, -1).
         new_code = response.get("returncode", 1)
-        self.exit_code = max(self.exit_code, abs(new_code) if new_code < 0 else new_code)
+        self.exit_code = max(
+            self.exit_code, abs(new_code) if new_code < 0 else new_code
+        )
 
     def _run_subprocess(
         self,

--- a/automated_security_helper/base/scanner_plugin.py
+++ b/automated_security_helper/base/scanner_plugin.py
@@ -10,13 +10,28 @@ from automated_security_helper.core.enums import OfflineStrategy, ScannerToolTyp
 from automated_security_helper.core.exceptions import ScannerError
 from automated_security_helper.models.core import IgnorePathWithReason, ToolArgs
 from automated_security_helper.schemas.cyclonedx_bom_1_6_schema import CycloneDXReport
-from automated_security_helper.schemas.sarif_schema_model import ArtifactLocation, Invocation, SarifReport
+from automated_security_helper.schemas.sarif_schema_model import (
+    ArtifactLocation,
+    Invocation,
+    SarifReport,
+)
 from automated_security_helper.utils.get_shortest_name import get_shortest_name
 from automated_security_helper.utils.log import ASH_LOGGER
 from automated_security_helper.utils.subprocess_utils import find_executable
 
 from pydantic import Field
-from typing import Annotated, Any, ClassVar, Generic, List, Literal, Optional, Set, Tuple, TypeVar
+from typing import (
+    Annotated,
+    Any,
+    ClassVar,
+    Generic,
+    List,
+    Literal,
+    Optional,
+    Set,
+    Tuple,
+    TypeVar,
+)
 from abc import abstractmethod
 
 # Pattern for valid CLI flag keys: one or two leading dashes followed by
@@ -323,9 +338,7 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             return
         working_dir = ArtifactLocation(uri=get_shortest_name(input=target))  # type: ignore[call-arg]
         extras = self._invocation_extras(sarif_report, final_args, target)
-        command_line = (
-            shlex.join(str(a) for a in final_args) if final_args else ""
-        )
+        command_line = shlex.join(str(a) for a in final_args) if final_args else ""
         sarif_report.runs[0].invocations = [
             Invocation(  # type: ignore[call-arg]
                 commandLine=command_line,

--- a/automated_security_helper/cli/config.py
+++ b/automated_security_helper/cli/config.py
@@ -20,7 +20,10 @@ from automated_security_helper.config.ash_config import (
     ReporterConfigSegment,
     ScannerConfigSegment,
 )
-from automated_security_helper.config.resolve_config import find_config_file, resolve_config
+from automated_security_helper.config.resolve_config import (
+    find_config_file,
+    resolve_config,
+)
 from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
 from automated_security_helper.core.exceptions import ASHConfigValidationError
 from automated_security_helper.utils.log import get_logger
@@ -683,8 +686,6 @@ def _apply_unused_fixes(
     )
 
 
-
-
 def _get_scanner_names() -> List[tuple]:
     """Return (python_name, display_name) tuples for built-in scanners.
 
@@ -848,8 +849,10 @@ def wizard(
         "  Offline mode skips tool installation. Set the ASH_OFFLINE "
         "environment variable at runtime to activate it."
     )
-    current_offline = (
-        os.environ.get("ASH_OFFLINE", "NO").upper() in ("YES", "TRUE", "1")
+    current_offline = os.environ.get("ASH_OFFLINE", "NO").upper() in (
+        "YES",
+        "TRUE",
+        "1",
     )
     enable_offline = typer.confirm(
         "  Set ASH_OFFLINE=YES in the generated config comments as a reminder?",
@@ -911,7 +914,9 @@ def wizard(
         "# yaml-language-server: $schema=https://raw.githubusercontent.com/awslabs/automated-security-helper/refs/heads/main/automated_security_helper/schemas/AshConfig.json",
     ]
     if enable_offline:
-        config_strings.append("# Reminder: export ASH_OFFLINE=YES before running ASH for offline mode")
+        config_strings.append(
+            "# Reminder: export ASH_OFFLINE=YES before running ASH for offline mode"
+        )
 
     config_strings.append(
         yaml.dump(
@@ -945,8 +950,6 @@ def wizard(
 
 if __name__ == "__main__":
     config_app()
-
-
 
 
 if __name__ == "__main__":

--- a/automated_security_helper/cli/mcp/__init__.py
+++ b/automated_security_helper/cli/mcp/__init__.py
@@ -124,7 +124,10 @@ def _build_auth_middleware(header_name: str, header_value: str):
                 received.encode("latin-1", errors="replace"), expected_value_bytes
             ):
                 return JSONResponse(
-                    {"error": "unauthorized", "detail": "missing or invalid auth header"},
+                    {
+                        "error": "unauthorized",
+                        "detail": "missing or invalid auth header",
+                    },
                     status_code=401,
                 )
             return await call_next(request)

--- a/automated_security_helper/cli/mcp_server.py
+++ b/automated_security_helper/cli/mcp_server.py
@@ -404,9 +404,7 @@ async def get_scan_summary(
     Args:
         output_dir: Path to the scan output directory (absolute path recommended)
     """
-    summary = await get_scan_results(
-        ctx, output_dir=output_dir, filter_level="summary"
-    )
+    summary = await get_scan_results(ctx, output_dir=output_dir, filter_level="summary")
     # Tag the response with the entry point that produced it. get_scan_results
     # serves several filter levels, so callers use this to tell a summary obtained
     # via get_scan_summary from one obtained by calling get_scan_results directly.
@@ -667,7 +665,13 @@ def list_scanners() -> list:
         return mcp_list_scanners()
     except Exception as e:
         logger.exception(f"Error in list_scanners: {str(e)}")
-        return [{"success": False, "error": f"Error listing scanners: {str(e)}", "error_type": type(e).__name__}]
+        return [
+            {
+                "success": False,
+                "error": f"Error listing scanners: {str(e)}",
+                "error_type": type(e).__name__,
+            }
+        ]
 
 
 @mcp.tool()
@@ -710,7 +714,9 @@ def validate_config(
         Dict with valid (bool) and errors (list of {field, message, type}).
     """
     try:
-        return mcp_validate_config(config_content=config_content, config_path=config_path)
+        return mcp_validate_config(
+            config_content=config_content, config_path=config_path
+        )
     except Exception as e:
         logger.exception(f"Error in validate_config: {str(e)}")
         return {
@@ -741,6 +747,7 @@ def _read_ash_suppression_schema() -> str:
     """Return the AshSuppression JSON schema as a string."""
     from automated_security_helper.models.core import AshSuppression
     import json as _json
+
     return _json.dumps(AshSuppression.model_json_schema(), indent=2)
 
 

--- a/automated_security_helper/config/ash_config.py
+++ b/automated_security_helper/config/ash_config.py
@@ -442,9 +442,7 @@ class RuntimeOverridesConfig(BaseModel):
 
     enabled: Annotated[
         bool,
-        Field(
-            description="Master switch — runtime patches are rejected unless True."
-        ),
+        Field(description="Master switch — runtime patches are rejected unless True."),
     ] = False
 
     allowed_paths: Annotated[
@@ -741,9 +739,7 @@ class AshConfig(BaseModel):
         return found
 
 
-def add_suppression_to_config(
-    config_path: Path, suppression: AshSuppression
-) -> None:
+def add_suppression_to_config(config_path: Path, suppression: AshSuppression) -> None:
     """Append a suppression to the suppressions list in an .ash.yaml config file.
 
     Uses an append-only strategy when the file already contains a suppressions
@@ -764,9 +760,7 @@ def add_suppression_to_config(
         # Duplicate detection: check if rule_id+path already suppressed
         data = yaml.safe_load(text) or {}
         if isinstance(data, dict):
-            existing = (
-                data.get("global_settings", {}).get("suppressions", []) or []
-            )
+            existing = data.get("global_settings", {}).get("suppressions", []) or []
             for existing_entry in existing:
                 if (
                     isinstance(existing_entry, dict)
@@ -782,7 +776,9 @@ def add_suppression_to_config(
             field_indent = list_indent + "  "
             items = list(entry.items())
             first_key, first_val = items[0]
-            formatted_lines = [f"{list_indent}- {first_key}: {_yaml_scalar(first_val)}\n"]
+            formatted_lines = [
+                f"{list_indent}- {first_key}: {_yaml_scalar(first_val)}\n"
+            ]
             for k, v in items[1:]:
                 formatted_lines.append(f"{field_indent}{k}: {_yaml_scalar(v)}\n")
             for line in reversed(formatted_lines):
@@ -862,7 +858,11 @@ def _find_suppressions_append_point(lines: list) -> tuple:
                 list_indent = line[:indent_len]
                 last_item_end = idx + 1
                 continue
-            if indent_len > 0 and not stripped.startswith("- ") and not stripped.startswith("#"):
+            if (
+                indent_len > 0
+                and not stripped.startswith("- ")
+                and not stripped.startswith("#")
+            ):
                 last_item_end = idx + 1
                 continue
             if stripped == "" or stripped.startswith("#"):

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_pipeline.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_pipeline.py
@@ -139,9 +139,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         return (
             f"Generate an executive summary for a security scan with the following results:\n\n"
             f"SCAN OVERVIEW:\n"
@@ -152,9 +150,7 @@ class BedrockPromptBuilder:
             f"Provide a concise executive summary that highlights the most important aspects of the scan results.\n"
         )
 
-    def severity_analysis(
-        self, findings: List[Dict[str, Any]], severity: str
-    ) -> str:
+    def severity_analysis(self, findings: List[Dict[str, Any]], severity: str) -> str:
         if not findings:
             return f"No findings with {severity} level severity."
 
@@ -234,9 +230,7 @@ class BedrockPromptBuilder:
         remaining = [f for f in findings if f not in severe]
         severe.extend(remaining[: max(0, max_findings - len(severe))])
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         lines = [
             f"Based on the security scan with the following results:\n\n"
             f"FINDINGS BY SEVERITY:\n{counts_str}\n\n"
@@ -271,13 +265,17 @@ class BedrockPromptBuilder:
         if not findings:
             return "No findings to analyze."
 
-        lines = ["Generate a detailed technical analysis of the following security findings:\n"]
+        lines = [
+            "Generate a detailed technical analysis of the following security findings:\n"
+        ]
         for i, finding in enumerate(findings[:max_findings]):
             msg = self._extract_message(finding)
             rule_id = self._extract_rule_id(finding)
             level = finding.get("level", "none")
             locations = self._extract_locations(finding)
-            code_snippets = self._extract_code_snippets(finding) if include_code_snippets else []
+            code_snippets = (
+                self._extract_code_snippets(finding) if include_code_snippets else []
+            )
 
             lines.append(
                 f"\nFINDING {i + 1}:\n"
@@ -287,7 +285,9 @@ class BedrockPromptBuilder:
                 f"- Locations: {', '.join(locations) if locations else 'Unknown'}\n"
             )
             if code_snippets and include_code_snippets:
-                lines.append("- Code Snippet:\n```\n" + "\n".join(code_snippets[:3]) + "\n```\n")
+                lines.append(
+                    "- Code Snippet:\n```\n" + "\n".join(code_snippets[:3]) + "\n```\n"
+                )
 
         lines.append(
             "\nProvide a detailed technical analysis including:\n"
@@ -310,9 +310,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         lines = [
             f"Generate a risk assessment based on the following security scan results:\n\n"
             f"FINDINGS BY SEVERITY:\n{counts_str}\n\n"
@@ -354,9 +352,7 @@ class BedrockPromptBuilder:
         for f in findings:
             severity_counts[f.get("level", "none")] += 1
 
-        counts_str = ", ".join(
-            f"{sev}: {cnt}" for sev, cnt in severity_counts.items()
-        )
+        counts_str = ", ".join(f"{sev}: {cnt}" for sev, cnt in severity_counts.items())
         fw_str = ", ".join(compliance_frameworks)
         lines = [
             f"Generate a compliance impact analysis for the following security scan results:\n\n"
@@ -442,7 +438,9 @@ class BedrockPromptBuilder:
             if industry_context:
                 context_info += f"- Industry: {industry_context}\n"
             if compliance_frameworks:
-                context_info += f"- Compliance frameworks: {', '.join(compliance_frameworks)}\n"
+                context_info += (
+                    f"- Compliance frameworks: {', '.join(compliance_frameworks)}\n"
+                )
             if custom_context:
                 context_info += f"\n{custom_context}"
             user_message += context_info

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cfn_nag_scanner.py
@@ -98,7 +98,9 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — CfnNag overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -172,7 +174,6 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -284,9 +285,7 @@ class CfnNagScanner(ScannerPluginBase[CfnNagScannerConfig]):
                         )
                         failed_files.append((cfn_file, "empty stdout"))
                         continue
-                    file_sarif = SarifReport.model_validate_json(
-                        json_data=stdout
-                    )
+                    file_sarif = SarifReport.model_validate_json(json_data=stdout)
                     if sarif_report is None and file_sarif is not None:
                         sarif_report = file_sarif
                     elif file_sarif is not None:

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
@@ -1,4 +1,5 @@
 import logging
+
 """Module containing the detect-secrets security scanner implementation."""
 
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
@@ -137,9 +138,7 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
         # We additionally consult the consolidated UV-or-direct-binary
         # resolver for diagnostic logging only — its return value never gates
         # the result because the Python import is the authoritative signal.
-        cmd = get_uv_tool_command(
-            "detect-secrets", fallback_binary="detect-secrets"
-        )
+        cmd = get_uv_tool_command("detect-secrets", fallback_binary="detect-secrets")
         if cmd is not None:
             ASH_LOGGER.debug(
                 f"detect-secrets CLI also reachable via {cmd[0]}; "
@@ -304,7 +303,9 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — DetectSecrets overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -377,7 +378,6 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -469,7 +469,7 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                     for file_path in scannable
                     if not any(
                         path_matches_pattern(
-                            file_path[len(source_prefix):]
+                            file_path[len(source_prefix) :]
                             if file_path.startswith(source_prefix)
                             else file_path,
                             ignore_path.path,

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/npm_audit_scanner.py
@@ -263,9 +263,7 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 # created above.  Build a minimal result from vuln_info.
                 if not has_dict_via and via_items:
                     vuln_id = f"npm-audit-transitive-{pkg_name}"
-                    via_refs = ", ".join(
-                        v for v in via_items if isinstance(v, str)
-                    )
+                    via_refs = ", ".join(v for v in via_items if isinstance(v, str))
                     title = f"Transitive vulnerability in {pkg_name} (via {via_refs})"
                     description = title
 
@@ -334,7 +332,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target_path)
@@ -354,7 +354,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
 
     def _execute_scan(self, target, target_type, global_ignore_paths):  # type: ignore[override]
         """Abstract stub — NpmAudit overrides scan() directly; this is unreachable."""
-        raise NotImplementedError(f"{self.__class__.__name__} overrides scan() directly.")
+        raise NotImplementedError(
+            f"{self.__class__.__name__} overrides scan() directly."
+        )
 
     def scan(
         self,
@@ -394,7 +396,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                     invocations=[
                         Invocation(
                             commandLine="npm audit --json",
-                            executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                            executionSuccessful=(
+                                self.exit_code == 0 or self.exit_code == 1
+                            ),
                             exitCode=self.exit_code,
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=target)
@@ -432,7 +436,6 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(
@@ -634,7 +637,9 @@ class NpmAuditScanner(ScannerPluginBase[NpmAuditScannerConfig]):
                             invocations=[
                                 Invocation(
                                     commandLine="npm audit --json",
-                                    executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                                    executionSuccessful=(
+                                        self.exit_code == 0 or self.exit_code == 1
+                                    ),
                                     exitCode=self.exit_code,
                                     workingDirectory=ArtifactLocation(
                                         uri=get_shortest_name(input=target)

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/syft_scanner.py
@@ -99,9 +99,7 @@ class SyftScanner(ScannerPluginBase[SyftScannerConfig]):
                     "SYFT_LOG_QUIET": "true",
                 }
             )
-            ASH_LOGGER.info(
-                "Running Syft in offline mode - update checks disabled"
-            )
+            ASH_LOGGER.info("Running Syft in offline mode - update checks disabled")
 
         super().model_post_init(context)
 
@@ -215,7 +213,6 @@ class SyftScanner(ScannerPluginBase[SyftScannerConfig]):
                 target_type=target_type,
             )
             return False
-
 
         if not self.dependencies_satisfied:
             self._post_scan(

--- a/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_ferret_plugins/ferret_scanner.py
@@ -832,7 +832,6 @@ class FerretScanScanner(ScannerPluginBase[FerretScannerConfig]):
             self._post_scan(target=target, target_type=target_type)
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(target=target, target_type=target_type)
             return False

--- a/automated_security_helper/plugin_modules/ash_snyk_plugins/snyk_code_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_snyk_plugins/snyk_code_scanner.py
@@ -211,7 +211,6 @@ class SnykCodeScanner(ScannerPluginBase[SnykCodeScannerConfig]):
             )
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(
                 target=target,

--- a/automated_security_helper/plugin_modules/ash_trivy_plugins/trivy_repo_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_trivy_plugins/trivy_repo_scanner.py
@@ -248,7 +248,6 @@ class TrivyRepoScanner(ScannerPluginBase[TrivyRepoScannerConfig]):
             )
             return False
 
-
         if not self.dependencies_satisfied:
             self._post_scan(
                 target=target,
@@ -316,7 +315,9 @@ class TrivyRepoScanner(ScannerPluginBase[TrivyRepoScannerConfig]):
                                 arguments=final_args[1:],
                                 startTimeUtc=self.start_time,
                                 endTimeUtc=self.end_time,
-                                executionSuccessful=(self.exit_code == 0 or self.exit_code == 1),
+                                executionSuccessful=(
+                                    self.exit_code == 0 or self.exit_code == 1
+                                ),
                                 exitCode=self.exit_code,
                                 exitCodeDescription="\n".join(self.errors),
                                 workingDirectory=ArtifactLocation(

--- a/automated_security_helper/utils/sarif_utils.py
+++ b/automated_security_helper/utils/sarif_utils.py
@@ -40,9 +40,7 @@ def get_finding_id(
     end_line: int | None = None,
 ) -> str:
     seed = "::".join(
-        str(item)
-        for item in [rule_id, file, start_line, end_line]
-        if item is not None
+        str(item) for item in [rule_id, file, start_line, end_line] if item is not None
     )
     rd = random.Random()  # nosec B311 — seeded PRNG for deterministic finding IDs, not security
     rd.seed(seed)
@@ -244,10 +242,10 @@ def _resolve_result_severity(result) -> str:
     if result.properties:
         props = result.properties
         if isinstance(props, PropertyBag):
-            props = props.model_dump(
-                mode="json", exclude_unset=True, exclude_none=True
-            )
-        issue_sev = props.get("issue_severity", "").upper() if isinstance(props, dict) else ""
+            props = props.model_dump(mode="json", exclude_unset=True, exclude_none=True)
+        issue_sev = (
+            props.get("issue_severity", "").upper() if isinstance(props, dict) else ""
+        )
         if issue_sev in ("CRITICAL", "HIGH", "MEDIUM", "LOW", "INFO"):
             return issue_sev.lower()
 
@@ -331,11 +329,13 @@ def _normalize_sarif_uri(
     """
     uri_normalized = uri.replace("\\", "/")
     if uri_normalized.startswith(source_dir_prefix):
-        return uri_normalized[len(source_dir_prefix):]
+        return uri_normalized[len(source_dir_prefix) :]
     if uri_normalized.startswith(source_dir_prefix_with_slash):
-        return uri_normalized[len(source_dir_prefix_with_slash):]
-    if source_dir_prefix_no_drive and uri_normalized.startswith(source_dir_prefix_no_drive):
-        return uri_normalized[len(source_dir_prefix_no_drive):]
+        return uri_normalized[len(source_dir_prefix_with_slash) :]
+    if source_dir_prefix_no_drive and uri_normalized.startswith(
+        source_dir_prefix_no_drive
+    ):
+        return uri_normalized[len(source_dir_prefix_no_drive) :]
     # source_dir_basename is None when the source dir contains a child of the same
     # name (see #361): the basename is a real project dir, not a scanner artifact,
     # so stripping it would corrupt the path. relative_to(None) raises TypeError,
@@ -367,7 +367,9 @@ def _apply_config_suppression(
 
     Mutates result.suppressions on match. Returns True when a suppression was applied.
     """
-    should_suppress, matching_suppression = should_suppress_finding(flat_finding, suppressions)
+    should_suppress, matching_suppression = should_suppress_finding(
+        flat_finding, suppressions
+    )
     if not should_suppress:
         return False
 
@@ -382,7 +384,9 @@ def _apply_config_suppression(
         )
         return True
 
-    reason = (matching_suppression and matching_suppression.reason) or "No reason provided"
+    reason = (
+        matching_suppression and matching_suppression.reason
+    ) or "No reason provided"
     ASH_LOGGER.verbose(
         f"Suppressing rule '{result.ruleId}' on location '{flat_finding.file_path}' based on suppression rule: [yellow]{reason}[/yellow]"
     )
@@ -411,7 +415,10 @@ def _apply_inline_suppression(
     if file_key not in inline_cache:
         inline_cache[file_key] = find_inline_suppressions(file_path)
     for isup in inline_cache[file_key]:
-        if isup.rule_id.lower() == result.ruleId.lower() and isup.line_number == result_line:
+        if (
+            isup.rule_id.lower() == result.ruleId.lower()
+            and isup.line_number == result_line
+        ):
             if not result.suppressions:
                 result.suppressions = []
             ASH_LOGGER.verbose(
@@ -465,12 +472,16 @@ def apply_suppressions_to_sarif(
     _output_dir_resolved = plugin_context.output_dir.resolve()
     _work_dir_resolved = plugin_context.output_dir.joinpath(ASH_WORK_DIR_NAME).resolve()
     _uri_resolve_cache: dict[str, Path] = {}
-    _source_dir_prefix = str(plugin_context.source_dir.resolve()).replace("\\", "/") + "/"
+    _source_dir_prefix = (
+        str(plugin_context.source_dir.resolve()).replace("\\", "/") + "/"
+    )
     # On Windows, SARIF URIs may have a leading "/" before the drive letter (e.g., /D:/path)
     _source_dir_prefix_with_slash = "/" + _source_dir_prefix
     # Some Windows scanners strip the drive letter entirely (e.g., /a/repo/ instead of D:/a/repo/)
     _source_dir_prefix_no_drive = (
-        _source_dir_prefix[2:] if len(_source_dir_prefix) > 2 and _source_dir_prefix[1] == ":" else None
+        _source_dir_prefix[2:]
+        if len(_source_dir_prefix) > 2 and _source_dir_prefix[1] == ":"
+        else None
     )
     # Offline opengrep produces relative paths with source_dir basename prefix (e.g., "src/.github/...")
     # However, skip basename stripping when source_dir contains a subdirectory with the same name
@@ -517,9 +528,9 @@ def apply_suppressions_to_sarif(
                     if uri not in _uri_resolve_cache:
                         _uri_resolve_cache[uri] = Path(uri).resolve()
                     resolved_uri = _uri_resolve_cache[uri]
-                    if resolved_uri.is_relative_to(_output_dir_resolved) and not resolved_uri.is_relative_to(
-                        _work_dir_resolved
-                    ):
+                    if resolved_uri.is_relative_to(
+                        _output_dir_resolved
+                    ) and not resolved_uri.is_relative_to(_work_dir_resolved):
                         ASH_LOGGER.verbose(
                             f"Excluding result -- location is in output path and NOT in the work directory and should not have been included: '{uri}'"
                         )
@@ -549,13 +560,17 @@ def apply_suppressions_to_sarif(
                         and location.physicalLocation.root.artifactLocation
                     ):
                         raw_uri = location.physicalLocation.root.artifactLocation.uri
-                        uri = _normalize_sarif_uri(
-                            raw_uri or "",
-                            _source_dir_prefix,
-                            _source_dir_prefix_with_slash,
-                            _source_dir_prefix_no_drive,
-                            _source_dir_basename,
-                        ) if raw_uri else (raw_uri or "")
+                        uri = (
+                            _normalize_sarif_uri(
+                                raw_uri or "",
+                                _source_dir_prefix,
+                                _source_dir_prefix_with_slash,
+                                _source_dir_prefix_no_drive,
+                                _source_dir_basename,
+                            )
+                            if raw_uri
+                            else (raw_uri or "")
+                        )
                         line_start = None
                         line_end = None
                         if (
@@ -599,7 +614,9 @@ def apply_suppressions_to_sarif(
                         continue
 
             # --- Step 3: inline suppression ---
-            if not ignore_suppressions and not (result.suppressions and len(result.suppressions) >= 1):
+            if not ignore_suppressions and not (
+                result.suppressions and len(result.suppressions) >= 1
+            ):
                 if result.ruleId and result.locations:
                     for location in result.locations:
                         if not (
@@ -615,7 +632,9 @@ def apply_suppressions_to_sarif(
                             hasattr(location.physicalLocation.root, "region")
                             and location.physicalLocation.root.region
                         ):
-                            result_line = location.physicalLocation.root.region.startLine
+                            result_line = (
+                                location.physicalLocation.root.region.startLine
+                            )
                         if result_line is None:
                             continue
                         uri = _normalize_sarif_uri(
@@ -626,7 +645,11 @@ def apply_suppressions_to_sarif(
                             _source_dir_basename,
                         )
                         _apply_inline_suppression(
-                            result, uri, plugin_context.source_dir, result_line, _inline_suppression_cache
+                            result,
+                            uri,
+                            plugin_context.source_dir,
+                            result_line,
+                            _inline_suppression_cache,
                         )
 
             updated_results.append(result)

--- a/automated_security_helper/utils/subprocess_utils.py
+++ b/automated_security_helper/utils/subprocess_utils.py
@@ -400,7 +400,9 @@ def get_host_uid() -> int:
         return int(result.stdout.strip())
     except Exception as e:
         ASH_LOGGER.error(f"Error getting host UID: {e}")
-        ASH_LOGGER.warning("Falling back to default UID 1000 (command 'id -u' unavailable on this platform)")
+        ASH_LOGGER.warning(
+            "Falling back to default UID 1000 (command 'id -u' unavailable on this platform)"
+        )
         return 1000  # Default UID as fallback
 
 
@@ -415,7 +417,9 @@ def get_host_gid() -> int:
         return int(result.stdout.strip())
     except Exception as e:
         ASH_LOGGER.error(f"Error getting host GID: {e}")
-        ASH_LOGGER.warning("Falling back to default GID 1000 (command 'id -g' unavailable on this platform)")
+        ASH_LOGGER.warning(
+            "Falling back to default GID 1000 (command 'id -g' unavailable on this platform)"
+        )
         return 1000  # Default GID as fallback
 
 

--- a/automated_security_helper/utils/suppression_matcher.py
+++ b/automated_security_helper/utils/suppression_matcher.py
@@ -22,15 +22,11 @@ from automated_security_helper.utils.log import ASH_LOGGER
 # Supported formats (slash-style for JS/TS/Java/C#/Go):
 #   // ash-ignore: RULE-ID [reason]
 #   // ash-ignore-next-line: RULE-ID [reason]
-_HASH_INLINE_PATTERN = re.compile(
-    r"#\s*ash-ignore:\s*(\S+)\s*(.*)?$", re.IGNORECASE
-)
+_HASH_INLINE_PATTERN = re.compile(r"#\s*ash-ignore:\s*(\S+)\s*(.*)?$", re.IGNORECASE)
 _HASH_NEXT_LINE_PATTERN = re.compile(
     r"#\s*ash-ignore-next-line:\s*(\S+)\s*(.*)?$", re.IGNORECASE
 )
-_SLASH_INLINE_PATTERN = re.compile(
-    r"//\s*ash-ignore:\s*(\S+)\s*(.*)?$", re.IGNORECASE
-)
+_SLASH_INLINE_PATTERN = re.compile(r"//\s*ash-ignore:\s*(\S+)\s*(.*)?$", re.IGNORECASE)
 _SLASH_NEXT_LINE_PATTERN = re.compile(
     r"//\s*ash-ignore-next-line:\s*(\S+)\s*(.*)?$", re.IGNORECASE
 )

--- a/tests/unit/config/test_resolve_config.py
+++ b/tests/unit/config/test_resolve_config.py
@@ -120,19 +120,22 @@ class TestApplyConfigOverrides:
 
     def test_validation_error_returns_original(self):
         from pydantic import ValidationError
+
         config = AshConfig(project_name="test")
         # Apply an override that makes the model invalid
         with patch(
             "automated_security_helper.config.resolve_config.AshConfig.model_validate",
             side_effect=ValidationError.from_exception_data(
                 title="AshConfig",
-                line_errors=[{
-                    "type": "value_error",
-                    "loc": ("project_name",),
-                    "msg": "invalid",
-                    "input": "bad",
-                    "ctx": {"error": ValueError("test")},
-                }],
+                line_errors=[
+                    {
+                        "type": "value_error",
+                        "loc": ("project_name",),
+                        "msg": "invalid",
+                        "input": "bad",
+                        "ctx": {"error": ValueError("test")},
+                    }
+                ],
             ),
         ):
             result = apply_config_overrides(config, ["project_name=new"])

--- a/tests/unit/plugin_modules/scanners/test_grep_scanner_base.py
+++ b/tests/unit/plugin_modules/scanners/test_grep_scanner_base.py
@@ -126,9 +126,7 @@ class TestOfflineCacheDiscovery:
         rule_file.write_text("rules: []")
         monkeypatch.setenv("SEMGREP_RULES_CACHE_DIR", str(tmp_path))
 
-        config = SemgrepScannerConfig(
-            options=SemgrepScannerConfigOptions(offline=True)
-        )
+        config = SemgrepScannerConfig(options=SemgrepScannerConfigOptions(offline=True))
         scanner = SemgrepScanner(context=test_plugin_context, config=config)
 
         pairs = _extra_arg_pairs(scanner)


### PR DESCRIPTION
Formatting only. **No behaviour change** — the full unit suite is byte-identical to `main`: 87 failed / 2881 passed on both. (Those 87 are an older `mcp` SDK in my local venv and reproduce unchanged on `main`.)

## Why land this separately, and first

`ruff format` rewrites a whole file, not just the lines you edited. Several files in this repo were already failing `ruff format --check` on `main`, so **nine of the thirteen open fix PRs carry incidental reflow hunks unrelated to their fix** — in one case a 60-line reflow around a 4-line change.

Because those PRs all branch from the same base, the reflows conflict *with each other* on merge, and every conflict has to be hand-inspected to confirm it really is only formatting. Landing the reformat once removes that whole class of conflict and leaves each remaining diff purely behavioural, which also makes them meaningfully smaller to review.

The plan is: merge this, then rebase the thirteen onto it.

## Scope

The 19 files that are both (a) touched by at least one open fix branch and (b) already unformatted on `main`. The other 9 touched files were already clean.

Deliberately **not** a repo-wide reformat — that would churn files no open branch touches, for no conflict benefit, and be much harder to review.

Pre-existing ruff **check** findings are untouched; this runs only the formatter.

## Verification

- `ruff format --check` on all 28 touched files: clean.
- Full unit suite before and after: identical counts. Formatting cannot change behaviour, but worth showing rather than asserting.