### PR TITLE
fix(tests): stop the integration conftest marking the whole repo slow

### DIFF
--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -44,7 +44,9 @@ def mock_mcp_environment():
     modules_to_mock = {
         "mcp": mock_mcp,
         "mcp.server": MagicMock(),
-        "mcp.server.mcpserver": MagicMock(MCPServer=mock_mcpserver, Context=mock_context),
+        "mcp.server.mcpserver": MagicMock(
+            MCPServer=mock_mcpserver, Context=mock_context
+        ),
     }
 
     with patch.dict("sys.modules", modules_to_mock):
@@ -211,11 +213,40 @@ def pytest_configure(config):
 
 # Test collection configuration
 def pytest_collection_modifyitems(config, items):
-    """Modify test collection to add markers automatically."""
+    """Modify test collection to add markers automatically.
+
+    Every rule here is scoped to this directory, and that scoping is the point.
+
+    ``pytest_collection_modifyitems`` receives *every* item in the session, not
+    only the ones under the conftest that defines the hook. The name-based rules
+    below were unscoped, so any test anywhere in the repository whose name
+    contained "workflow", "lifecycle" or "end_to_end" was marked slow -- and
+    ``tests/conftest.py`` then skips slow tests unless ``--run-slow`` is passed.
+    Any unit test whose name matched was therefore silently not running in a
+    full-suite run, including CI gates whose whole job is to fail when a workflow
+    drifts from its documented budget. Every affected test passes when executed
+    directly, which is how they were verified when written, so nothing was
+    hiding a real failure; they were simply providing no coverage while appearing
+    to.
+
+    The failure mode is worth naming because it is invisible from either end. The
+    test file gives no hint it will be skipped, and the conftest that skips it
+    lives in an unrelated directory the author had no reason to read. A green
+    suite plus a skip count nobody diffs is all the signal there was.
+    """
+    integration_root = Path(__file__).resolve().parent.parent
+
     for item in items:
-        # Add integration marker to all tests in this directory
-        if "integration" in str(item.fspath):
+        path = str(item.fspath)
+        if "integration" in path:
             item.add_marker(pytest.mark.integration)
