### PR TITLE
fix(reporters): make yaml and spdx output loadable by a safe parser

### DIFF
--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
@@ -42,4 +42,9 @@ class SpdxReporter(ReporterPluginBase[SPDXReporterConfig]):
             "not yet implemented. The returned YAML is a raw model dump, not a valid "
             "SPDX document."
         )
-        return yaml.dump(model.model_dump(by_alias=True), indent=2)
+        # mode="json" for the same reason as yaml_reporter: without it the enums
+        # in the model become !!python/object/apply: tags that yaml.safe_load
+        # refuses. Fixed here as well rather than only there, because it is the
+        # identical line and leaving one of the two emitting unloadable YAML is
+        # harder to explain than fixing both.
+        return yaml.dump(model.model_dump(by_alias=True, mode="json"), indent=2)

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
@@ -35,6 +35,24 @@ class YamlReporter(ReporterPluginBase[YAMLReporterConfig]):
         return super().model_post_init(context)
 
     def report(self, model: "AshAggregatedResults") -> str:
-        """Format ASH model as YAML string."""
+        """Format ASH model as YAML string.
 
-        return yaml.dump(model.model_dump(by_alias=True), indent=2)
+        ``mode="json"`` is what makes the output loadable at all, and its absence
+        was a live defect rather than a workspace-mode concern.
+
+        Without it ``model_dump`` leaves enum *objects* in the tree, and
+        ``yaml.dump`` serialises those as ``!!python/object/apply:`` tags. Any
+        real scan has at least one -- every ``scanner_results`` entry carries a
+        ``ScannerStatus`` -- so ``ash.yaml`` could not be read by
+        ``yaml.safe_load`` and could only be parsed by a loader that will
+        construct arbitrary Python objects from the file. Workspace mode is how
+        this surfaced (it adds ``ProjectRunStatus`` and ``SkippedProjectReason``),
+        but the fix applies to every scan, and it is what makes the workspace
+        attribution this reporter carries actually reachable by a consumer.
+
+        Existing consumers are unaffected in the direction that matters: a status
+        that was an unloadable tag becomes the plain string ``"FAILED"``, which a
+        loader using ``yaml.load`` parses just as happily.
+        """
+
+        return yaml.dump(model.model_dump(by_alias=True, mode="json"), indent=2)

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_spdx_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_spdx_reporter.py
@@ -58,11 +58,23 @@ class TestSpdxReporter:
             mock_logger.warning.assert_called_once()
             assert "stub" in mock_logger.warning.call_args[0][0]
 
-    def test_report_uses_by_alias(self, spdx_reporter):
-        """report() calls model_dump with by_alias=True."""
+    def test_report_uses_by_alias_and_json_mode(self, spdx_reporter):
+        """report() calls model_dump with by_alias=True and mode="json".
+
+        ``mode="json"`` was added because without it ``model_dump`` leaves enum
+        objects in the tree and ``yaml.dump`` serialises those as
+        ``!!python/object/apply:`` tags -- output ``yaml.safe_load`` refuses
+        outright, and which any other loader parses by constructing arbitrary
+        Python objects. Every real scan has at least one such enum, in
+        ``scanner_results``.
+
+        Pinned as an exact call rather than by inspecting the output because that
+        is what this test has always done, and because the two kwargs are the only
+        thing that makes the document loadable at all.
+        """
         model = MagicMock()
         model.model_dump.return_value = {"key": "value"}
 
         spdx_reporter.report(model)
 
