### PR TITLE
fix(ci): make the schema freshness gate see a newly added schema

### DIFF
--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -55,8 +55,18 @@ jobs:
         run: python -m automated_security_helper.schemas.generate_schemas
       - name: Check schemas are up to date
         run: |
-          if ! git diff --exit-code automated_security_helper/schemas/*.json; then
+          # git diff compares the index to the worktree, so it cannot see a file
+          # git has never heard of. Generating a schema for a newly registered
+          # model produces an untracked .json, which a diff-based check reports
+          # as clean -- so the schema would silently never be committed.
+          # git status --porcelain reports untracked files too. The pathspec is
+          # quoted so git does the matching rather than the shell, which is what
+          # lets it match files that do not exist in the index yet.
+          changed="$(git status --porcelain -- 'automated_security_helper/schemas/*.json')"
+          if [ -n "$changed" ]; then
             echo "::error::JSON schemas are out of date. Run 'python -m automated_security_helper.schemas.generate_schemas' and commit the result."
+            echo "$changed"
+            git diff -- 'automated_security_helper/schemas/*.json'
             exit 1
           fi
       - name: Verify documentation freshness


### PR DESCRIPTION
The `lint` job regenerates the JSON schemas and then checks for drift:

```
git diff --exit-code automated_security_helper/schemas/*.json
```

`git diff` compares the index to the worktree, so it cannot see a file git has never heard of. Registering a new model in `generate_schemas.py` writes a new `.json` that stays untracked until someone adds it, and the diff reports clean. The schema silently never gets committed, and the gate whose whole purpose is to prevent that reports success.

Only two schemas are tracked today, `AshConfig.json` and `AshAggregatedResults.json`, so the untracked case has never arisen. It arises the first time a third model is registered.

## The fix

Detect with `git status --porcelain`, which reports untracked files, and keep `git diff` for the display so the log still shows what changed. The pathspec is quoted so git does the matching rather than the shell -- that is what lets it match a path with no index entry.

## Verification

The step's script was extracted with `yaml.safe_load` and run exactly as the YAML parser yields it, against a scratch repository, over five cases. The two clean cases are controls: without them, a gate that simply always failed would look like a fix.

| case | before | after |
| --- | --- | --- |
| nothing changed | exit 0 | exit 0 |
| tracked schema drifts | exit 1 | exit 1 |
| **new schema generated, not added** | **exit 0** | **exit 1** |
| gitignored `__pycache__` churn | exit 0 | exit 0 |
| unrelated `.py` edit in `schemas/` | exit 0 | exit 0 |

The last two matter because the check is scoped to `*.json` rather than the directory. Widening it to the directory would have made the gate fail on `__pycache__` churn and on any edit to `generate_schemas.py` itself.

## Scope

Shell inside one existing `run:` block. No new step, no new job, no change to what is generated or to any schema file. Nothing here reads workflow inputs or event payloads.