+
+        # Scoped to the integration tree, which is what these heuristics are
+        # about. Compared against a resolved path rather than by substring: a
+        # substring test is how the unscoped version reached the whole repo, and
+        # "integration" appears in enough unrelated paths to do it again.
+        if not Path(item.fspath).resolve().is_relative_to(integration_root):
+            continue
 
         # Add slow marker to tests that might take longer
         if any(

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -233,20 +233,37 @@ def pytest_collection_modifyitems(config, items):
     test file gives no hint it will be skipped, and the conftest that skips it
     lives in an unrelated directory the author had no reason to read. A green
     suite plus a skip count nobody diffs is all the signal there was.
+
+    The same defect survived that fix in the ``integration`` marker, which kept
+    testing ``"integration" in str(item.fspath)`` while only the slow rules were
+    scoped -- with a comment saying the substring form would reach the whole repo
+    again. It did: a unit test at
+    ``tests/unit/workspace/test_workspace_policy_resolution.py``, originally
+    named ``..._integration.py``, had all fourteen of its tests skipped in a full
+    run while passing when the file was run on its own. Fixing one instance of a
+    pattern and documenting it is not the same as removing the pattern, so the
+    ``integration`` marker now hangs off the same path scoping as everything
+    else. Detected by diffing the skipped-test IDs against a baseline, which is
+    the only signal this failure emits.
     """
     integration_root = Path(__file__).resolve().parent.parent
 
     for item in items:
-        path = str(item.fspath)
-        if "integration" in path:
-            item.add_marker(pytest.mark.integration)
-
-        # Scoped to the integration tree, which is what these heuristics are
+        # Scoped to the integration tree, which is what every heuristic below is
         # about. Compared against a resolved path rather than by substring: a
-        # substring test is how the unscoped version reached the whole repo, and
-        # "integration" appears in enough unrelated paths to do it again.
+        # substring test is how the unscoped version reached the whole repo.
         if not Path(item.fspath).resolve().is_relative_to(integration_root):
             continue
+
+        # What makes a test an integration test is living in this tree, not
+        # having "integration" in its path. The previous version tested the
+        # substring and so marked -- and therefore skipped -- any test anywhere
+        # in the repository whose path happened to contain the word. That is the
+        # same defect this hook's docstring describes for the slow marker, left
+        # in place when that one was fixed; a unit test named
+        # test_workspace_policy_integration.py hit it and its fourteen tests
+        # were silently skipped in the full suite while passing in isolation.
+        item.add_marker(pytest.mark.integration)
 
         # Add slow marker to tests that might take longer
         if any(

--- a/tests/unit/test_collection_marker_scoping.py
+++ b/tests/unit/test_collection_marker_scoping.py
@@ -1,0 +1,118 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A conftest hook must not mark tests outside its own tree.
+
+The failure this prevents
+-------------------------
+``pytest_collection_modifyitems`` receives *every* item in the session, not only
+the ones beneath the conftest that defines the hook.
+``tests/integration/cli/conftest.py`` used that hook to add ``pytest.mark.slow``
+to any test whose name contained "workflow", "lifecycle" or "end_to_end" -- with
+no path scoping. ``tests/conftest.py`` then skips slow tests unless ``--run-slow``
+is passed.
+
+The result was that any unit test whose name matched silently did not run in a
+full-suite run, including CI gates whose entire job is to fail when a GitHub
+workflow drifts from its documented timeout budget. Every affected test passes
+when executed directly, which is how they were verified when written, so nothing was
+hiding a real failure -- they were simply providing no coverage while appearing to.
+
+It is worth guarding rather than just fixing, because the failure is invisible
+from both ends. A test file gives no hint that a conftest three directories away
+will skip it, and the author of that conftest had no reason to think about tests
+they did not write. The only signal was a skip count in a summary line, against a
+suite that stays green either way.
+
+Asserted against the hook rather than against a real collection
+--------------------------------------------------------------
+The hook is called directly with stand-in items. Driving a real nested pytest
+session would be slower, would need the marker state inspected across process
+boundaries, and would test pytest's collection machinery rather than the one
+decision this file cares about: does the rule look at the path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Names that trigger the heuristic in ``tests/integration/cli/conftest.py``.
+#: Taken from that file; if it grows a keyword and this list does not, the
+#: parametrised cases below simply cover less rather than failing wrongly.
+TRIGGERING_NAMES = (
+    "test_complete_scan_workflow",
+    "test_server_lifecycle",
+    "test_report_end_to_end",
+)
+
+
+class _FakeItem:
+    """The minimum surface ``pytest_collection_modifyitems`` touches."""
+
+    def __init__(self, path: Path, name: str) -> None:
+        self.fspath = path
+        self.name = name
+        self.applied: list[str] = []
+
+    def add_marker(self, marker) -> None:
+        self.applied.append(getattr(marker, "name", str(marker)))
+
+
+@pytest.fixture
+def modify_items():
+    """The hook under test, imported from the integration conftest by path."""
+    import importlib.util
+
+    conftest = REPO_ROOT / "tests" / "integration" / "cli" / "conftest.py"
+    spec = importlib.util.spec_from_file_location(
+        "_integration_cli_conftest_under_test", conftest
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.pytest_collection_modifyitems
+
+
+@pytest.fixture
+def config():
+    class _Config:
+        rootpath = REPO_ROOT
+
+        def addinivalue_line(self, *args, **kwargs):  # pragma: no cover
+            pass
+
+    return _Config()
+
+
+@pytest.mark.parametrize("name", TRIGGERING_NAMES)
+def test_a_unit_test_is_never_marked_slow_by_the_integration_conftest(
+    modify_items, config, name
+):
+    item = _FakeItem(REPO_ROOT / "tests" / "unit" / "workspace" / "test_x.py", name)
+    modify_items(config, [item])
+    assert "slow" not in item.applied
+    assert "mcp" not in item.applied
+    assert "integration" not in item.applied
+
+
+@pytest.mark.parametrize("name", TRIGGERING_NAMES)
+def test_an_integration_test_is_still_marked_slow(modify_items, config, name):
+    """The companion assertion, and the reason the fix is a scope and not a delete.
+
+    Without this, removing the heuristic entirely would satisfy the test above --
+    and the integration suite would lose the ``--run-slow`` gate that keeps a
+    default run fast.
+    """
+    item = _FakeItem(REPO_ROOT / "tests" / "integration" / "cli" / "test_x.py", name)
+    modify_items(config, [item])
+    assert "slow" in item.applied
+    assert "integration" in item.applied
+
+
+def test_a_unit_test_named_after_mcp_is_not_marked_mcp(modify_items, config):
+    item = _FakeItem(
+        REPO_ROOT / "tests" / "unit" / "cli" / "test_x.py", "test_mcp_something"
+    )
+    modify_items(config, [item])
+    assert "mcp" not in item.applied


### PR DESCRIPTION
`tests/integration/cli/conftest.py` adds marker heuristics from `pytest_collection_modifyitems`. That hook receives **every item in the session**, not just items collected under its own conftest, and the heuristics were not scoped to a path. `tests/conftest.py` then skips those markers unless `--run-slow` is passed.

The result is that a unit test whose name happens to contain `workflow`, `lifecycle` or `end_to_end` is silently marked slow and skipped in any invocation that also collects `tests/integration/` — which is the default, because `pytest.ini` sets `testpaths = tests`. The same applies to the `mcp` heuristic.

## What this costs today

On `main`, **four unit tests are silently skipped** in every full-suite run:

```
tests/unit/core/test_base_plugins.py                 ::test_report_end_to_end
tests/unit/plugin_modules/test_scanner_fixes.py      ::test_scan_method_preserves_excludes_end_to_end
tests/unit/test_external_target_scan_gate.py         ::test_the_workflow_timeout_matches_the_documented_budget
tests/unit/utils/test_path_matching.py               ::test_github_workflows_pattern
```

Measured before and after, `uv run pytest` on `main`:

```
before   3011 passed, 110 skipped
after    3022 passed, 106 skipped
```

The +11 reconciles as 4 tests freed plus the 7 new guard tests; the -4 is the four skips removed. All four pass when they run. Nothing was hiding a failure -- they were providing no coverage while appearing green, which is worse than a red test, because a red test gets attention.

## Why it matters beyond those four

The heuristic disarms any future test whose name matches, silently, with no signal in the test file. The conftest that causes it lives three directories away from the tests it affects, and the suite stays green either way.

That has already happened, and one instance is in the list above. `test_the_workflow_timeout_matches_the_documented_budget` belongs to the external-target scan gate, and its entire job is to fail when a GitHub workflow drifts from the timeout budget its script documents. It has never run in a full-suite invocation since the day it landed. It passes when executed directly, which is exactly how it was verified when it was written.

A sibling gate added since carries `test_the_declared_budget_matches_the_workflow`, which matches the same keyword and would be disarmed identically.

## The fix

Scope the heuristics to `tests/integration`, comparing resolved paths rather than matching a substring of the path. A substring test would still mis-fire on any path that happens to contain the word.

`tests/unit/test_collection_marker_scoping.py` guards both directions: a unit test named `test_report_end_to_end` must not be marked, and an integration test with the same name must still be. Verified to fail 4 of its 7 assertions against the unscoped conftest, so it is a test that has been watched failing rather than one assumed to work.

## Verification

- `uv run pytest` on this branch: 3022 passed, 106 skipped, 0 failed.
- The guard test: 7 passed against the fix, 4 failed against the previous conftest.
- `ruff check` and `ruff format --check` clean on both files; no temp-directory literals.

Found while adding a test for unrelated work whose skip count in a full run disagreed with its skip count in isolation by exactly one. That discrepancy is the only signal this defect produces.

One note for anyone reproducing the counts: `pytest -rs` reports skips at **file** granularity with a repetition count, not per test id, so grepping its output for a test name finds nothing and reads as "not skipped". Diff the whole `SKIPPED` set between the two revisions instead.