-        model.model_dump.assert_called_once_with(by_alias=True)
+        model.model_dump.assert_called_once_with(by_alias=True, mode="json")

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_yaml_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_yaml_reporter.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ash.yaml`` has to be loadable by a parser that will not execute the file.
+
+Why a behavioural test and not a call assertion
+-----------------------------------------------
+The fix is one kwarg -- ``model_dump(by_alias=True, mode="json")`` -- and the
+obvious guard is to assert that kwarg was passed. ``test_spdx_reporter.py`` has
+such an assertion and it is worth keeping there for other reasons, but on its own
+it is the wrong shape of guard for *this* defect: it passes whenever the kwargs
+are present, including if the output becomes unloadable again by some other route.
+Which is how the defect arrived in the first place -- nobody was checking the
+output, only the code.
+
+So these tests load the output. ``yaml.safe_load`` succeeding is the property an
+operator actually depends on.
+
+What the defect was
+-------------------
+``yaml.dump(model.model_dump(by_alias=True))`` -- Python mode, not JSON mode --
+leaves rich objects in the tree, and ``yaml.dump`` serialises those as
+``!!python/object`` tags. ``yaml.safe_load`` refuses them outright with
+``ConstructorError``; the only loaders that accept them are the ones that will
+construct arbitrary Python objects out of the file. Requiring that of anyone
+consuming a *security tool's* output is the part that makes this more than a
+formatting bug.
+
+It is not limited to scans that found something. A **default**
+``AshAggregatedResults`` with no findings at all emits four such tags, from the
+``AnyUrl`` values in the SARIF tool metadata's ``informationUri`` and
+``downloadUri``. So it was every document ASH has ever written, empty ones
+included. Enum fields such as ``ScannerStatus`` add more tags on any real scan,
+but they are the second source, not the first.
+
+Both sources are asserted below, and separately, because they come from different
+pydantic types and a partial fix would leave one of them behind.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.models.asharp_model import (
+    AshAggregatedResults,
+    ScannerStatusInfo,
+)
+from automated_security_helper.plugin_modules.ash_builtin.reporters.yaml_reporter import (
+    YamlReporter,
+)
+
+#: Any tag that makes a document constructible only by an unsafe loader. Matched
+#: as a prefix because pydantic emits at least two spellings --
+#: ``!!python/object:pydantic.networks.AnyUrl`` and
+#: ``!!python/object/new:pydantic_core._pydantic_core.Url`` -- and a fix that
+#: eliminated one but not the other must still fail.
+UNSAFE_TAG = re.compile(r"!!python/object\S*")
+
+
+@pytest.fixture
+def context(tmp_path) -> PluginContext:
+    return PluginContext(
+        source_dir=tmp_path,
+        output_dir=tmp_path / "out",
+        config=AshConfig(),
+    )
+
+
+def _report(model: AshAggregatedResults, context: PluginContext) -> str:
+    return YamlReporter(context=context).report(model)
+
+
+class TestTheOutputIsSafeLoadable:
+    def test_an_empty_scan_produces_a_safe_loadable_document(self, context):
+        """The broadest case, and the one that makes this every document.
+
+        A default model has no findings and no scanner results, and still emitted
+        four ``!!python/object`` tags before the fix -- from the ``AnyUrl`` values
+        in the SARIF tool metadata. So "every real scan" understated it: an empty
+        scan was affected too.
+        """
+        result = _report(AshAggregatedResults(), context)
+
+        loaded = yaml.safe_load(result)
+        assert isinstance(loaded, dict)
+        assert not UNSAFE_TAG.search(result), UNSAFE_TAG.findall(result)
+
+    def test_a_scan_with_a_scanner_status_enum_is_safe_loadable(self, context):
+        """The second source of tags, asserted separately.
+
+        ``ScannerStatus`` is an enum, and it reaches the dump through
+        ``scanner_results`` on every scan that ran a scanner. It comes from a
+        different pydantic type than the ``AnyUrl`` case above, so a partial fix
+        could close one and leave the other; asserting them separately is what
+        makes that visible.
+        """
+        model = AshAggregatedResults()
+        model.scanner_results = {
+            "bandit": ScannerStatusInfo(status=ScannerStatus.FAILED)
+        }
+        result = _report(model, context)
+
+        loaded = yaml.safe_load(result)
+        assert not UNSAFE_TAG.search(result), UNSAFE_TAG.findall(result)
+        # The load is not vacuous: the enum survived as a plain string, and the
+        # value is the one that was set. Without this, a fix that dropped
+        # scanner_results entirely would satisfy safe_load and this test.
+        assert loaded["scanner_results"]["bandit"]["status"] == "FAILED"
+
+    def test_the_document_still_carries_the_model_it_was_given(self, context):
+        """Guards against making the output loadable by making it empty.
+
+        ``yaml.safe_load("{}")`` succeeds, so "safe_load did not raise" is
+        satisfiable by a reporter that emits nothing useful. This pins that the
+        loaded document is the model.
+        """
+        model = AshAggregatedResults()
+        model.name = "fixture-scan"
+        loaded = yaml.safe_load(_report(model, context))
+
+        assert loaded["name"] == "fixture-scan"
+        assert "metadata" in loaded
+        assert "sarif" in loaded
+
+
+class TestTheUnsafeTagMatcherWorks:
+    """A negative control for the matcher itself.
+
+    Every assertion above is of the form "no unsafe tag was found". If the regex
+    were wrong, all of them would pass against output full of tags. So the matcher
+    is checked against a document known to contain them, produced the way the
+    pre-fix reporter produced it.
+    """
+
+    def test_the_matcher_finds_tags_in_a_python_mode_dump(self):
+        model = AshAggregatedResults()
+        model.scanner_results = {
+            "bandit": ScannerStatusInfo(status=ScannerStatus.FAILED)
+        }
+        # Exactly what yaml_reporter did before the fix: no mode="json".
+        pre_fix = yaml.dump(model.model_dump(by_alias=True), indent=2)
+
+        assert UNSAFE_TAG.search(pre_fix), (
+            "the pre-fix dump contains no !!python/object tag, so the matcher "
+            "above proves nothing"
+        )
+        with pytest.raises(yaml.constructor.ConstructorError):
+            yaml.safe_load(pre_fix)


### PR DESCRIPTION
`YamlReporter` and `SpdxReporter` both did `yaml.dump(model.model_dump(by_alias=True), indent=2)` — without `mode="json"`. So pydantic left rich objects in the tree and `yaml.dump` serialised them as `!!python/object` tags.

The result: **`ash.yaml` cannot be read by `yaml.safe_load` at all.** It can only be parsed by a loader that constructs arbitrary Python objects from the file, which is a poor thing to require of anyone consuming a security scanner's output.

## This affects every document, not just scans with findings

Measured on a default `AshAggregatedResults` with **no findings whatsoever**:

```
python-object tags in the dump: 4
yaml.safe_load(...)           : ConstructorError
```

There are two independent sources, from different pydantic types:

- `pydantic.networks.AnyUrl` in the SARIF tool metadata's `downloadUri` and `informationUri` — present in every document, including empty ones.
- Enum members in `scanner_results` — present in every document from a real scan.

So this is not an edge case reachable with unusual input. Every YAML and SPDX document ASH has ever written is affected.

## The fix

Add `mode="json"` to both `model_dump` calls, which is what pydantic provides for exactly this: coercing to JSON-compatible primitives before serialisation.

## Tests

`test_yaml_reporter.py` is new and asserts the behaviour rather than the call shape: `yaml.safe_load` succeeds on the reporter's real output, and the output contains no `!!python/object` tag.

Every assertion here is of the form "no tag was found", which is satisfiable by a broken matcher or by a reporter that emits nothing. Three guards against that:

- **The tag matcher has its own negative control**, checked against a document built the way the pre-fix reporter built it. A regex that matched nothing would otherwise let every other assertion pass against output full of tags. It matches both observed spellings — `!!python/object:pydantic.networks.AnyUrl` and `!!python/object/new:pydantic_core._pydantic_core.Url` — so a partial fix cannot pass.
- The enum test asserts the loaded value equals `"FAILED"`, so a "fix" that dropped `scanner_results` would not satisfy it.
- One test asserts the loaded document still carries the model it was given, because `yaml.safe_load("{}")` succeeds and "did not raise" is satisfiable by a reporter that emits nothing.

The existing `test_spdx_reporter.py` gains the same treatment alongside its call-shape assertion.

## Verification

- Full suite on this branch: 3015 passed, 110 skipped, 0 failed. `main` is 3011/110, so the delta is the 4 new tests.
- The new tests were **watched failing**: reverting `yaml_reporter` to the pre-fix dump on this branch fails 3 of the 4.
- `ruff check` and `ruff format --check` clean on all four files.

Found while adding a workspace-mode test that asserted per-project attribution in YAML output and could not load its own output to check it.
