### PR TITLE
feat(workspace): workspace-level policy file with a severity ceiling and per-project push-down

### DIFF
--- a/automated_security_helper/cli/scan.py
+++ b/automated_security_helper/cli/scan.py
@@ -54,6 +54,7 @@ def _handle_workspace_mode(
     source_dir: str | None,
     allow_missing_projects: bool,
     dry_run: bool,
+    workspace_config: str | None = None,
 ) -> "WorkspacePlan":
     """Resolve a workspace and return the plan, or exit.
 
@@ -88,7 +89,11 @@ def _handle_workspace_mode(
             else Path(workspace)
         )
         plan = resolve_workspace(
-            workspace_file, allow_missing_projects=allow_missing_projects
+            workspace_file,
+            allow_missing_projects=allow_missing_projects,
+            workspace_config=(
+                Path(workspace_config) if workspace_config is not None else None
+            ),
         )
     except WorkspaceDefinitionError as exc:
         _fail_workspace(str(exc))
@@ -315,6 +320,14 @@ def run_ash_scan_cli_command(
             envvar="ASH_WORKSPACE",
         ),
     ] = None,
+    workspace_config: Annotated[
+        str | None,
+        typer.Option(
+            "--workspace-config",
+            help="Path to the workspace policy file (severity ceiling, workspace-wide suppressions and ignore paths, additional scanners). Without this, ASH looks for 'ash-workspace.{yaml,yml,json}' in the workspace root or its '.ash' directory; finding none is not an error. Must not be any project's own ASH config: workspace policy governs every project, so reading one project's config as policy would apply its settings to its siblings.",
+            envvar="ASH_WORKSPACE_CONFIG",
+        ),
+    ] = None,
     allow_missing_projects: Annotated[
         bool,
         typer.Option(
@@ -421,14 +434,19 @@ def run_ash_scan_cli_command(
     # Workspace mode is handled before any cwd-based default is applied, because
     # --workspace and --source-dir are mutually exclusive and defaulting
     # source_dir first would make every invocation look like it had both.
-    if workspace is None and (dry_run or allow_missing_projects):
-        # Neither flag means anything outside workspace mode. Silently ignoring
-        # --dry-run would run a full scan for someone who asked for none.
+    if workspace is None and (
+        dry_run or allow_missing_projects or workspace_config is not None
+    ):
+        # None of these flags mean anything outside workspace mode. Silently
+        # ignoring --dry-run would run a full scan for someone who asked for
+        # none; silently ignoring --workspace-config would scan with no policy
+        # for someone who believes a severity ceiling is in force.
         offending = [
             flag
             for flag, given in (
                 ("--dry-run", dry_run),
                 ("--allow-missing-projects", allow_missing_projects),
+                ("--workspace-config", workspace_config is not None),
             )
             if given
         ]
@@ -444,6 +462,7 @@ def run_ash_scan_cli_command(
             source_dir=source_dir,
             allow_missing_projects=allow_missing_projects,
             dry_run=dry_run,
+            workspace_config=workspace_config,
         )
         # The workspace root is the scan root: it is what container mode mounts at
         # /src, and what every workspace-relative finding path is relative to.

--- a/automated_security_helper/config/ash_workspace_config.py
+++ b/automated_security_helper/config/ash_workspace_config.py
@@ -1,0 +1,211 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The schema of the workspace-level policy file.
+
+Why this module exists
+----------------------
+Workspace mode scans N projects as N independently scoped executions, each
+judged against its own config. That leaves no place for a statement an operator
+needs to make about the workspace as a whole -- "no project here may be laxer
+than MEDIUM", "this vendored directory is not ours in any project". Putting such
+a statement in a project's config would make one project's file govern its
+siblings; putting it in the ``.code-workspace`` file would put ASH policy in a
+file owned by an editor, whose schema ASH does not control (see
+``workspace/workspace_file.py``, which ignores that file's ``settings`` block
+for exactly this reason).
+
+So workspace policy gets its own file with its own schema, and this is that
+schema. ``workspace/policy.py`` finds and loads it and pushes it down into each
+project; nothing here reads the filesystem.
+
+Why this is a DISTINCT file from any project config
+---------------------------------------------------
+A workspace root is frequently also a project. When it is, ``.ash/ash.yaml`` at
+the root is that project's config and must keep meaning exactly that. If policy
+could also be read from it, one project's severity threshold would silently
+become its siblings' ceiling -- and the operator would have written a
+project-scoped file expecting project scope.
+
+``workspace/policy.py`` therefore looks only for ``ash-workspace.*`` names,
+which are disjoint from ``ASH_CONFIG_FILE_NAMES``, and refuses when it is
+pointed at a file that is some project's config. That disjointness is asserted
+by ``tests/unit/workspace/test_workspace_policy.py`` so the two name sets cannot
+drift into overlap.
+
+Why the top-level key is ``workspace``
+--------------------------------------
+It mirrors ``AshConfig.workspace``, so an operator who knows where
+``max_parallel_projects`` goes knows where the ceiling goes. The two blocks are
+deliberately in different FILES rather than merged: ``WorkspaceExecutionConfig``
+holds scheduling knobs that cannot change any project's verdict, and everything
+here can. Its docstring records that split, and this file is the other half of
+it.
+
+Why the ceiling defaults to None rather than to MEDIUM
+------------------------------------------------------
+``None`` means "no ceiling", and it has to be distinguishable from a configured
+one. ASH's own default threshold is MEDIUM, so defaulting this field to MEDIUM
+would mean an operator who created a policy file to add one suppression had
+thereby imposed a MEDIUM ceiling on every project in the workspace -- tightening
+projects they never mentioned, in a file that says nothing about severity. The
+absence of a ceiling is a value in the domain, so it is a value in the schema.
+
+The ceiling is case-SENSITIVE, and that is load-bearing
+-------------------------------------------------------
+``Literal["ALL", ...]`` rejects ``"medium"``. This matches
+``utils.severity_ladder``, which is case-sensitive for the reason recorded
+there: it gates an *unrecognised* threshold like ``CRITICAL``, the loosest
+setting. Accepting ``"medium"`` here and passing it through would therefore turn
+a ceiling the operator meant as MEDIUM into no effective ceiling at all -- the
+one direction a ceiling must never fail in. Refusing the file is the honest
+outcome.
+
+No ``!ENV`` substitution, unlike the project config
+---------------------------------------------------
+``AshConfig.from_file`` resolves ``${VAR}`` in its YAML. The policy loader uses
+plain ``yaml.safe_load`` and does not. A ceiling an environment variable can
+loosen is not a ceiling, and CI is precisely where an unset variable is easy to
+arrange and hard to notice. The failure mode is safe rather than silent: an
+unsubstituted ``${THRESH}`` stays a literal string and fails the ``Literal``
+above, so the workspace is refused with exit 4 instead of scanning with the gate
+quietly off.
+
+Failure modes and known limitations
+-----------------------------------
+* ``extra="forbid"`` on both models, so ``max_severity_threshhold`` is an error
+  rather than an ignored key. A silently-ignored policy key is the worst
+  outcome available here: the operator believes a ceiling is in force and no
+  output contradicts them.
+* ``additional_scanners`` is a list of names, not per-scanner config. A scanner
+  added by policy alone runs with ASH's default config for it, because the
+  workspace has no legitimate source for that project's tuning of a scanner the
+  project never enabled. Operators wanting tuned settings must enable the
+  scanner in the project.
+* ``max_severity_threshold`` tightens the gate only for findings that carry a
+  severity. A finding carrying only a SARIF ``error`` level is treated as
+  CRITICAL and stays actionable at every threshold, so no ceiling excludes it.
+  That is not specific to workspace mode -- single-project ``severity_threshold``
+  behaves identically, and the two paths were verified to agree over all 120
+  level/severity/threshold combinations -- but it means the ceiling cannot
+  quieten a scanner that omits ``properties.issue_severity``, checkov being the
+  one ASH ships. See ``utils/severity_ladder.py``.
+* This schema does not validate that a suppression's ``path`` can be rewritten
+  for any project; that depends on the project list and is
+  ``workspace/policy.py``'s job.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+
+
+class WorkspacePolicyConfig(BaseModel):
+    """Workspace-wide policy: the ``workspace`` block of the policy file.
+
+    Every field here can change a project's verdict, which is why they live in
+    their own file rather than beside the execution knobs in
+    ``AshConfig.workspace``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_severity_threshold: Annotated[
+        # A real Literal, not a str with an advertised enum: the enum has to be
+        # ENFORCED, not merely documented, for the case-sensitivity reason in the
+        # module docstring. A value pydantic lets through reaches the ladder,
+        # which reads an unrecognised threshold as CRITICAL -- no ceiling at all.
+        Literal["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"] | None,
+        Field(
+            None,
+            description=(
+                "The LOOSEST severity threshold any project may use. A project "
+                "configuring something stricter keeps it; a project configuring "
+                "something looser is tightened to this value. 'max' refers to "
+                "permissiveness, not to severity: the strictness order is "
+                "ALL < LOW < MEDIUM < HIGH < CRITICAL, so raising this value "
+                "LOOSENS the ceiling. Unset means no ceiling. Case-sensitive."
+            ),
+        ),
+    ] = None
+
+    suppressions: Annotated[
+        list[AshSuppression],
+        Field(
+            description=(
+                "Suppressions that apply across the workspace. Paths are "
+                "WORKSPACE-relative (e.g. 'api/src/legacy.py') and are rewritten "
+                "into each project's own coordinates before being applied. A "
+                "suppression that cannot match inside a project is not passed to "
+                "it; one that cannot be rewritten soundly refuses the workspace."
+            )
+        ),
+    ] = []
+
+    ignore_paths: Annotated[
+        list[IgnorePathWithReason],
+        Field(
+            description=(
+                "Paths excluded across the workspace. Workspace-relative and "
+                "pushed down per project, exactly as 'suppressions' are."
+            )
+        ),
+    ] = []
+
+    additional_scanners: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Scanners every project must run, in addition to whatever it "
+                "enables itself. Additive only -- this cannot disable a scanner "
+                "a project enabled. A scanner the project already declares runs "
+                "under the project's own config and its findings are the "
+                "project's; a scanner added only by this policy runs with "
+                "default config and its findings are tagged "
+                "'origin: workspace-policy' and reported separately."
+            )
+        ),
+    ] = []
+
+    policy_scanners_gate: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether findings from policy-added scanners affect a project's "
+                "exit code. Default false: a workspace that adds a scanner to "
+                "gather visibility should not thereby fail projects that never "
+                "opted into it, and turning it on is the operator saying they "
+                "have triaged what the new scanner reports."
+            ),
+        ),
+    ] = False
+
+
+class AshWorkspaceConfig(BaseModel):
+    """The whole workspace policy file.
+
+    A thin wrapper over one block, kept as its own model so the file has a
+    versionable top-level schema and so ``workspace:`` reads the same here as it
+    does in a project config.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace: Annotated[
+        WorkspacePolicyConfig,
+        Field(
+            description=(
+                "Workspace-wide policy. Distinct from AshConfig.workspace, which "
+                "holds execution scheduling knobs in a project config; nothing "
+                "here can be set from a project's own file."
+            ),
+        ),
+    ] = WorkspacePolicyConfig()

--- a/automated_security_helper/models/workspace.py
+++ b/automated_security_helper/models/workspace.py
@@ -354,6 +354,24 @@ class WorkspaceProjectResult(BaseModel):
             description="Final status per scanner name, for this project alone.",
         ),
     ]
+    ceiling_unreachable_findings: Annotated[
+        Dict[str, int],
+        Field(
+            default_factory=dict,
+            description=(
+                "Per scanner, how many of this project's findings the workspace "
+                "severity ceiling could not affect, because they carry no "
+                "properties.issue_severity and are therefore judged from the "
+                "SARIF level -- where `error` is read as critical and so is "
+                "actionable at every threshold. Populated only when the ceiling "
+                "actually tightened this project AND some of its findings were "
+                "beyond that tightening's reach, so an empty mapping means the "
+                "ceiling did what it says. An observation about these findings, "
+                "not a claim about the scanner: it is recomputed every scan, so "
+                "it stops appearing if a scanner starts emitting severity."
+            ),
+        ),
+    ]
     skip_reason: Annotated[
         Optional[SkippedProjectReason],
         Field(None, description="Why the project was skipped, when it was."),

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -21048,6 +21048,14 @@
           "title": "Actionable Finding Count",
           "type": "integer"
         },
+        "ceiling_unreachable_findings": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Per scanner, how many of this project's findings the workspace severity ceiling could not affect, because they carry no properties.issue_severity and are therefore judged from the SARIF level -- where `error` is read as critical and so is actionable at every threshold. Populated only when the ceiling actually tightened this project AND some of its findings were beyond that tightening's reach, so an empty mapping means the ceiling did what it says. An observation about these findings, not a claim about the scanner: it is recomputed every scan, so it stops appearing if a scanner starts emitting severity.",
+          "title": "Ceiling Unreachable Findings",
+          "type": "object"
+        },
         "display_label": {
           "description": "What a human reads. Not unique.",
           "minLength": 1,

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -1638,6 +1638,14 @@
             }
           },
           "description": "Scanner configurations by name."
+        },
+        "workspace": {
+          "$ref": "#/$defs/WorkspaceExecutionConfig",
+          "default": {
+            "max_parallel_projects": null,
+            "project_timeout": null
+          },
+          "description": "Workspace-mode execution settings. Read from the config resolved for the workspace root; a project's own copy of this block is ignored, because how many projects run at once is not a project's decision."
         }
       },
       "title": "AshConfig",
@@ -12343,6 +12351,16 @@
       "title": "Primitive",
       "type": "string"
     },
+    "ProjectRunStatus": {
+      "description": "What became of one project once execution started.\n\n``SKIPPED`` covers both skip reasons and carries ``skip_reason`` to say\nwhich; ``FAILED`` is reserved for a project that was attempted and produced\nno verdict, which is the only one of the three that fails the workspace.",
+      "enum": [
+        "completed",
+        "skipped",
+        "failed"
+      ],
+      "title": "ProjectRunStatus",
+      "type": "string"
+    },
     "ProofOfConcept": {
       "properties": {
         "environment": {
@@ -17189,6 +17207,15 @@
       "title": "Signer",
       "type": "object"
     },
+    "SkippedProjectReason": {
+      "description": "Why a project in the workspace was not scanned.\n\nThe distinction is load-bearing: ``NO_CHANGES`` is a successful\noptimisation, ``ERROR`` is a project the operator asked for that did not\nrun. Only the latter should affect the exit status.",
+      "enum": [
+        "no-changes",
+        "error"
+      ],
+      "title": "SkippedProjectReason",
+      "type": "string"
+    },
     "Source": {
       "additionalProperties": false,
       "properties": {
@@ -20973,6 +21000,295 @@
       "title": "Workspace",
       "type": "object"
     },
+    "WorkspaceExecutionConfig": {
+      "additionalProperties": false,
+      "description": "How many projects a workspace scan runs at once, and how long each may take.\n\nWhy this is not read from the .code-workspace file\n--------------------------------------------------\n``automated_security_helper.workspace.workspace_file`` deliberately ignores\nthat file's ``settings`` block, because it belongs to another tool whose\nschema ASH does not control. So every ASH knob, including these two, lives in\nASH's own config -- here, in the config resolved for the workspace root.\n\nWhy these two land before the workspace policy block\n----------------------------------------------------\nNeither can change any project's verdict. ``max_parallel_projects`` decides\nscheduling and ``project_timeout`` decides how long to wait; the findings a\nproject reports and the threshold they are judged against are untouched. The\nworkspace-level *policy* fields -- a severity ceiling, workspace-wide\nsuppressions -- can change a verdict, and they arrive separately and visibly\nrather than riding in on an execution change.\n\nWall clock is ``ceil(projects / bound)`` waves, and that is arithmetic\n-----------------------------------------------------------------------\nA workspace of N projects at a bound of B runs in ``ceil(N / B)`` waves, so\nits wall clock is roughly that multiple of one project's. Reproduce with\n``scripts/measure_workspace_parallelism.py``; measured on a 192-CPU Linux\nhost on 2026-08-25, five projects, bound 4, three timed runs per arm, the\nwhole child process timed:\n\n* five equal projects -- one alone 21.3s median (19.4-22.7), the workspace\n  43.4s median (41.5-45.8). Ratio of medians **2.036x**, range 1.823-2.365x.\n* one larger project plus four small -- one alone 20.7s median (20.7-26.3),\n  the workspace 40.5s median (39.3-46.0). Ratio **1.958x**, range\n  1.495-2.227x.\n\nBoth sit on the ``ceil(5/4) = 2`` floor, so neither says much about the\nimplementation: an operator who wants a workspace to finish in about the time\nof its slowest project has to set ``max_parallel_projects`` to at least the\nproject count and accept the thread product below. The default stays at 4\nbecause that product is the thing worth defaulting conservatively.\n\nTwo earlier figures for this were wrong and are withdrawn. A reported 0.88x at\nbound 5 -- a five-project workspace beating one project alone -- was an\nartefact of timing a cold single-project arm against a warm workspace arm,\nbecause ``uv_tool_runner`` caches tool probing across invocations. The\nmeasurement script now runs a discard pass first and alternates the arms, and\nnothing close to a sub-1.0 ratio reappears. A reported 2.35x at bound 4 was a\nsingle unrepeated run; it lands at the top of the range measured here rather\nthan at its centre, which is why the figures above are medians with a spread.\n\nThe second shape did not do what it was designed to do, and that is worth\nknowing before anyone repeats it. It gave one project five times the files, on\nthe theory that \"the slowest project alone\" would then be a real baseline and\nthe small projects could hide inside its wave. But 60 files scanned in 20.7s\nand 12 files in 21.3s -- indistinguishable. Scan wall clock here is dominated\nby per-scanner startup, not by file count, so the fixture produced no dominant\nproject and its number is really the equal case again. Testing the RFC's 1.5x\ncriterion properly needs a project large enough to be file-bound rather than\nstartup-bound, which is thousands of files, not sixty.\n\nOn this evidence the 1.5x criterion is not met at the default bound in either\nshape, and for five projects at bound 4 it cannot be: two waves is 2.0x before\nany implementation cost.\n\nFailure modes and known limitations\n-----------------------------------\n* ``project_timeout`` bounds the *verdict*, not the worker. Python cannot\n  preempt a thread, so a timed-out project is recorded FAILED and the\n  workspace continues, but the abandoned worker keeps running -- and keeps\n  its pool slot. Once every slot is held by an abandoned project, nothing\n  still queued can start, so those projects are cancelled and recorded\n  FAILED rather than waited on. A workspace with more projects than\n  ``max_parallel_projects`` can therefore report several failures from one\n  slow project; raising either knob avoids it.\n* The process still does not exit until every abandoned worker finishes,\n  because the interpreter joins them. Scanners run as subprocesses with\n  their own timeouts, so the residual exposure is a genuinely wedged\n  in-process scanner.\n* The outer bound multiplies with the inner scanner pool. That pool is\n  ``min(32, cpu_count + 4)`` in ``ScanExecutionEngine.__init__``, not 4, and\n  not the unrelated ``thread_pool_max_workers`` MCP setting, so the\n  worst-case thread count is ``max_parallel_projects * min(32, cpu + 4)``.\n  On the 192-CPU host above, the default bound of 4 already permits up to\n  128 concurrent scanner threads.",
+      "properties": {
+        "max_parallel_projects": {
+          "anyOf": [
+            {
+              "maximum": 64,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of projects scanned concurrently. Unset means min(4, cpu_count). This is an outer bound over each project's own scanner thread pool, not a replacement for it.",
+          "title": "Max Parallel Projects"
+        },
+        "project_timeout": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds to allow a single project. Unset means no limit. On timeout that project is recorded as failed and the remaining projects still complete.",
+          "title": "Project Timeout"
+        }
+      },
+      "title": "WorkspaceExecutionConfig",
+      "type": "object"
+    },
+    "WorkspaceProjectResult": {
+      "additionalProperties": true,
+      "description": "One project's outcome, as it appears in the aggregated results.",
+      "properties": {
+        "actionable_finding_count": {
+          "default": 0,
+          "description": "Findings at or above this project's own effective threshold.",
+          "minimum": 0,
+          "title": "Actionable Finding Count",
+          "type": "integer"
+        },
+        "display_label": {
+          "description": "What a human reads. Not unique.",
+          "minLength": 1,
+          "title": "Display Label",
+          "type": "string"
+        },
+        "duration_seconds": {
+          "default": 0.0,
+          "description": "Wall clock spent on this project.",
+          "minimum": 0.0,
+          "title": "Duration Seconds",
+          "type": "number"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "What went wrong, for a FAILED project.",
+          "title": "Error"
+        },
+        "exceeds_threshold": {
+          "default": false,
+          "description": "Whether this project's own verdict is a failure. Stored rather than derived from actionable_finding_count because fail_on_findings can be off, in which case a project has actionable findings and still passes.",
+          "title": "Exceeds Threshold",
+          "type": "boolean"
+        },
+        "finding_count": {
+          "default": 0,
+          "description": "Unsuppressed findings reported for the project.",
+          "minimum": 0,
+          "title": "Finding Count",
+          "type": "integer"
+        },
+        "invalid_config": {
+          "default": false,
+          "description": "Whether the failure was this project's own configuration. Separated from a general failure because it selects exit code 3 rather than 1, and those route to different people.",
+          "title": "Invalid Config",
+          "type": "boolean"
+        },
+        "output_path": {
+          "description": "Where this project's own subtree lives, relative to the workspace output directory.",
+          "minLength": 1,
+          "title": "Output Path",
+          "type": "string"
+        },
+        "project": {
+          "description": "The project key -- its workspace-relative path with separators replaced by dashes. Every other attribution in the results joins on this.",
+          "minLength": 1,
+          "title": "Project",
+          "type": "string"
+        },
+        "relative_path": {
+          "description": "The project's workspace-relative path, forward-slash separated. The coordinate system workspace-relative finding paths live in.",
+          "minLength": 1,
+          "title": "Relative Path",
+          "type": "string"
+        },
+        "sarif_run_index": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Index of this project's run in the aggregated SARIF, so a consumer can extract one project by selecting a run. Null when the project contributed no run.",
+          "title": "Sarif Run Index"
+        },
+        "scanners": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Final status per scanner name, for this project alone.",
+          "title": "Scanners",
+          "type": "object"
+        },
+        "severity_threshold": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The threshold this project's verdict was judged against. Null for a project that never ran.",
+          "title": "Severity Threshold"
+        },
+        "skip_detail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Human-readable explanation of the skip.",
+          "title": "Skip Detail"
+        },
+        "skip_reason": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SkippedProjectReason"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Why the project was skipped, when it was."
+        },
+        "status": {
+          "$ref": "#/$defs/ProjectRunStatus",
+          "description": "Whether the project completed, was skipped, or failed."
+        }
+      },
+      "required": [
+        "project",
+        "relative_path",
+        "display_label",
+        "status",
+        "output_path"
+      ],
+      "title": "WorkspaceProjectResult",
+      "type": "object"
+    },
+    "WorkspaceResults": {
+      "additionalProperties": true,
+      "description": "Everything a workspace scan concluded, keyed under ``workspace``.",
+      "properties": {
+        "exit_code": {
+          "description": "The process status this run exited with.",
+          "title": "Exit Code",
+          "type": "integer"
+        },
+        "max_parallel_projects": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The outer concurrency bound this run used.",
+          "title": "Max Parallel Projects"
+        },
+        "project_timeout": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The per-project time budget, when one was set.",
+          "title": "Project Timeout"
+        },
+        "projects": {
+          "description": "Every project in workspace-file order, skipped ones included.",
+          "items": {
+            "$ref": "#/$defs/WorkspaceProjectResult"
+          },
+          "title": "Projects",
+          "type": "array"
+        },
+        "refusal_detail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Why the workspace was refused, for status='refused'. Null for a run that scanned anything.",
+          "title": "Refusal Detail"
+        },
+        "status": {
+          "default": "completed",
+          "description": "Whether projects were scanned at all. The discriminator for the code-2 collision -- see the module docstring.",
+          "enum": [
+            "completed",
+            "refused"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "unconvertible_finding_paths": {
+          "default": 0,
+          "description": "Number of findings that could not be given a workspace-relative path, because every location they offered was absolute and outside the project or traversed upward. One per finding, not per location. Counted rather than dropped: dropping a finding because its path is awkward is a silent false negative.",
+          "minimum": 0,
+          "title": "Unconvertible Finding Paths",
+          "type": "integer"
+        },
+        "wall_clock_seconds": {
+          "default": 0.0,
+          "description": "Wall clock for the whole workspace.",
+          "minimum": 0.0,
+          "title": "Wall Clock Seconds",
+          "type": "number"
+        },
+        "workspace_file": {
+          "description": "Absolute path of the workspace definition.",
+          "minLength": 1,
+          "title": "Workspace File",
+          "type": "string"
+        },
+        "workspace_root": {
+          "description": "Absolute path of the directory holding it. Every workspace-relative finding path is relative to this, and in container mode this is what was mounted at /src.",
+          "minLength": 1,
+          "title": "Workspace Root",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workspace_file",
+        "workspace_root",
+        "exit_code"
+      ],
+      "title": "WorkspaceResults",
+      "type": "object"
+    },
     "YAMLReporterConfig": {
       "additionalProperties": true,
       "properties": {
@@ -21524,7 +21840,7 @@
                 "supportedTaxonomies": [],
                 "taxa": [],
                 "translationMetadata": null,
-                "version": "3.6.0"
+                "version": "3.5.9"
               },
               "extensions": [],
               "properties": null
@@ -21563,6 +21879,18 @@
       },
       "title": "Validation Checkpoints",
       "type": "array"
+    },
+    "workspace": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/WorkspaceResults"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Per-project attribution for a workspace-mode scan: one entry per project, the skipped-project payload, and the exit code the run produced. Null for a single-directory scan, which is how a consumer tells the two shapes apart."
     }
   },
   "title": "AshAggregatedResults",

--- a/automated_security_helper/schemas/AshConfig.json
+++ b/automated_security_helper/schemas/AshConfig.json
@@ -400,6 +400,14 @@
             }
           },
           "description": "Scanner configurations by name."
+        },
+        "workspace": {
+          "$ref": "#/$defs/WorkspaceExecutionConfig",
+          "default": {
+            "max_parallel_projects": null,
+            "project_timeout": null
+          },
+          "description": "Workspace-mode execution settings. Read from the config resolved for the workspace root; a project's own copy of this block is ignored, because how many projects run at once is not a project's decision."
         }
       },
       "title": "AshConfig",
@@ -3751,6 +3759,43 @@
         "key"
       ],
       "title": "ToolExtraArg",
+      "type": "object"
+    },
+    "WorkspaceExecutionConfig": {
+      "additionalProperties": false,
+      "description": "How many projects a workspace scan runs at once, and how long each may take.\n\nWhy this is not read from the .code-workspace file\n--------------------------------------------------\n``automated_security_helper.workspace.workspace_file`` deliberately ignores\nthat file's ``settings`` block, because it belongs to another tool whose\nschema ASH does not control. So every ASH knob, including these two, lives in\nASH's own config -- here, in the config resolved for the workspace root.\n\nWhy these two land before the workspace policy block\n----------------------------------------------------\nNeither can change any project's verdict. ``max_parallel_projects`` decides\nscheduling and ``project_timeout`` decides how long to wait; the findings a\nproject reports and the threshold they are judged against are untouched. The\nworkspace-level *policy* fields -- a severity ceiling, workspace-wide\nsuppressions -- can change a verdict, and they arrive separately and visibly\nrather than riding in on an execution change.\n\nWall clock is ``ceil(projects / bound)`` waves, and that is arithmetic\n-----------------------------------------------------------------------\nA workspace of N projects at a bound of B runs in ``ceil(N / B)`` waves, so\nits wall clock is roughly that multiple of one project's. Reproduce with\n``scripts/measure_workspace_parallelism.py``; measured on a 192-CPU Linux\nhost on 2026-08-25, five projects, bound 4, three timed runs per arm, the\nwhole child process timed:\n\n* five equal projects -- one alone 21.3s median (19.4-22.7), the workspace\n  43.4s median (41.5-45.8). Ratio of medians **2.036x**, range 1.823-2.365x.\n* one larger project plus four small -- one alone 20.7s median (20.7-26.3),\n  the workspace 40.5s median (39.3-46.0). Ratio **1.958x**, range\n  1.495-2.227x.\n\nBoth sit on the ``ceil(5/4) = 2`` floor, so neither says much about the\nimplementation: an operator who wants a workspace to finish in about the time\nof its slowest project has to set ``max_parallel_projects`` to at least the\nproject count and accept the thread product below. The default stays at 4\nbecause that product is the thing worth defaulting conservatively.\n\nTwo earlier figures for this were wrong and are withdrawn. A reported 0.88x at\nbound 5 -- a five-project workspace beating one project alone -- was an\nartefact of timing a cold single-project arm against a warm workspace arm,\nbecause ``uv_tool_runner`` caches tool probing across invocations. The\nmeasurement script now runs a discard pass first and alternates the arms, and\nnothing close to a sub-1.0 ratio reappears. A reported 2.35x at bound 4 was a\nsingle unrepeated run; it lands at the top of the range measured here rather\nthan at its centre, which is why the figures above are medians with a spread.\n\nThe second shape did not do what it was designed to do, and that is worth\nknowing before anyone repeats it. It gave one project five times the files, on\nthe theory that \"the slowest project alone\" would then be a real baseline and\nthe small projects could hide inside its wave. But 60 files scanned in 20.7s\nand 12 files in 21.3s -- indistinguishable. Scan wall clock here is dominated\nby per-scanner startup, not by file count, so the fixture produced no dominant\nproject and its number is really the equal case again. Testing the RFC's 1.5x\ncriterion properly needs a project large enough to be file-bound rather than\nstartup-bound, which is thousands of files, not sixty.\n\nOn this evidence the 1.5x criterion is not met at the default bound in either\nshape, and for five projects at bound 4 it cannot be: two waves is 2.0x before\nany implementation cost.\n\nFailure modes and known limitations\n-----------------------------------\n* ``project_timeout`` bounds the *verdict*, not the worker. Python cannot\n  preempt a thread, so a timed-out project is recorded FAILED and the\n  workspace continues, but the abandoned worker keeps running -- and keeps\n  its pool slot. Once every slot is held by an abandoned project, nothing\n  still queued can start, so those projects are cancelled and recorded\n  FAILED rather than waited on. A workspace with more projects than\n  ``max_parallel_projects`` can therefore report several failures from one\n  slow project; raising either knob avoids it.\n* The process still does not exit until every abandoned worker finishes,\n  because the interpreter joins them. Scanners run as subprocesses with\n  their own timeouts, so the residual exposure is a genuinely wedged\n  in-process scanner.\n* The outer bound multiplies with the inner scanner pool. That pool is\n  ``min(32, cpu_count + 4)`` in ``ScanExecutionEngine.__init__``, not 4, and\n  not the unrelated ``thread_pool_max_workers`` MCP setting, so the\n  worst-case thread count is ``max_parallel_projects * min(32, cpu + 4)``.\n  On the 192-CPU host above, the default bound of 4 already permits up to\n  128 concurrent scanner threads.",
+      "properties": {
+        "max_parallel_projects": {
+          "anyOf": [
+            {
+              "maximum": 64,
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Maximum number of projects scanned concurrently. Unset means min(4, cpu_count). This is an outer bound over each project's own scanner thread pool, not a replacement for it.",
+          "title": "Max Parallel Projects"
+        },
+        "project_timeout": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Seconds to allow a single project. Unset means no limit. On timeout that project is recorded as failed and the remaining projects still complete.",
+          "title": "Project Timeout"
+        }
+      },
+      "title": "WorkspaceExecutionConfig",
       "type": "object"
     },
     "YAMLReporterConfig": {

--- a/automated_security_helper/schemas/AshWorkspaceConfig.json
+++ b/automated_security_helper/schemas/AshWorkspaceConfig.json
@@ -1,0 +1,189 @@
+{
+  "$defs": {
+    "AshSuppression": {
+      "description": "Represents a finding suppression rule.",
+      "properties": {
+        "expiration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Expiration date (YYYY-MM-DD)",
+          "title": "Expiration"
+        },
+        "line_end": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Ending line number",
+          "title": "Line End"
+        },
+        "line_start": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Starting line number",
+          "title": "Line Start"
+        },
+        "path": {
+          "description": "Path or pattern to exclude",
+          "title": "Path",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason for exclusion",
+          "title": "Reason",
+          "type": "string"
+        },
+        "rule_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rule ID to suppress",
+          "title": "Rule Id"
+        }
+      },
+      "required": [
+        "path",
+        "reason"
+      ],
+      "title": "AshSuppression",
+      "type": "object"
+    },
+    "IgnorePathWithReason": {
+      "description": "Represents a path exclusion entry.",
+      "properties": {
+        "expiration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Expiration date (YYYY-MM-DD)",
+          "title": "Expiration"
+        },
+        "path": {
+          "description": "Path or pattern to exclude",
+          "title": "Path",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason for exclusion",
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "reason"
+      ],
+      "title": "IgnorePathWithReason",
+      "type": "object"
+    },
+    "WorkspacePolicyConfig": {
+      "additionalProperties": false,
+      "description": "Workspace-wide policy: the ``workspace`` block of the policy file.\n\nEvery field here can change a project's verdict, which is why they live in\ntheir own file rather than beside the execution knobs in\n``AshConfig.workspace``.",
+      "properties": {
+        "additional_scanners": {
+          "default": [],
+          "description": "Scanners every project must run, in addition to whatever it enables itself. Additive only -- this cannot disable a scanner a project enabled. A scanner the project already declares runs under the project's own config and its findings are the project's; a scanner added only by this policy runs with default config and its findings are tagged 'origin: workspace-policy' and reported separately.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Additional Scanners",
+          "type": "array"
+        },
+        "ignore_paths": {
+          "default": [],
+          "description": "Paths excluded across the workspace. Workspace-relative and pushed down per project, exactly as 'suppressions' are.",
+          "items": {
+            "$ref": "#/$defs/IgnorePathWithReason"
+          },
+          "title": "Ignore Paths",
+          "type": "array"
+        },
+        "max_severity_threshold": {
+          "anyOf": [
+            {
+              "enum": [
+                "ALL",
+                "LOW",
+                "MEDIUM",
+                "HIGH",
+                "CRITICAL"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The LOOSEST severity threshold any project may use. A project configuring something stricter keeps it; a project configuring something looser is tightened to this value. 'max' refers to permissiveness, not to severity: the strictness order is ALL < LOW < MEDIUM < HIGH < CRITICAL, so raising this value LOOSENS the ceiling. Unset means no ceiling. Case-sensitive.",
+          "title": "Max Severity Threshold"
+        },
+        "policy_scanners_gate": {
+          "default": false,
+          "description": "Whether findings from policy-added scanners affect a project's exit code. Default false: a workspace that adds a scanner to gather visibility should not thereby fail projects that never opted into it, and turning it on is the operator saying they have triaged what the new scanner reports.",
+          "title": "Policy Scanners Gate",
+          "type": "boolean"
+        },
+        "suppressions": {
+          "default": [],
+          "description": "Suppressions that apply across the workspace. Paths are WORKSPACE-relative (e.g. 'api/src/legacy.py') and are rewritten into each project's own coordinates before being applied. A suppression that cannot match inside a project is not passed to it; one that cannot be rewritten soundly refuses the workspace.",
+          "items": {
+            "$ref": "#/$defs/AshSuppression"
+          },
+          "title": "Suppressions",
+          "type": "array"
+        }
+      },
+      "title": "WorkspacePolicyConfig",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The whole workspace policy file.\n\nA thin wrapper over one block, kept as its own model so the file has a\nversionable top-level schema and so ``workspace:`` reads the same here as it\ndoes in a project config.",
+  "properties": {
+    "workspace": {
+      "$ref": "#/$defs/WorkspacePolicyConfig",
+      "default": {
+        "additional_scanners": [],
+        "ignore_paths": [],
+        "max_severity_threshold": null,
+        "policy_scanners_gate": false,
+        "suppressions": []
+      },
+      "description": "Workspace-wide policy. Distinct from AshConfig.workspace, which holds execution scheduling knobs in a project config; nothing here can be set from a project's own file."
+    }
+  },
+  "title": "AshWorkspaceConfig",
+  "type": "object"
+}

--- a/automated_security_helper/schemas/generate_schemas.py
+++ b/automated_security_helper/schemas/generate_schemas.py
@@ -6,16 +6,24 @@ from typing import Literal
 
 def generate_schemas(output: Literal["file", "json", "dict"] = "file"):
     """Generate JSON schemas for the models."""
-    from pathlib import Path
-    from automated_security_helper.config.ash_config import AshConfig
-    from automated_security_helper.models.asharp_model import AshAggregatedResults
     import json
+    from pathlib import Path
+
+    from automated_security_helper.config.ash_config import AshConfig
+    from automated_security_helper.config.ash_workspace_config import (
+        AshWorkspaceConfig,
+    )
+    from automated_security_helper.models.asharp_model import AshAggregatedResults
 
     cur_file_path = Path(__file__)
     # create schemas dir if not existing
     schemas_dir = cur_file_path.parent
     resp = {}
-    for model in [AshConfig, AshAggregatedResults]:
+    # AshWorkspaceConfig is the workspace policy file's schema. It is a separate
+    # model, not a block of AshConfig, because it lives in a separate file -- see
+    # config/ash_workspace_config.py for why policy must not be readable from a
+    # project's config.
+    for model in [AshConfig, AshAggregatedResults, AshWorkspaceConfig]:
         json_schema_path = schemas_dir.joinpath(f"{model.__name__}.json").resolve()
         schema = model.model_json_schema()
         if output == "dict":

--- a/automated_security_helper/workspace/aggregation.py
+++ b/automated_security_helper/workspace/aggregation.py
@@ -638,8 +638,13 @@ class WorkspaceAggregator:
         # project's own total.
         if outcome.actionable_finding_count:
             for name, results in by_scanner.items():
+                # gate_threshold, matching what the project's own verdict was
+                # computed from. Using severity_threshold here made the two
+                # derivations of one number disagree the moment a workspace
+                # ceiling tightened anything: the project reported 1 actionable
+                # and this split summed to 0, with no rule for which to trust.
                 actionable = count_actionable_results(
-                    results, project.severity_threshold
+                    results, project.gate_threshold
                 )
                 self._scanner_actionable[name] = (
                     self._scanner_actionable.get(name, 0) + actionable

--- a/automated_security_helper/workspace/execution.py
+++ b/automated_security_helper/workspace/execution.py
@@ -248,6 +248,7 @@ from automated_security_helper.workspace.aggregation import (
     has_finding_at_min_severity,
 )
 from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.policy import ceiling_unreachable_counts
 from automated_security_helper.workspace.reporting import (
     WorkspaceReportOutcome,
     emit_workspace_reports,
@@ -650,6 +651,19 @@ def _scan_one_project(
 
     _write_project_results(project_output, results)
 
+    # Where the ceiling could not reach, computed from the findings actually
+    # present rather than asserted about a scanner. Only when the ceiling really
+    # did tighten this project: a disclosure printed on every scan is noise, and
+    # noise gets skipped. ceiling_unreachable_counts returns {} when the two
+    # thresholds are equal, so this is belt and braces rather than the only guard.
+    unreachable: Dict[str, int] = {}
+    if project.threshold_tightened_by_policy:
+        unreachable = ceiling_unreachable_counts(
+            results_list,
+            declared_threshold=project.severity_threshold,
+            effective_threshold=threshold,
+        )
+
     outcome = WorkspaceProjectResult(
         project=project.key,
         relative_path=project.relative_path,
@@ -662,6 +676,7 @@ def _scan_one_project(
         duration_seconds=time.monotonic() - started,
         output_path=output_path,
         scanners=_scanner_statuses(results),
+        ceiling_unreachable_findings=unreachable,
     )
     return _ProjectRun(outcome=outcome, run=run)
 

--- a/automated_security_helper/workspace/execution.py
+++ b/automated_security_helper/workspace/execution.py
@@ -9,12 +9,40 @@ Phase 1 produced a plan and refused to act on it. This is the part that acts, an
 its whole job is to hold one invariant while doing so:
 
     For any project P, the findings reported for P and the pass/fail verdict for P
-    are identical to what ``ash --source-dir P`` would produce.
+    are identical to what ``ash --source-dir P`` would produce, ABSENT workspace
+    policy.
 
-Everything below follows from that. Nothing here applies a workspace-level policy,
-because a workspace-level policy can change a project's verdict and that arrives
-in a later phase, explicitly and visibly, rather than sneaking in with an
-execution change.
+Everything below follows from that. The qualification was added in Phase 3 and is
+not a weakening of the invariant; it is the one thing allowed to change a verdict,
+and it does so only where an operator wrote a policy file saying so.
+
+Where policy enters, and where it deliberately does not
+------------------------------------------------------
+Exactly one line applies it: the verdict reads ``project.gate_threshold`` rather
+than ``project.severity_threshold``, so a workspace severity ceiling decides which
+findings are actionable. Everything else about a project's scan -- which scanners
+run, what config they read, what they report -- is still the project's own.
+
+That single point is deliberate. The ceiling changes only the JUDGEMENT of
+findings, never their discovery, so a project scanned under a ceiling reports the
+same findings as ``ash --source-dir P`` and differs only in how many of them are
+counted actionable. An operator can therefore always reproduce a workspace
+verdict locally by passing the effective threshold, which ``--dry-run`` prints.
+
+Two policy fields do NOT yet reach the scan, and the reason is a real constraint
+rather than an omission. ``workspace.suppressions``, ``workspace.ignore_paths``
+and ``workspace.additional_scanners`` have to be visible to the scanners
+themselves, which read them from the resolved ``AshConfig``.
+``ASHScanOrchestrator.__init__`` unconditionally overwrites its ``config`` field
+by calling ``resolve_config`` itself, so a caller cannot hand it a config with
+policy merged in. The other available channel, ``config_overrides``, is
+string-keyed and FAILS OPEN: ``apply_config_overrides`` logs a warning and
+returns the ORIGINAL config when an override does not parse or the result does
+not validate. Routing a security policy through it would mean a typo silently
+scans with no policy at all, which is the failure direction this whole feature
+exists to prevent. Those fields are resolved, validated, pushed down per project
+and recorded on the plan; wiring them into the scan needs the orchestrator to
+accept a pre-resolved config, which touches the single-project path.
 
 How the scoping is achieved, and why it needs almost no new code
 ---------------------------------------------------------------
@@ -393,7 +421,7 @@ def _skipped_outcome(
             relative_path=project.relative_path,
             display_label=project.display_label,
             status=ProjectRunStatus.SKIPPED,
-            severity_threshold=project.severity_threshold,
+            severity_threshold=project.gate_threshold,
             output_path=_project_output_dir(settings, project)
             .relative_to(Path(settings.output_dir))
             .as_posix(),
@@ -417,7 +445,7 @@ def _failed_outcome(
             relative_path=project.relative_path,
             display_label=project.display_label,
             status=ProjectRunStatus.FAILED,
-            severity_threshold=project.severity_threshold,
+            severity_threshold=project.gate_threshold,
             output_path=_project_output_dir(settings, project)
             .relative_to(Path(settings.output_dir))
             .as_posix(),
@@ -586,7 +614,11 @@ def _scan_one_project(
     results_list = list(run.get("results") or []) if run else []
 
     unsuppressed = [entry for entry in results_list if not entry.get("suppressions")]
-    threshold = project.severity_threshold
+    # gate_threshold, not severity_threshold: this is where a workspace severity
+    # ceiling takes effect on the verdict. Reading the declared value here would
+    # leave the ceiling visible in the plan and in --dry-run while changing
+    # nothing about which projects fail.
+    threshold = project.gate_threshold
     actionable = count_actionable_results(results_list, threshold)
     if actionable and not has_finding_at_min_severity(
         results_list, settings.min_severity

--- a/automated_security_helper/workspace/plan.py
+++ b/automated_security_helper/workspace/plan.py
@@ -71,6 +71,10 @@ from typing import Annotated, Dict, List, Optional
 
 from pydantic import BaseModel, Field, computed_field
 
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
 from automated_security_helper.models.workspace import (
     SkippedProject,
     SkippedProjectReason,
@@ -158,13 +162,84 @@ class ProjectPlan(BaseModel):
         Field(
             None,
             description=(
-                "The project's own global_settings.severity_threshold. A "
-                "workspace-level ceiling is a later phase; when one exists the "
-                "effective value becomes severity_ladder.stricter_of(this, "
-                "ceiling)."
+                "The project's own global_settings.severity_threshold, exactly as "
+                "its config declared it. Kept alongside "
+                "effective_severity_threshold rather than being overwritten, so "
+                "an operator can see what a workspace ceiling changed instead of "
+                "only its result."
             ),
         ),
     ] = None
+    effective_severity_threshold: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "The threshold this project is actually judged against: "
+                "severity_ladder.stricter_of(severity_threshold, the workspace "
+                "ceiling). Equal to severity_threshold when there is no policy, "
+                "or when the project was already stricter than the ceiling."
+            ),
+        ),
+    ] = None
+    threshold_tightened_by_policy: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether the workspace ceiling actually moved this project's "
+                "threshold. Recorded rather than left to be re-derived, so "
+                "--dry-run and the reporters can state where policy took effect "
+                "without comparing two fields and reaching their own conclusion."
+            ),
+        ),
+    ] = False
+    policy_suppressions: Annotated[
+        List[AshSuppression],
+        Field(
+            default_factory=list,
+            description=(
+                "Workspace-level suppressions rewritten into THIS project's "
+                "coordinates. Only those whose pattern can match inside it; a "
+                "workspace suppression naming a sibling is absent here rather "
+                "than present and inert."
+            ),
+        ),
+    ]
+    policy_ignore_paths: Annotated[
+        List[IgnorePathWithReason],
+        Field(
+            default_factory=list,
+            description=(
+                "Workspace-level ignore paths, rewritten for this project on the "
+                "same terms as policy_suppressions."
+            ),
+        ),
+    ]
+    policy_scanners: Annotated[
+        List[str],
+        Field(
+            default_factory=list,
+            description=(
+                "Scanners the workspace policy adds that this project does not "
+                "itself enable. These run with ASH's default config and their "
+                "findings are tagged 'origin: workspace-policy'. A scanner the "
+                "project already declares is absent here, because it runs under "
+                "the project's own config and its findings are the project's."
+            ),
+        ),
+    ]
+    policy_scanners_gate: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether findings from policy_scanners affect this project's exit "
+                "code. Carried per project so no consumer has to reach back into "
+                "the policy to interpret policy_scanners."
+            ),
+        ),
+    ] = False
     scanner_pins: Annotated[
         Dict[str, str],
         Field(
@@ -267,6 +342,18 @@ class WorkspacePlan(BaseModel):
             ),
         ),
     ] = False
+    workspace_config_source: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "Path of the workspace policy file that was applied, or null when "
+                "the workspace declares no policy. Recorded because a ceiling "
+                "changes verdicts, so which file imposed it has to be answerable "
+                "from the output rather than by re-running discovery."
+            ),
+        ),
+    ] = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -299,8 +386,14 @@ class WorkspacePlan(BaseModel):
             f"{len(self.active_projects)} to scan, {len(skipped)} skipped",
             f"{_INDENT}{'missing ok:':<{_FIELD_WIDTH}}"
             f"{'yes' if self.allow_missing_projects else 'no'}",
-            "",
         ]
+        # Only shown when there is policy. A "policy: none" line on every plan
+        # would train the reader to skip the line that matters.
+        if self.workspace_config_source:
+            lines.append(
+                f"{_INDENT}{'policy:':<{_FIELD_WIDTH}}{self.workspace_config_source}"
+            )
+        lines.append("")
 
         for position, project in enumerate(self.projects, start=1):
             suffix = ""
@@ -326,14 +419,34 @@ class WorkspacePlan(BaseModel):
                 f"{_INDENT}{'config:':<{_FIELD_WIDTH}}"
                 f"{project.config_source or 'ASH default config'}"
             )
-            lines.append(
-                f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}"
-                f"{project.severity_threshold or 'none'}"
-            )
+            # Both values when policy moved the threshold, so the reader can see
+            # what was declared and what will be enforced. One value otherwise:
+            # printing "CRITICAL -> CRITICAL" everywhere would bury the real cases.
+            declared = project.severity_threshold or "none"
+            if project.threshold_tightened_by_policy:
+                effective = project.effective_severity_threshold or "none"
+                lines.append(
+                    f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}"
+                    f"{effective}  (workspace policy tightened {declared})"
+                )
+            else:
+                lines.append(f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}{declared}")
             lines.append(
                 f"{_INDENT}{'scanners:':<{_FIELD_WIDTH}}"
                 f"{', '.join(project.scanners) or 'none enabled'}"
             )
+            if project.policy_scanners:
+                gating = "gating" if project.policy_scanners_gate else "not gating"
+                lines.append(
+                    f"{_INDENT}{'+policy:':<{_FIELD_WIDTH}}"
+                    f"{', '.join(project.policy_scanners)} ({gating})"
+                )
+            if project.policy_suppressions or project.policy_ignore_paths:
+                lines.append(
+                    f"{_INDENT}{'policy:':<{_FIELD_WIDTH}}"
+                    f"{len(project.policy_suppressions)} suppression(s), "
+                    f"{len(project.policy_ignore_paths)} ignore path(s)"
+                )
             if project.scanner_pins:
                 pins = ", ".join(
                     f"{scanner} {pin}"

--- a/automated_security_helper/workspace/plan.py
+++ b/automated_security_helper/workspace/plan.py
@@ -279,6 +279,27 @@ class ProjectPlan(BaseModel):
         Field(None, description="Human-readable explanation of the skip."),
     ] = None
 
+    @property
+    def gate_threshold(self) -> Optional[str]:
+        """The threshold this project's verdict must actually be judged against.
+
+        One accessor rather than each call site choosing, because a call site
+        that reads ``severity_threshold`` directly silently ignores the workspace
+        ceiling -- the ceiling would appear in the plan and in ``--dry-run`` while
+        changing no verdict, which is worse than not having it.
+
+        Falls back to ``severity_threshold`` when the effective value was never
+        computed. That happens for plans not built by ``resolve_workspace`` --
+        which this module's docstring says can exist -- and for skipped projects.
+        The fallback is not a silent default: when policy HAS been applied the
+        effective value is always set, equal to the declared one where the
+        ceiling did not bite. Returning ``None`` instead would turn the gate off
+        for those plans, which is the one failure direction that must not happen.
+        """
+        if self.effective_severity_threshold is not None:
+            return self.effective_severity_threshold
+        return self.severity_threshold
+
     def as_skipped_project(self) -> Optional[SkippedProject]:
         """This project as a ``skipped_projects`` payload entry, or None.
 

--- a/automated_security_helper/workspace/policy.py
+++ b/automated_security_helper/workspace/policy.py
@@ -101,9 +101,10 @@ Failure modes and known limitations
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import yaml
 from pydantic import ValidationError
@@ -120,7 +121,11 @@ from automated_security_helper.models.core import (
     AshSuppression,
     IgnorePathWithReason,
 )
-from automated_security_helper.utils.severity_ladder import stricter_of
+from automated_security_helper.utils.severity_ladder import (
+    SEVERITIES,
+    sarif_level_fails_threshold,
+    stricter_of,
+)
 from automated_security_helper.utils.workspace_paths import to_project_pattern
 
 # Written as `str | Path` rather than `Union[...]` -- evaluated eagerly at import,
@@ -176,6 +181,83 @@ class ProjectPolicy:
 
 def _refuse(message: str) -> WorkspaceDefinitionError:
     return WorkspaceDefinitionError(message)
+
+
+def ceiling_unreachable_counts(
+    results: Iterable[Mapping[str, Any]],
+    declared_threshold: str | None,
+    effective_threshold: str | None,
+) -> dict[str, int]:
+    """Per scanner, how many findings the severity ceiling could not affect.
+
+    This is the mechanised form of the limitation described in the module
+    docstring. Rather than documenting "the ceiling does not apply to checkov",
+    which goes stale the moment checkov starts emitting severity, it counts the
+    findings actually present for which tightening the threshold changed nothing,
+    and lets a reporter state that as an observation about those findings.
+
+    A finding counts when BOTH hold:
+
+    * It carries no usable ``properties.issue_severity``, so it is judged from
+      the SARIF ``level``. This is the discriminator, and it is why a genuinely
+      CRITICAL severity-carrying finding is NOT counted: that finding is
+      actionable at both thresholds too, but correctly so, and reporting it would
+      tell the operator the ceiling failed at something it never claimed.
+    * Its actionable verdict is identical at both thresholds, so the tightening
+      did not reach it. A level-only ``note`` under a CRITICAL-to-LOW tightening
+      IS reached, and so is not counted.
+
+    Suppressed findings are skipped: they are not actionable at any threshold, so
+    the ceiling is irrelevant to them.
+
+    Args:
+        results: The project's SARIF results.
+        declared_threshold: The threshold the project's own config asked for.
+        effective_threshold: The threshold after the workspace ceiling.
+
+    Returns:
+        Scanner name to count, for scanners with at least one such finding.
+        Empty when the two thresholds are equal -- no tightening means there is
+        no claim to qualify, which is what keeps this disclosure load-bearing
+        rather than printed on every scan.
+    """
+    if declared_threshold == effective_threshold:
+        return {}
+
+    counts: dict[str, int] = {}
+    for result in results:
+        if not isinstance(result, Mapping):
+            continue
+        if result.get("suppressions"):
+            continue
+
+        properties = result.get("properties")
+        issue_severity = ""
+        if isinstance(properties, Mapping):
+            issue_severity = str(properties.get("issue_severity") or "").upper()
+        if issue_severity in SEVERITIES:
+            # The ceiling reaches severity-carrying findings; nothing to disclose.
+            continue
+
+        level = result.get("level")
+        if sarif_level_fails_threshold(
+            level, declared_threshold
+        ) != sarif_level_fails_threshold(level, effective_threshold):
+            # The tightening changed this finding's verdict, so it was reached.
+            continue
+        if not sarif_level_fails_threshold(level, effective_threshold):
+            # Not actionable either way -- below both thresholds, not beyond reach.
+            continue
+
+        scanner = None
+        if isinstance(properties, Mapping):
+            scanner = properties.get("scanner_name")
+        # "unattributed" matches the name the aggregator uses for a finding with
+        # no scanner_name, so the two payloads agree on what to call it.
+        name = str(scanner) if scanner else "unattributed"
+        counts[name] = counts.get(name, 0) + 1
+
+    return counts
 
 
 def _normalise_scanner_name(name: str) -> str:

--- a/automated_security_helper/workspace/policy.py
+++ b/automated_security_helper/workspace/policy.py
@@ -1,0 +1,475 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find the workspace policy file, and push its policy down into one project.
+
+Why this module exists
+----------------------
+``config/ash_workspace_config.py`` says what workspace policy IS; this module
+decides which file carries it and what it means for a given project. Those are
+separate jobs because the second one needs the project list and the filesystem,
+and because every judgement here can change a project's verdict and so wants its
+reasoning written down next to it.
+
+Two things happen here, and they fail in opposite directions
+------------------------------------------------------------
+1. **Resolution** -- locate and parse the policy file. Everything is refused
+   with :class:`WorkspaceDefinitionError` (exit 4), because a policy file that
+   cannot be read is a policy that cannot be applied, and applying no policy
+   while the operator believes a ceiling is in force is a fail-open outcome.
+   The one non-refusal is a policy file that is simply absent: workspace policy
+   is opt-in, so its absence is the Phase 2b behaviour and not an error.
+2. **Push-down** -- rewrite the policy for one project. Here a pattern that
+   cannot match inside the project is DROPPED for that project rather than
+   refused, because it is legitimately about a different project. A pattern that
+   has no sound rewrite is refused, because silently dropping it would leave the
+   operator's stated suppression unapplied with nothing in the output to say so.
+
+Why the policy file cannot be a project's config
+------------------------------------------------
+A workspace root is often also a project, and then ``.ash/ash.yaml`` there is
+that project's config. Reading it as workspace policy would promote one
+project's ``severity_threshold`` into its siblings' ceiling, silently, from a
+file whose author expected project scope.
+
+Two mechanisms keep that from happening, and the second exists because the first
+is not sufficient:
+
+* ``WORKSPACE_POLICY_FILE_NAMES`` is disjoint from ``ASH_CONFIG_FILE_NAMES``, so
+  *discovery* can never land on a project config. A test asserts the
+  disjointness rather than trusting it to stay true.
+* ``--workspace-config`` can name any path, so discovery's guarantee does not
+  cover it. An explicit file is checked by RESOLVED IDENTITY against each
+  project's config path, not by filename, so a symlink or a ``./`` -prefixed
+  spelling of the same file is caught too. This mirrors the resolver's overlap
+  check, which compares real paths for the same reason.
+
+Ambiguity is refused, never ranked
+----------------------------------
+Two candidate policy files in one workspace is an error listing both. Picking by
+sort order or mtime would mean the effective ceiling changes when an operator
+adds a file they thought was inert -- and a ceiling that moves on its own is
+worse than no ceiling, because it is believed.
+
+What the ceiling can and cannot reach
+-------------------------------------
+``effective_threshold`` is ``stricter_of(project, ceiling)``, so a stricter
+project is untouched and a looser one is tightened. That composition is correct
+for every finding that carries ``properties.issue_severity``.
+
+It cannot tighten a finding that carries only a SARIF ``error`` level. Both
+ASH threshold gates map ``error`` to CRITICAL -- ``severity_ladder`` and
+``run_ash_scan``'s ``_THRESHOLD_QUALIFYING_LEVELS``, which agree over all 120
+level/severity/threshold combinations -- and CRITICAL is actionable at every
+threshold, including CRITICAL. So for such findings no threshold has ever
+changed anything, in workspace mode or single-project mode. checkov is the
+scanner ASH ships that omits ``issue_severity``.
+
+That was left as-is rather than remapped, deliberately. Remapping ``error`` to
+HIGH in ``severity_ladder`` alone was measured to break the central invariant at
+exactly one cell -- a level-only ``error`` at a CRITICAL threshold, which
+single-project mode calls actionable and workspace mode would not -- and it
+breaks it in the loosening direction, which is the one that hides findings.
+Remapping both gates instead keeps them consistent but silently stops failing
+CRITICAL-threshold single-project scans on ``error`` findings, a change to
+published exit-code behaviour well outside a workspace feature. Deriving
+``issue_severity`` for checkov has no source data: ASH reads checkov's SARIF
+verbatim and checkov does not emit severity.
+
+``threshold_tightened`` records whether the ceiling actually moved this project,
+so a reporter can say where policy took effect instead of leaving the operator
+to diff two numbers.
+
+Failure modes and known limitations
+-----------------------------------
+* Resolution is a point-in-time read; the file can change before the scan.
+* ``policy_scanners`` is computed by comparing normalised scanner names
+  (lower-cased, ``-`` and ``_`` folded together), because ``--scanners`` and the
+  config accept ``cdk-nag`` while the Python field is ``cdk_nag``. Treating
+  those as two scanners would run a second copy under default config and report
+  its findings as policy-origin duplicates of the project's own.
+* A policy suppression is pushed down per project, so one workspace-level entry
+  can become N project-level entries. Each is a copy: mutating in place would
+  leave the second project rewriting the first project's already-rewritten path.
+* ``additional_scanners`` is not validated against the set of scanners ASH knows
+  about. A typo therefore surfaces when execution cannot find the scanner rather
+  than at policy-resolution time. Validating here would need the plugin registry,
+  which is not loaded at resolution and whose contents depend on each project's
+  ``ash_plugin_modules``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from automated_security_helper.config.ash_workspace_config import (
+    AshWorkspaceConfig,
+    WorkspacePolicyConfig,
+)
+from automated_security_helper.core.exceptions import (
+    WorkspaceDefinitionError,
+    WorkspacePatternError,
+)
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+from automated_security_helper.utils.severity_ladder import stricter_of
+from automated_security_helper.utils.workspace_paths import to_project_pattern
+
+# Written as `str | Path` rather than `Union[...]` -- evaluated eagerly at import,
+# and PEP 604 unions are runtime-valid from 3.10, this project's floor.
+PathLike = str | Path
+
+#: Names a workspace policy file may take. Deliberately disjoint from
+#: ``ASH_CONFIG_FILE_NAMES`` -- see "Why the policy file cannot be a project's
+#: config" in the module docstring.
+WORKSPACE_POLICY_FILE_NAMES: list[str] = [
+    ".ash-workspace.yml",
+    ".ash-workspace.yaml",
+    ".ash-workspace.json",
+    "ash-workspace.yml",
+    "ash-workspace.yaml",
+    "ash-workspace.json",
+]
+
+#: Subdirectory of the workspace root also searched, matching where project
+#: configs may live so an operator keeps one habit for both.
+_POLICY_SUBDIR = ".ash"
+
+
+@dataclass(frozen=True)
+class ProjectPolicy:
+    """Workspace policy as it applies to ONE project.
+
+    Attributes:
+        effective_threshold: ``stricter_of(project, ceiling)``. ``None`` when
+            neither side configures a threshold, which means the gate is off --
+            not a synonym for CRITICAL. See ``severity_ladder``.
+        threshold_tightened: Whether the ceiling changed this project's
+            threshold. Recorded rather than re-derived so a reporter can state
+            where policy took effect without comparing two values itself.
+        suppressions: Workspace suppressions rewritten into this project's
+            coordinates. Only those that can match inside it.
+        ignore_paths: The same, for ``ignore_paths``.
+        policy_scanners: Scanners this policy adds that the project does not
+            already declare. These run with default config and their findings
+            are tagged ``origin: workspace-policy``.
+        policy_scanners_gate: Whether those findings affect the project's exit
+            code. Carried per project so a caller never has to reach back into
+            the policy to interpret ``policy_scanners``.
+    """
+
+    effective_threshold: str | None
+    threshold_tightened: bool
+    suppressions: tuple[AshSuppression, ...]
+    ignore_paths: tuple[IgnorePathWithReason, ...]
+    policy_scanners: tuple[str, ...]
+    policy_scanners_gate: bool
+
+
+def _refuse(message: str) -> WorkspaceDefinitionError:
+    return WorkspaceDefinitionError(message)
+
+
+def _normalise_scanner_name(name: str) -> str:
+    """Fold a scanner name to the form used for comparison.
+
+    ``cdk-nag`` and ``cdk_nag`` are one scanner: the former is what
+    ``--scanners`` and the config file accept, the latter is the Python field
+    name. Comparing raw strings would make policy add a duplicate.
+    """
+    return name.strip().lower().replace("-", "_")
+
+
+def _read_policy_document(path: Path) -> object:
+    """Parse the policy file, refusing anything unreadable.
+
+    Uses ``yaml.safe_load`` rather than ``AshConfig``'s ``!ENV``-aware loader.
+    See "No ``!ENV`` substitution" in ``config/ash_workspace_config.py``: a
+    ceiling an environment variable can loosen is not a ceiling.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' could not be read: {exc}"
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' is not valid UTF-8: {exc}"
+        ) from exc
+
+    try:
+        if path.suffix.lower() == ".json":
+            return json.loads(raw)
+        return yaml.safe_load(raw)
+    except (yaml.YAMLError, json.JSONDecodeError) as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' could not be parsed: {exc}"
+        ) from exc
+
+
+def load_workspace_policy(path: PathLike) -> AshWorkspaceConfig:
+    """Parse and validate the policy file at *path*.
+
+    Args:
+        path: The policy file. Must exist.
+
+    Returns:
+        The validated policy.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, for every unusable file -- absent,
+            unreadable, unparseable, not a mapping, or failing the schema. The
+            message names the file, because a workspace may have several config
+            files and "validation error" alone does not say which to open.
+    """
+    resolved = Path(path)
+    if not resolved.exists():
+        raise _refuse(f"workspace policy file '{resolved.as_posix()}' does not exist")
+    if not resolved.is_file():
+        raise _refuse(f"workspace policy file '{resolved.as_posix()}' is not a file")
+
+    resolved = resolved.resolve()
+    document = _read_policy_document(resolved)
+
+    # An empty file parses to None. Treated as "declares no policy" rather than
+    # refused: a commented-out policy file is a reasonable thing to keep in a
+    # repository, and it states no policy, which is representable.
+    if document is None:
+        return AshWorkspaceConfig()
+
+    if not isinstance(document, dict):
+        raise _refuse(
+            f"workspace policy file '{resolved.as_posix()}' must contain a "
+            f"mapping at the top level, found {type(document).__name__}"
+        )
+
+    try:
+        return AshWorkspaceConfig.model_validate(document)
+    except ValidationError as exc:
+        raise _refuse(
+            f"workspace policy file '{resolved.as_posix()}' is not valid: {exc}"
+        ) from exc
+
+
+def discover_workspace_policy_file(root: PathLike) -> Path | None:
+    """Find the one policy file for the workspace rooted at *root*.
+
+    Looks in *root* itself and in ``root/.ash``, non-recursively. Recursing would
+    let a vendored checkout supply workspace policy.
+
+    Returns:
+        The canonical path, or ``None`` when there is none.
+
+    Raises:
+        WorkspaceDefinitionError: When more than one candidate exists. Listed,
+            not ranked -- see the module docstring.
+    """
+    directory = Path(root)
+    candidates: list[Path] = []
+    for parent in (directory, directory / _POLICY_SUBDIR):
+        for name in WORKSPACE_POLICY_FILE_NAMES:
+            candidate = parent / name
+            if candidate.is_file():
+                candidates.append(candidate)
+
+    if not candidates:
+        return None
+
+    if len(candidates) > 1:
+        listed = "\n  - ".join(candidate.as_posix() for candidate in sorted(candidates))
+        raise _refuse(
+            f"Found {len(candidates)} workspace policy files under "
+            f"'{directory.as_posix()}'; there must be exactly one. Remove the "
+            f"extras or name one with '--workspace-config':\n  - {listed}"
+        )
+
+    return candidates[0].resolve()
+
+
+def _refuse_project_config_as_policy(
+    policy_path: Path, project_config_paths: Sequence[Path]
+) -> None:
+    """Refuse a policy file that is actually some project's config.
+
+    Compared by resolved path rather than by name, so a symlink to a project's
+    config, or a differently-spelled path to it, is caught as well.
+    """
+    from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
+
+    for project_config in project_config_paths:
+        try:
+            same = policy_path.resolve() == Path(project_config).resolve()
+        except OSError:  # pragma: no cover - unresolvable path
+            same = False
+        if same:
+            raise _refuse(
+                f"'{policy_path.as_posix()}' is a project's own ASH config, so it "
+                f"cannot also be the workspace policy file. A project config "
+                f"governs one project; workspace policy governs all of them, and "
+                f"reading one as the other would apply a single project's "
+                f"settings to its siblings. Put workspace policy in "
+                f"'{_POLICY_SUBDIR}/ash-workspace.yaml' instead."
+            )
+
+    # Also refuse by name. This catches the workspace root's own config even when
+    # the caller passed no project list -- the common CLI shape, since the root
+    # project's config path is not known to argument parsing.
+    if policy_path.name in ASH_CONFIG_FILE_NAMES:
+        raise _refuse(
+            f"'{policy_path.as_posix()}' is named like an ASH project config "
+            f"('{policy_path.name}'), so it cannot be the workspace policy file. "
+            f"Workspace policy must live in a distinct file -- "
+            f"'{_POLICY_SUBDIR}/ash-workspace.yaml', or any name passed to "
+            f"'--workspace-config' that is not a project config name."
+        )
+
+
+def resolve_workspace_policy(
+    root: PathLike,
+    *,
+    explicit: PathLike | None = None,
+    project_config_paths: Iterable[PathLike] = (),
+) -> tuple[AshWorkspaceConfig | None, Path | None]:
+    """Locate and load the workspace policy, if there is one.
+
+    Args:
+        root: The workspace root -- the directory holding the ``.code-workspace``
+            file. Policy is looked for here and in ``root/.ash``.
+        explicit: The value of ``--workspace-config``. When given, it is used
+            instead of discovery and must exist: silently falling back to
+            discovery would run with different policy than the operator named.
+        project_config_paths: Each project's own config file, where it has one.
+            Used to refuse a policy file that is one of them.
+
+    Returns:
+        ``(policy, source)``. Both are ``None`` when the workspace declares no
+        policy, which is not an error -- workspace policy is opt-in.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4. The named file is absent, the
+            workspace has two candidates, the file is unusable, or it is a
+            project's config. The message names the file in every case.
+    """
+    if explicit is not None:
+        policy_path = Path(explicit)
+        if not policy_path.exists():
+            raise _refuse(
+                f"workspace policy file '{policy_path.as_posix()}' does not "
+                f"exist. '--workspace-config' names the file to use; ASH does "
+                f"not fall back to searching, because that would apply different "
+                f"policy than the one asked for."
+            )
+    else:
+        discovered = discover_workspace_policy_file(root)
+        if discovered is None:
+            return None, None
+        policy_path = discovered
+
+    _refuse_project_config_as_policy(
+        policy_path, [Path(p) for p in project_config_paths]
+    )
+
+    return load_workspace_policy(policy_path), policy_path.resolve()
+
+
+def _push_down(
+    entries: Sequence[IgnorePathWithReason], project_prefix: PathLike
+) -> tuple[IgnorePathWithReason, ...]:
+    """Rewrite each entry's path into *project_prefix*'s coordinates.
+
+    Entries whose pattern cannot match inside the project are dropped -- they are
+    about a different project. Entries with no sound rewrite are refused, because
+    dropping one would leave a stated suppression unapplied and invisible.
+
+    Each surviving entry is a COPY, so the shared policy object is not mutated
+    as it is pushed into successive projects.
+    """
+    pushed: list[IgnorePathWithReason] = []
+    for entry in entries:
+        try:
+            rewritten = to_project_pattern(entry.path, project_prefix)
+        except WorkspacePatternError as exc:
+            raise _refuse(
+                f"workspace policy pattern '{entry.path}' cannot be applied to "
+                f"project '{Path(project_prefix).as_posix()}': {exc}"
+            ) from exc
+        if rewritten is None:
+            continue
+        # model_copy rather than reconstruction, so every field the model gains
+        # later is carried over without this call site needing to learn about it.
+        pushed.append(entry.model_copy(update={"path": rewritten}))
+    return tuple(pushed)
+
+
+def policy_for_project(
+    policy: WorkspacePolicyConfig | None,
+    *,
+    project_prefix: PathLike,
+    project_threshold: str | None,
+    project_scanners: Iterable[str],
+) -> ProjectPolicy:
+    """Apply workspace *policy* to one project.
+
+    Args:
+        policy: The workspace policy block, or ``None`` for no policy.
+        project_prefix: The project's workspace-relative path, e.g. ``api`` or
+            ``services/worker``. The coordinate system the patterns are rewritten
+            into.
+        project_threshold: The threshold the project's own config resolved to.
+            ``None`` or ``""`` means the project turned its gate off, which is
+            LOOSER than any ceiling and so is tightened by one.
+        project_scanners: The scanners the project already enables. Used to tell
+            a scanner the project owns from one this policy adds.
+
+    Returns:
+        The policy as it applies to this project.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, when a policy pattern has no sound
+            rewrite for this project.
+    """
+    if policy is None:
+        return ProjectPolicy(
+            effective_threshold=project_threshold,
+            threshold_tightened=False,
+            suppressions=(),
+            ignore_paths=(),
+            policy_scanners=(),
+            policy_scanners_gate=False,
+        )
+
+    ceiling = policy.max_severity_threshold
+    # Argument order is not arbitrary: stricter_of is commutative, so this is
+    # safe either way, but the ceiling is passed second to read as "the project
+    # asked for X, capped by Y".
+    effective = stricter_of(project_threshold, ceiling)
+
+    declared = {_normalise_scanner_name(name) for name in project_scanners}
+    policy_scanners = tuple(
+        name
+        for name in policy.additional_scanners
+        if _normalise_scanner_name(name) not in declared
+    )
+
+    return ProjectPolicy(
+        effective_threshold=effective,
+        threshold_tightened=effective != project_threshold,
+        suppressions=tuple(
+            # _push_down returns the base type; suppressions keep their own type
+            # because model_copy preserves the class it was called on.
+            entry  # type: ignore[misc]
+            for entry in _push_down(policy.suppressions, project_prefix)
+        ),
+        ignore_paths=_push_down(policy.ignore_paths, project_prefix),
+        policy_scanners=policy_scanners,
+        policy_scanners_gate=policy.policy_scanners_gate,
+    )

--- a/automated_security_helper/workspace/resolver.py
+++ b/automated_security_helper/workspace/resolver.py
@@ -140,6 +140,10 @@ from automated_security_helper.core.exceptions import (
 from automated_security_helper.models.workspace import SkippedProjectReason
 from automated_security_helper.utils.path_containment import validate_contained_path
 from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.policy import (
+    policy_for_project,
+    resolve_workspace_policy,
+)
 from automated_security_helper.workspace.scanner_pins import PinVerdict, compare_pins
 from automated_security_helper.workspace.workspace_file import (
     WorkspaceDefinition,
@@ -599,10 +603,67 @@ def _assign_display_labels(projects: List[ProjectPlan]) -> None:
         )
 
 
+def _apply_workspace_policy(
+    definition: WorkspaceDefinition,
+    projects: List[ProjectPlan],
+    workspace_config: Optional[PathLike],
+) -> Optional[Path]:
+    """Resolve the workspace policy and fold it into every active project.
+
+    Runs AFTER the per-project configs are resolved, because the ceiling needs
+    each project's own threshold to combine with and the scanner classification
+    needs each project's scanner set. It runs after ``_validate_scanner_pins``
+    and ``_validate_plugin_modules`` too: a workspace that cannot be scanned at
+    all should say so rather than first complaining about a policy pattern.
+
+    Skipped projects are left alone. Applying a ceiling to a project that will
+    not be scanned would put a threshold in the plan for work that never
+    happens, and pushing a pattern into it could refuse the whole workspace over
+    a project nobody is looking at.
+
+    Returns:
+        The policy file that was applied, or ``None`` when there is no policy.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, for an unusable policy file or a
+            pattern with no sound rewrite for some project. The message names the
+            project as well as the pattern, because a workspace-level pattern is
+            legal in itself and only fails in combination with one project.
+    """
+    policy, source = resolve_workspace_policy(
+        definition.root,
+        explicit=workspace_config,
+        project_config_paths=[
+            Path(project.config_source)
+            for project in projects
+            if project.config_source
+        ],
+    )
+
+    for project in projects:
+        if project.skipped:
+            continue
+        resolved = policy_for_project(
+            policy.workspace if policy else None,
+            project_prefix=project.relative_path,
+            project_threshold=project.severity_threshold,
+            project_scanners=project.scanners,
+        )
+        project.effective_severity_threshold = resolved.effective_threshold
+        project.threshold_tightened_by_policy = resolved.threshold_tightened
+        project.policy_suppressions = list(resolved.suppressions)
+        project.policy_ignore_paths = list(resolved.ignore_paths)
+        project.policy_scanners = list(resolved.policy_scanners)
+        project.policy_scanners_gate = resolved.policy_scanners_gate
+
+    return source
+
+
 def resolve_workspace(
     workspace_file: PathLike,
     *,
     allow_missing_projects: bool = False,
+    workspace_config: Optional[PathLike] = None,
 ) -> WorkspacePlan:
     """Resolve and validate a workspace, returning an inspectable plan.
 
@@ -615,6 +676,11 @@ def resolve_workspace(
             absent or unreadable. Those projects are marked skipped and recorded
             in the plan's ``skipped_projects`` payload. Does not opt out of any
             other check -- see "Fail-closed" in the module docstring.
+        workspace_config: ``--workspace-config``: the workspace policy file to
+            apply. When omitted the workspace root is searched for one, and
+            having none is not an error. When given it must exist; ASH does not
+            fall back to searching, because that would apply different policy
+            than the one named. It may not be any project's own config.
 
     Returns:
         A :class:`~automated_security_helper.workspace.plan.WorkspacePlan` with
@@ -684,10 +750,14 @@ def resolve_workspace(
     _validate_scanner_pins(definition, active)
     _validate_plugin_modules(definition, active)
     _assign_display_labels(projects)
+    policy_source = _apply_workspace_policy(definition, projects, workspace_config)
 
     return WorkspacePlan(
         workspace_file=definition.path.as_posix(),
         workspace_root=definition.root.as_posix(),
+        workspace_config_source=(
+            policy_source.as_posix() if policy_source is not None else None
+        ),
         projects=projects,
         allow_missing_projects=allow_missing_projects,
     )

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -116,6 +116,7 @@ ash [options]
 | `--phases`                    | Phases to run: `convert`, `scan`, `report`, `inspect`   | `convert,scan,report` |                         |
 | `--inspect`                   | Enable inspection of SARIF fields                       | `False`               |                         |
 | `--workspace`                 | Path to a `.code-workspace` file, or `auto` to find the one in the current directory. Mutually exclusive with `--source-dir` | None | `ASH_WORKSPACE` |
+| `--workspace-config`          | Path to the workspace policy file. Defaults to `ash-workspace.{yaml,yml,json}` in the workspace root or its `.ash` directory | None | `ASH_WORKSPACE_CONFIG` |
 | `--allow-missing-projects`    | Skip workspace projects that are absent or unreadable   | `False`               |                         |
 | `--dry-run`                   | Print the resolved workspace plan and exit without scanning | `False`           |                         |
 
@@ -137,6 +138,39 @@ Folder paths are relative to the directory holding the workspace file, which bec
 `--workspace` and `--source-dir` cannot be combined. Note that `ASH_SOURCE_DIR` counts as setting `--source-dir`.
 
 `--dry-run` resolves and validates the workspace, prints the resulting plan, and exits 0 without scanning anything. Without it, the same plan is what gets scanned — resolved once, so what you inspect is what runs.
+
+#### Workspace policy
+
+Each project is judged against its own configuration, so there is nowhere in a project's config to say something about the workspace as a whole. That goes in a workspace policy file, which ASH looks for at `ash-workspace.yaml` (or `.yml`/`.json`) in the workspace root or its `.ash` directory. Having none is not an error.
+
+```yaml
+workspace:
+  # The LOOSEST threshold any project may use. A stricter project keeps its own.
+  max_severity_threshold: MEDIUM
+  # Paths are workspace-relative and are rewritten per project.
+  suppressions:
+    - path: services/api/src/legacy.py
+      rule_id: B101
+      reason: tracked in TICKET-1
+  ignore_paths:
+    - path: '**/vendor'
+      reason: third-party code
+  # Additive: a project cannot be made to run fewer scanners than it enables.
+  additional_scanners:
+    - bandit
+  # Whether findings from scanners added above affect a project's exit code.
+  policy_scanners_gate: false
+```
+
+The policy file must be a **different file** from any project's ASH config. When the workspace root is itself a project, `.ash/ash.yaml` there is that project's config and keeps meaning exactly that; policy goes in `.ash/ash-workspace.yaml`, or in any file named with `--workspace-config`. Pointing `--workspace-config` at a project's config exits 4 and names the file, because workspace policy governs every project and reading one project's config as policy would apply its settings to its siblings.
+
+`max_severity_threshold` is a ceiling on permissiveness, not on severity. The strictness order is `ALL` (strictest) through `CRITICAL` (loosest), so *raising* this value loosens it. A project's effective threshold is whichever of its own setting and this ceiling is stricter: a project at `CRITICAL` under a `MEDIUM` ceiling is judged at `MEDIUM`, while a project already at `LOW` is left alone. `--dry-run` prints both values for any project the ceiling moved, so you can see what it changed before running a scan.
+
+One limitation is worth knowing before relying on the ceiling. It tightens findings that carry a severity. A finding that carries only a SARIF `error` level is treated as critical and stays actionable at every threshold, so no ceiling excludes it — this is not specific to workspace mode, and `severity_threshold` behaves the same way in a single-project scan. In practice it means the ceiling cannot quieten checkov, which reports no per-finding severity.
+
+Suppressions and ignore paths are written workspace-relative and pushed down into each project's own coordinates. A pattern that cannot match inside a project is not applied there, so `services/api/src/legacy.py` silences nothing in `shared-infra`. A pattern with no exact per-project equivalent is refused with exit 4 rather than approximated, because a suppression that matches more than intended hides findings and leaves nothing in the output to show what went missing. `**/vendor` works; `**/vendor/**` is refused, and the error names the pattern and the project.
+
+Scanners in `additional_scanners` that a project already enables run under that project's own configuration and their findings are the project's. Scanners only the policy adds run with default configuration, are reported separately as `origin: workspace-policy`, and do not affect the project's exit code unless `policy_scanners_gate: true`.
 
 #### What each project gets
 

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -168,6 +168,14 @@ The policy file must be a **different file** from any project's ASH config. When
 
 One limitation is worth knowing before relying on the ceiling. It tightens findings that carry a severity. A finding that carries only a SARIF `error` level is treated as critical and stays actionable at every threshold, so no ceiling excludes it — this is not specific to workspace mode, and `severity_threshold` behaves the same way in a single-project scan. In practice it means the ceiling cannot quieten checkov, which reports no per-finding severity.
 
+Rather than leave that as a caveat to remember, ASH measures it. When the ceiling tightens a project and some of that project's findings were beyond the tightening's reach, the project's entry in `ash_aggregated_results.json` carries `ceiling_unreachable_findings` — a count per scanner:
+
+```json
+"ceiling_unreachable_findings": { "checkov": 7 }
+```
+
+Read it as a statement about those findings, not about the scanner: seven findings in this project carry no severity, so the ceiling did not change their verdict. It is recomputed on every scan from the findings actually present, so it disappears if a scanner starts reporting severity, and it is absent entirely when the ceiling either did not tighten the project or reached everything it needed to.
+
 Suppressions and ignore paths are written workspace-relative and pushed down into each project's own coordinates. A pattern that cannot match inside a project is not applied there, so `services/api/src/legacy.py` silences nothing in `shared-infra`. A pattern with no exact per-project equivalent is refused with exit 4 rather than approximated, because a suppression that matches more than intended hides findings and leaves nothing in the output to show what went missing. `**/vendor` works; `**/vendor/**` is refused, and the error names the pattern and the project.
 
 Scanners in `additional_scanners` that a project already enables run under that project's own configuration and their findings are the project's. Scanners only the policy adds run with default configuration, are reported separately as `origin: workspace-policy`, and do not affect the project's exit code unless `policy_scanners_gate: true`.

--- a/scripts/verify_workspace_policy.py
+++ b/scripts/verify_workspace_policy.py
@@ -1,0 +1,385 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove workspace policy on a real scan, not on mocks.
+
+Why this script exists
+----------------------
+The unit suite drives ``policy_for_project`` and ``resolve_workspace`` directly,
+and ``tests/unit/workspace/test_execution.py`` drives the executor against a fake
+orchestrator. None of that runs a scanner. So none of it can catch the failure
+this feature is most exposed to: policy that resolves correctly, appears in the
+plan, and then changes no verdict because the value never reaches the code that
+counts actionable findings. That defect passes every mock-based test.
+
+This runs ``ash --workspace`` for real, twice over the same fixture -- once with
+no policy and once with a ceiling -- and compares the two verdicts. Only a real
+scan can show the ceiling moved a real finding count.
+
+What it asserts, and why each one is here
+-----------------------------------------
+1. **A project looser than the ceiling is tightened.** The lax project passes on
+   its own and fails under the ceiling, over an identical finding set. This is
+   the assertion that fails if the ceiling is decorative.
+2. **A stricter project is untouched.** Its actionable count is the same in both
+   runs. Without this, "the ceiling replaced every threshold" would pass (1).
+3. **A workspace suppression is pushed into one project and not another.**
+   Checked on the resolved plan, because the suppression list is per project
+   there; see the limitation below for why it is not yet checked on findings.
+4. **An unrewritable pattern refuses with exit 4** and names the pattern.
+
+The positive control
+--------------------
+Assertion 1 is only meaningful if the lax project HAS findings that sit between
+the two thresholds. A fixture that produced no findings at all would satisfy
+"passes without the ceiling" trivially and then fail (1) for the wrong reason, or
+worse, satisfy both arms vacuously. So the script first asserts the baseline run
+found a non-zero number of findings in the lax project and that its actionable
+count is zero; if either is untrue it reports the fixture as broken rather than
+reporting a policy result.
+
+Known limitations
+-----------------
+* Assertion 3 stops at the plan. ``workspace.suppressions`` do not yet reach the
+  scanners -- see "Where policy enters" in ``workspace/execution.py`` for the
+  orchestrator constraint -- so a findings-level check would fail for a reason
+  that is not about the push-down.
+* ``additional_scanners`` is not exercised end to end for the same reason.
+* The fixture uses bandit only, because it is the scanner ASH ships that emits
+  ``properties.issue_severity``. A ceiling cannot tighten a level-only scanner
+  such as checkov (see ``utils/severity_ladder.py``), so building the fixture on
+  checkov would measure the limitation instead of the feature.
+* Findings come from real bandit rules, so a bandit release can change the
+  counts. The script asserts relationships between the two runs rather than
+  absolute numbers, so a version bump changes what is scanned but not whether the
+  assertions hold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - runs ash itself, argv-only, no shell
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# A finding bandit rates MEDIUM severity, so it is actionable at MEDIUM and below
+# but not at HIGH or CRITICAL. That gap is what the ceiling is measured against.
+# Kept free of anything credential-shaped: ASH self-scans this repository and
+# detect-secrets matches line by line.
+LAX_SOURCE = """\
+import subprocess
+
+
+def run(target):
+    # B602: shell=True with a non-literal argument. Bandit rates this MEDIUM.
+    return subprocess.call("echo " + target, shell=True)
+"""
+
+STRICT_SOURCE = """\
+import subprocess
+
+
+def run(target):
+    return subprocess.call("echo " + target, shell=True)
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _project_config(threshold: str) -> str:
+    """A project config at *threshold* running bandit only.
+
+    Every other scanner is disabled to keep the run short and the finding set
+    attributable to one tool.
+    """
+    disabled = [
+        "cdk-nag",
+        "cfn-nag",
+        "checkov",
+        "detect-secrets",
+        "grype",
+        "npm-audit",
+        "opengrep",
+        "semgrep",
+        "syft",
+    ]
+    lines = [
+        "global_settings:",
+        f"  severity_threshold: {threshold}",
+        "scanners:",
+        "  bandit:",
+        "    enabled: true",
+    ]
+    for name in disabled:
+        lines.append(f"  {name}:")
+        lines.append("    enabled: false")
+    return "\n".join(lines) + "\n"
+
+
+def build_fixture(root: Path) -> Path:
+    """Create a two-project workspace: one lax at CRITICAL, one strict at LOW."""
+    _write(root / "lax" / "src" / "runner.py", LAX_SOURCE)
+    _write(root / "lax" / ".ash" / "ash.yaml", _project_config("CRITICAL"))
+
+    _write(root / "strict" / "src" / "runner.py", STRICT_SOURCE)
+    _write(root / "strict" / ".ash" / "ash.yaml", _project_config("LOW"))
+
+    workspace = root / "fixture.code-workspace"
+    workspace.write_text(
+        json.dumps({"folders": [{"path": "lax"}, {"path": "strict"}]}),
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def run_ash(
+    workspace: Path,
+    output_dir: Path,
+    policy: Path | None = None,
+) -> tuple[int, dict[str, Any], str]:
+    """Run a real workspace scan; return (exit code, workspace payload, output)."""
+    argv = [
+        sys.executable,
+        "-m",
+        # cli.main, not cli: the package has no __main__ and cannot be run.
+        "automated_security_helper.cli.main",
+        "scan",
+        "--workspace",
+        str(workspace),
+        "--output-dir",
+        str(output_dir),
+        "--phases",
+        "scan",
+        "--no-progress",
+        "--simple",
+    ]
+    if policy is not None:
+        argv += ["--workspace-config", str(policy)]
+
+    # cwd is the repository root and is passed to the child rather than set with
+    # os.chdir, matching verify_multi_project_attribution.py: this project
+    # deliberately removed process-wide cwd dependence.
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    env.setdefault("PYTHONUTF8", "1")
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parent.parent)
+
+    completed = subprocess.run(  # nosec B603 - argv list, no shell, argv[0] is sys.executable
+        argv,
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).resolve().parent.parent),
+        env=env,
+        # Explicitly not check=True. A non-zero exit is the expected result for
+        # most runs here: 2 when a project has actionable findings, 4 when the
+        # policy is deliberately malformed. Raising on it would turn the
+        # measurement into a crash.
+        check=False,
+    )
+    combined = completed.stdout + completed.stderr
+
+    results = output_dir / "ash_aggregated_results.json"
+    payload: dict[str, Any] = {}
+    if results.exists():
+        payload = json.loads(results.read_text(encoding="utf-8")).get("workspace", {})
+    return completed.returncode, payload, combined
+
+
+def _by_project(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entry["project"]: entry for entry in payload.get("projects", [])}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the scratch directory for inspection",
+    )
+    args = parser.parse_args()
+
+    scratch = Path(tempfile.mkdtemp(prefix="ash-policy-verify-"))
+    failures = []
+    checks = 0
+
+    def check(label: str, ok: bool, detail: str = "") -> None:
+        nonlocal checks
+        checks += 1
+        print(f"{'PASS' if ok else 'FAIL'}  {label}")
+        if detail:
+            print(f"        {detail}")
+        if not ok:
+            failures.append(label)
+
+    try:
+        workspace = build_fixture(scratch)
+
+        # ---- Run A: no policy -------------------------------------------------
+        code_a, payload_a, out_a = run_ash(workspace, scratch / "out-a")
+        projects_a = _by_project(payload_a)
+
+        if not projects_a:
+            print("FIXTURE BROKEN: run A produced no workspace payload")
+            print(out_a[-3000:])
+            return 3
+
+        lax_a = projects_a.get("lax", {})
+        strict_a = projects_a.get("strict", {})
+
+        # Positive control. Without findings in the gap between CRITICAL and
+        # MEDIUM, assertion 1 below would be vacuous.
+        check(
+            "fixture control: lax project reports findings",
+            lax_a.get("finding_count", 0) > 0,
+            f"finding_count={lax_a.get('finding_count')}",
+        )
+        check(
+            "fixture control: lax passes at its own CRITICAL threshold",
+            lax_a.get("actionable_finding_count") == 0,
+            f"actionable={lax_a.get('actionable_finding_count')}",
+        )
+        check(
+            "fixture control: strict fails at its own LOW threshold",
+            (strict_a.get("actionable_finding_count") or 0) > 0,
+            f"actionable={strict_a.get('actionable_finding_count')}",
+        )
+
+        # ---- Run B: MEDIUM ceiling -------------------------------------------
+        policy = _write(
+            scratch / ".ash" / "ash-workspace.yaml",
+            "workspace:\n"
+            "  max_severity_threshold: MEDIUM\n"
+            "  suppressions:\n"
+            "    - path: lax/src/runner.py\n"
+            "      reason: verification fixture\n",
+        )
+        code_b, payload_b, out_b = run_ash(workspace, scratch / "out-b", policy=policy)
+        projects_b = _by_project(payload_b)
+
+        if not projects_b:
+            print("FIXTURE BROKEN: run B produced no workspace payload")
+            print(out_b[-3000:])
+            return 3
+
+        lax_b = projects_b.get("lax", {})
+        strict_b = projects_b.get("strict", {})
+
+        # 1. The ceiling tightened the lax project.
+        check(
+            "ceiling tightens a lax project: actionable rises above zero",
+            (lax_b.get("actionable_finding_count") or 0) > 0,
+            f"without policy={lax_a.get('actionable_finding_count')}, "
+            f"with MEDIUM ceiling={lax_b.get('actionable_finding_count')}",
+        )
+        check(
+            "ceiling tightens a lax project: verdict flips to failing",
+            lax_a.get("exceeds_threshold") is False
+            and lax_b.get("exceeds_threshold") is True,
+            f"exceeds_threshold {lax_a.get('exceeds_threshold')} -> "
+            f"{lax_b.get('exceeds_threshold')}",
+        )
+        check(
+            "the enforced threshold is reported, not the declared one",
+            lax_b.get("severity_threshold") == "MEDIUM",
+            f"reported={lax_b.get('severity_threshold')} (declared CRITICAL)",
+        )
+
+        # 2. The stricter project is untouched.
+        check(
+            "stricter project untouched: same actionable count both runs",
+            strict_a.get("actionable_finding_count")
+            == strict_b.get("actionable_finding_count"),
+            f"{strict_a.get('actionable_finding_count')} -> "
+            f"{strict_b.get('actionable_finding_count')}",
+        )
+        check(
+            "stricter project untouched: still judged at its own LOW",
+            strict_b.get("severity_threshold") == "LOW",
+            f"reported={strict_b.get('severity_threshold')}",
+        )
+
+        # 3. Suppression scoping, on the resolved plan.
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from automated_security_helper.workspace.resolver import resolve_workspace
+
+        plan = resolve_workspace(workspace, workspace_config=policy)
+        by_key = {p.key: p for p in plan.projects}
+        check(
+            "workspace suppression is pushed into the project it names",
+            [s.path for s in by_key["lax"].policy_suppressions] == ["src/runner.py"],
+            f"lax={[s.path for s in by_key['lax'].policy_suppressions]}",
+        )
+        check(
+            "workspace suppression is NOT passed to the other project",
+            by_key["strict"].policy_suppressions == [],
+            f"strict={[s.path for s in by_key['strict'].policy_suppressions]}",
+        )
+        check(
+            "the plan records which policy file was applied",
+            plan.workspace_config_source == policy.resolve().as_posix(),
+            f"source={plan.workspace_config_source}",
+        )
+
+        # 4. An unrewritable pattern refuses with exit 4.
+        bad_policy = _write(
+            scratch / "bad-policy.yaml",
+            "workspace:\n"
+            "  suppressions:\n"
+            "    - path: '*/sub/*.py'\n"
+            "      reason: no sound rewrite\n",
+        )
+        code_c, _, out_c = run_ash(workspace, scratch / "out-c", policy=bad_policy)
+        check(
+            "an unrewritable policy pattern exits 4",
+            code_c == 4,
+            f"exit={code_c}",
+        )
+        check(
+            "the refusal names the offending pattern",
+            "*/sub/*.py" in out_c,
+            "pattern quoted in output" if "*/sub/*.py" in out_c else out_c[-400:],
+        )
+
+        # A project config may not double as the policy file.
+        code_d, _, _ = run_ash(
+            workspace,
+            scratch / "out-d",
+            policy=scratch / "lax" / ".ash" / "ash.yaml",
+        )
+        check(
+            "naming a project config as the policy file exits 4",
+            code_d == 4,
+            f"exit={code_d}",
+        )
+
+        print()
+        print(
+            f"Results: {checks - len(failures)} passed, {len(failures)} failed, "
+            f"{checks} total"
+        )
+        print(f"Baseline run exit={code_a}, ceiling run exit={code_b}")
+        if failures:
+            print("\nFailed checks:")
+            for label in failures:
+                print(f"  - {label}")
+            return 1
+        print("\nWorkspace policy verified end to end on a real scan.")
+        return 0
+    finally:
+        if args.keep:
+            print(f"\nScratch kept at {scratch}")
+        else:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_workspace_policy.py
+++ b/scripts/verify_workspace_policy.py
@@ -23,13 +23,20 @@ What it asserts, and why each one is here
    the assertion that fails if the ceiling is decorative.
 2. **A stricter project is untouched.** Its actionable count is the same in both
    runs. Without this, "the ceiling replaced every threshold" would pass (1).
-3. **A workspace suppression is pushed into one project and not another.**
+3. **The ceiling's reach is disclosed where it fell short.** The iac project's
+   checkov findings carry no severity, so they are judged from the SARIF level
+   and stay actionable at every threshold; the ceiling cannot reach them and
+   ``ceiling_unreachable_findings`` says so per scanner. The baseline run must
+   disclose nothing, and so must the project the ceiling did reach -- a
+   disclosure that appears unconditionally is noise and gets ignored.
+4. **A workspace suppression is pushed into one project and not another.**
    Checked on the resolved plan, because the suppression list is per project
    there; see the limitation below for why it is not yet checked on findings.
-4. **An unrewritable pattern refuses with exit 4** and names the pattern.
+5. **An unrewritable pattern refuses with exit 4** and names the pattern, as
+   does a project config passed as the policy file.
 
-The positive control
---------------------
+Two positive controls
+---------------------
 Assertion 1 is only meaningful if the lax project HAS findings that sit between
 the two thresholds. A fixture that produced no findings at all would satisfy
 "passes without the ceiling" trivially and then fail (1) for the wrong reason, or
@@ -38,21 +45,29 @@ found a non-zero number of findings in the lax project and that its actionable
 count is zero; if either is untrue it reports the fixture as broken rather than
 reporting a policy result.
 
+Assertion 3 has the same hazard from the other direction: with no checkov
+findings, "the ceiling could not reach them" and "there was nothing to reach"
+are indistinguishable. So the disclosure checks are skipped with a printed note
+when checkov reports nothing, rather than passing on an empty set.
+
 Known limitations
 -----------------
-* Assertion 3 stops at the plan. ``workspace.suppressions`` do not yet reach the
+* Assertion 4 stops at the plan. ``workspace.suppressions`` do not yet reach the
   scanners -- see "Where policy enters" in ``workspace/execution.py`` for the
   orchestrator constraint -- so a findings-level check would fail for a reason
   that is not about the push-down.
 * ``additional_scanners`` is not exercised end to end for the same reason.
-* The fixture uses bandit only, because it is the scanner ASH ships that emits
-  ``properties.issue_severity``. A ceiling cannot tighten a level-only scanner
-  such as checkov (see ``utils/severity_ladder.py``), so building the fixture on
-  checkov would measure the limitation instead of the feature.
-* Findings come from real bandit rules, so a bandit release can change the
-  counts. The script asserts relationships between the two runs rather than
-  absolute numbers, so a version bump changes what is scanned but not whether the
-  assertions hold.
+* Two scanners are used, and which one is deliberate. bandit is the ASH-shipped
+  scanner that emits ``properties.issue_severity``, so it measures the ceiling
+  working; checkov emits none, so it measures the ceiling's limit. Building every
+  assertion on one of them would measure only half the behaviour.
+* Findings come from real bandit and checkov rules, so a release of either can
+  change the counts. The script asserts relationships between the two runs, and
+  the presence rather than the size of the disclosure, so a version bump changes
+  what is scanned but not whether the assertions hold.
+* checkov must be installed for assertion 3 to run. It is skipped with a note
+  rather than failed when checkov reports nothing, so an environment without it
+  does not produce a false failure -- but it also does not produce a false pass.
 """
 
 from __future__ import annotations
@@ -88,6 +103,16 @@ def run(target):
     return subprocess.call("echo " + target, shell=True)
 """
 
+# Terraform checkov flags, used to exercise the level-only case. checkov emits no
+# properties.issue_severity, so these findings are judged from the SARIF level,
+# where `error` is read as critical and stays actionable at every threshold. That
+# is what the ceiling cannot reach, and what the disclosure has to report.
+IAC_SOURCE = """\
+resource "aws_s3_bucket" "example" {
+  bucket = "policy-verification-fixture"
+}
+"""
+
 
 def _write(path: Path, text: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -95,47 +120,61 @@ def _write(path: Path, text: str) -> Path:
     return path
 
 
-def _project_config(threshold: str) -> str:
-    """A project config at *threshold* running bandit only.
+_ALL_SCANNERS = [
+    "bandit",
+    "cdk-nag",
+    "cfn-nag",
+    "checkov",
+    "detect-secrets",
+    "grype",
+    "npm-audit",
+    "opengrep",
+    "semgrep",
+    "syft",
+]
 
-    Every other scanner is disabled to keep the run short and the finding set
-    attributable to one tool.
+
+def _project_config(threshold: str, keep: str = "bandit") -> str:
+    """A project config at *threshold* running only the *keep* scanner.
+
+    Everything else is disabled to keep the run short and the finding set
+    attributable to one tool -- which also makes the per-scanner disclosure
+    unambiguous.
     """
-    disabled = [
-        "cdk-nag",
-        "cfn-nag",
-        "checkov",
-        "detect-secrets",
-        "grype",
-        "npm-audit",
-        "opengrep",
-        "semgrep",
-        "syft",
-    ]
     lines = [
         "global_settings:",
         f"  severity_threshold: {threshold}",
         "scanners:",
-        "  bandit:",
-        "    enabled: true",
     ]
-    for name in disabled:
+    for name in _ALL_SCANNERS:
         lines.append(f"  {name}:")
-        lines.append("    enabled: false")
+        lines.append(f"    enabled: {'true' if name == keep else 'false'}")
     return "\n".join(lines) + "\n"
 
 
 def build_fixture(root: Path) -> Path:
-    """Create a two-project workspace: one lax at CRITICAL, one strict at LOW."""
+    """Create the three-project workspace the assertions are written against.
+
+    lax at CRITICAL with a severity-carrying bandit finding -- the ceiling reaches
+    it. strict at LOW -- the ceiling must not loosen it. iac at CRITICAL with
+    level-only checkov findings -- the ceiling cannot reach those, which is what
+    the disclosure has to report.
+    """
     _write(root / "lax" / "src" / "runner.py", LAX_SOURCE)
     _write(root / "lax" / ".ash" / "ash.yaml", _project_config("CRITICAL"))
 
     _write(root / "strict" / "src" / "runner.py", STRICT_SOURCE)
     _write(root / "strict" / ".ash" / "ash.yaml", _project_config("LOW"))
 
+    _write(root / "iac" / "main.tf", IAC_SOURCE)
+    _write(
+        root / "iac" / ".ash" / "ash.yaml",
+        _project_config("CRITICAL", keep="checkov"),
+    )
+
     workspace = root / "fixture.code-workspace"
     workspace.write_text(
-        json.dumps({"folders": [{"path": "lax"}, {"path": "strict"}]}),
+        json.dumps({"folders": [{"path": "lax"}, {"path": "strict"}, {"path": "iac"}]}),
         encoding="utf-8",
     )
     return workspace
@@ -306,6 +345,43 @@ def main() -> int:
             strict_b.get("severity_threshold") == "LOW",
             f"reported={strict_b.get('severity_threshold')}",
         )
+
+        # 2b. The ceiling's reach, disclosed from the findings actually present.
+        iac_a = projects_a.get("iac", {})
+        iac_b = projects_b.get("iac", {})
+        unreachable_b = iac_b.get("ceiling_unreachable_findings") or {}
+        unreachable_a = iac_a.get("ceiling_unreachable_findings") or {}
+
+        if not iac_a.get("finding_count"):
+            print(
+                "FIXTURE NOTE: checkov produced no findings for the iac project; "
+                "skipping the disclosure checks rather than asserting vacuously"
+            )
+            print(f"        iac finding_count={iac_a.get('finding_count')}")
+        else:
+            check(
+                "level-only findings stay actionable at CRITICAL (the limitation)",
+                (iac_a.get("actionable_finding_count") or 0) > 0,
+                f"at declared CRITICAL: actionable="
+                f"{iac_a.get('actionable_finding_count')} of "
+                f"{iac_a.get('finding_count')} findings",
+            )
+            check(
+                "the ceiling could not tighten them, and says so per scanner",
+                bool(unreachable_b) and "checkov" in unreachable_b,
+                f"ceiling_unreachable_findings={unreachable_b}",
+            )
+            check(
+                "no disclosure without a ceiling, so it stays load-bearing",
+                unreachable_a == {},
+                f"baseline run disclosure={unreachable_a}",
+            )
+            check(
+                "the project the ceiling DID reach discloses nothing",
+                (projects_b.get("lax", {}).get("ceiling_unreachable_findings") or {})
+                == {},
+                "lax carries severity, so there is nothing to qualify",
+            )
 
         # 3. Suppression scoping, on the resolved plan.
         sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -232,20 +232,37 @@ def pytest_collection_modifyitems(config, items):
     test file gives no hint it will be skipped, and the conftest that skips it
     lives in an unrelated directory the author had no reason to read. A green
     suite plus a skip count nobody diffs is all the signal there was.
+
+    The same defect survived that fix in the ``integration`` marker, which kept
+    testing ``"integration" in str(item.fspath)`` while only the slow rules were
+    scoped -- with a comment saying the substring form would reach the whole repo
+    again. It did: a unit test at
+    ``tests/unit/workspace/test_workspace_policy_resolution.py``, originally
+    named ``..._integration.py``, had all fourteen of its tests skipped in a full
+    run while passing when the file was run on its own. Fixing one instance of a
+    pattern and documenting it is not the same as removing the pattern, so the
+    ``integration`` marker now hangs off the same path scoping as everything
+    else. Detected by diffing the skipped-test IDs against a baseline, which is
+    the only signal this failure emits.
     """
     integration_root = Path(__file__).resolve().parent.parent
 
     for item in items:
-        path = str(item.fspath)
-        if "integration" in path:
-            item.add_marker(pytest.mark.integration)
-
-        # Scoped to the integration tree, which is what these heuristics are
+        # Scoped to the integration tree, which is what every heuristic below is
         # about. Compared against a resolved path rather than by substring: a
-        # substring test is how the unscoped version reached the whole repo, and
-        # "integration" appears in enough unrelated paths to do it again.
+        # substring test is how the unscoped version reached the whole repo.
         if not Path(item.fspath).resolve().is_relative_to(integration_root):
             continue
+
+        # What makes a test an integration test is living in this tree, not
+        # having "integration" in its path. The previous version tested the
+        # substring and so marked -- and therefore skipped -- any test anywhere
+        # in the repository whose path happened to contain the word. That is the
+        # same defect this hook's docstring describes for the slow marker, left
+        # in place when that one was fixed; a unit test named
+        # test_workspace_policy_integration.py hit it and its fourteen tests
+        # were silently skipped in the full suite while passing in isolation.
+        item.add_marker(pytest.mark.integration)
 
         # Add slow marker to tests that might take longer
         if any(

--- a/tests/unit/workspace/test_execution.py
+++ b/tests/unit/workspace/test_execution.py
@@ -280,6 +280,73 @@ class TestPerProjectThresholds:
         verdicts = {p.project: p.exceeds_threshold for p in outcome.payload.projects}
         assert verdicts == {"strict": True, "lax": False}
 
+    def test_a_workspace_ceiling_makes_a_lax_project_fail(self, tmp_path):
+        """The ceiling has to change the VERDICT, not just the plan.
+
+        api declares CRITICAL, so on its own a warning-level finding is not
+        actionable -- test_a_project_below_its_own_threshold_passes above is that
+        exact case. Under a MEDIUM ceiling the same finding must fail. If
+        execution read severity_threshold instead of the effective value, this
+        test would see exit 0 and the ceiling would be decorative.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.exceeds_threshold is True
+        assert outcome.exit_code == WorkspaceExitCode.ACTIONABLE_FINDINGS
+        # The reported threshold is the one actually enforced, or a reader
+        # comparing the finding against it would conclude ASH had miscounted.
+        assert entry.severity_threshold == "MEDIUM"
+
+    def test_a_ceiling_does_not_loosen_a_stricter_project(self, tmp_path):
+        """The other direction, since a ceiling that replaced would pass here.
+
+        strict declares LOW and the ceiling is CRITICAL. stricter_of keeps LOW,
+        so the warning stays actionable. An implementation that let the ceiling
+        win would report exit 0 for a project the operator set to LOW.
+        """
+        _, plan = _make_workspace(tmp_path, ("strict", "LOW"))
+        project = plan.projects[0]
+        # What resolution produces for a project already stricter than the
+        # ceiling: unchanged, and not flagged as tightened.
+        project.effective_severity_threshold = "LOW"
+        project.threshold_tightened_by_policy = False
+        FakeOrchestrator.behaviour["strict"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.exceeds_threshold is True
+        assert entry.severity_threshold == "LOW"
+
+    def test_a_plan_with_no_effective_threshold_falls_back_to_the_projects_own(
+        self, tmp_path
+    ):
+        """Plans built outside resolve_workspace never set the effective value.
+
+        plan.py's docstring says a hand-built plan can hold states resolution
+        would not produce, and the executor is given plans by tests and by
+        callers that predate this field. Falling back keeps those judged by their
+        own threshold rather than by None, which would turn the gate off.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "LOW"))
+        assert plan.projects[0].effective_severity_threshold is None
+
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.severity_threshold == "LOW"
+
     def test_the_aggregate_exit_code_reflects_the_strictest_failing_project(
         self, tmp_path
     ):

--- a/tests/unit/workspace/test_execution.py
+++ b/tests/unit/workspace/test_execution.py
@@ -347,6 +347,135 @@ class TestPerProjectThresholds:
         assert entry.actionable_finding_count == 1
         assert entry.severity_threshold == "LOW"
 
+    def test_the_per_scanner_rollup_agrees_with_the_project_total_under_a_ceiling(
+        self, tmp_path
+    ):
+        """Two derivations of one number must not disagree once policy applies.
+
+        The project's actionable count is computed from the effective threshold,
+        while the workspace rollup splits it per scanner. If the split is derived
+        from the DECLARED threshold instead, the two disagree the moment a ceiling
+        tightens anything -- the per-scanner numbers sum to 0 while the project
+        says 1, and a reader has no rule for which to trust.
+
+        This is the failure the ceiling wiring introduces if the split is missed,
+        so it is asserted as an equality between the two payloads rather than
+        against a literal.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        # Control: the ceiling really did make this actionable, or the equality
+        # below would hold trivially at 0 == 0 and prove nothing.
+        assert entry.actionable_finding_count == 1
+
+        # Read the written file: scanner_results is a top-level key of the
+        # aggregated report, not a field of WorkspaceResults, and the file is what
+        # a consumer actually reads.
+        written = json.loads(
+            (tmp_path / "out" / "ash_aggregated_results.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rollup = {
+            name: (value or {}).get("actionable_finding_count", 0)
+            for name, value in (written.get("scanner_results") or {}).items()
+        }
+        assert sum(rollup.values()) == entry.actionable_finding_count, rollup
+
+    def test_a_tightened_project_discloses_findings_the_ceiling_could_not_reach(
+        self, tmp_path
+    ):
+        """The mechanised form of the documented limitation, on the outcome.
+
+        A level-only `error` is read as critical by both threshold gates, so
+        tightening CRITICAL to MEDIUM changes nothing for it. The project still
+        fails -- correctly -- but the operator needs to know the ceiling is not
+        what made it fail, or they will conclude the ceiling works on findings it
+        never touched.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        assert entry.ceiling_unreachable_findings == {"bandit": 1}
+
+    def test_an_untightened_project_discloses_nothing(self, tmp_path):
+        """Load-bearing only. The same finding, no ceiling, no disclosure.
+
+        Without this the disclosure would appear on every scan carrying a
+        level-only finding, and a message that always appears is one nobody
+        reads.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        # Control: the finding IS present and actionable, so the empty disclosure
+        # is a decision rather than an absence of input.
+        assert entry.actionable_finding_count == 1
+        assert entry.ceiling_unreachable_findings == {}
+
+    def test_the_disclosure_follows_the_tightened_flag_not_just_the_thresholds(
+        self, tmp_path
+    ):
+        """Pins the execution-level guard, which is otherwise indistinguishable.
+
+        ceiling_unreachable_counts short-circuits on equal thresholds, so for any
+        plan resolve_workspace builds -- where the flag and the two thresholds are
+        set together and cannot disagree -- either guard alone suffices, and
+        removing the one in execution.py leaves every other test green. That was
+        measured, not assumed.
+
+        This constructs the one state where they disagree: differing thresholds
+        with the flag false, which plan.py's docstring says a hand-built plan may
+        hold. The flag is the record of whether policy moved this project, so it
+        is what the disclosure follows.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = False
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+
+        # Control: the finding is present and the thresholds DO differ, so the
+        # empty disclosure is the flag's doing and not a missing input.
+        assert entry.actionable_finding_count == 1
+        assert project.severity_threshold != project.effective_severity_threshold
+        assert entry.ceiling_unreachable_findings == {}
+
+    def test_a_tightened_project_whose_findings_the_ceiling_reached_discloses_nothing(
+        self, tmp_path
+    ):
+        """The other load-bearing arm: tightening happened AND it worked.
+
+        A severity-carrying MEDIUM finding is exactly what the ceiling is for, so
+        there is nothing to qualify. Distinguishes "we disclose whenever tightened"
+        from "we disclose when tightening fell short".
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        sarif = _sarif(level="warning")
+        sarif["runs"][0]["results"][0]["properties"]["issue_severity"] = "MEDIUM"
+        FakeOrchestrator.behaviour["api"] = {"sarif": sarif}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        assert entry.actionable_finding_count == 1
+        assert entry.ceiling_unreachable_findings == {}
+
     def test_the_aggregate_exit_code_reflects_the_strictest_failing_project(
         self, tmp_path
     ):

--- a/tests/unit/workspace/test_workspace_policy.py
+++ b/tests/unit/workspace/test_workspace_policy.py
@@ -38,6 +38,7 @@ from automated_security_helper.models.core import (
 )
 from automated_security_helper.workspace.policy import (
     WORKSPACE_POLICY_FILE_NAMES,
+    ceiling_unreachable_counts,
     policy_for_project,
     resolve_workspace_policy,
 )
@@ -579,6 +580,158 @@ def test_a_policy_file_with_an_unknown_key_is_refused_naming_the_file(tmp_path):
     with pytest.raises(WorkspaceDefinitionError) as excinfo:
         resolve_workspace_policy(tmp_path)
     assert path.name in str(excinfo.value)
+
+
+def test_an_unsubstituted_env_placeholder_refuses_rather_than_disabling_the_gate(
+    tmp_path,
+):
+    """The policy loader does no ${VAR} substitution, and that must fail CLOSED.
+
+    AshConfig.from_file resolves ${VAR} in its YAML; this loader deliberately
+    does not, because a ceiling an environment variable can loosen is not a
+    ceiling. The danger is the failure MODE, not the missing feature: if
+    '${THRESH}' were accepted and then read as an unrecognised threshold, the
+    ladder would gate it like CRITICAL -- the loosest setting -- and the operator
+    would have no ceiling while believing they had one. It must refuse instead.
+    """
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: ${ASH_THRESHOLD}\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+
+    message = str(excinfo.value)
+    assert "ash-workspace.yaml" in message
+    # The message has to show the value that was rejected, or an operator with a
+    # templated CI config cannot tell substitution never happened.
+    assert "ASH_THRESHOLD" in message
+
+
+def test_an_env_placeholder_is_not_silently_substituted_from_the_environment(
+    tmp_path, monkeypatch
+):
+    """Companion to the above: even with the variable SET, it must not expand.
+
+    Without this, the previous test would pass for the wrong reason on a machine
+    where the variable happens to be unset, and the loader could quietly gain
+    substitution later without any test noticing.
+    """
+    monkeypatch.setenv("ASH_THRESHOLD", "CRITICAL")
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: ${ASH_THRESHOLD}\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError):
+        resolve_workspace_policy(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 6. The ceiling's reach, disclosed from the findings actually present
+# ---------------------------------------------------------------------------
+
+
+def _finding(level="error", issue_severity=None, scanner="checkov"):
+    result = {"ruleId": "R1", "level": level, "properties": {}}
+    if scanner is not None:
+        result["properties"]["scanner_name"] = scanner
+    if issue_severity is not None:
+        result["properties"]["issue_severity"] = issue_severity
+    return result
+
+
+def test_a_level_only_error_finding_is_reported_as_beyond_the_ceilings_reach():
+    """The measured limitation, disclosed per scanner from the findings.
+
+    An `error` with no issue_severity is treated as CRITICAL by both threshold
+    gates, so it is actionable at every threshold and tightening CRITICAL to
+    MEDIUM changes nothing for it.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", scanner="checkov")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {"checkov": 1}
+
+
+def test_a_severity_carrying_finding_is_not_reported():
+    """The ceiling reaches it, so there is nothing to disclose.
+
+    bandit's MEDIUM finding is not actionable at CRITICAL and is actionable at
+    MEDIUM, so the tightening did exactly what it says.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="warning", issue_severity="MEDIUM", scanner="bandit")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_a_genuinely_critical_finding_is_not_reported_as_unreachable():
+    """It is actionable at both thresholds, but that is correct, not a limitation.
+
+    Reporting it would tell the operator the ceiling failed on a finding the
+    ceiling was never meant to change. The discriminator is the ABSENCE of
+    issue_severity, not sameness of verdict alone.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", issue_severity="CRITICAL", scanner="bandit")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_nothing_is_reported_when_the_ceiling_did_not_tighten():
+    """Load-bearing only: no tightening means there is no claim to qualify."""
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", scanner="checkov")],
+        declared_threshold="MEDIUM",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_a_suppressed_finding_is_not_reported():
+    """It is not actionable at any threshold, so the ceiling is irrelevant to it."""
+    suppressed = _finding(level="error", scanner="checkov")
+    suppressed["suppressions"] = [{"kind": "external"}]
+    counts = ceiling_unreachable_counts(
+        [suppressed],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_counts_are_split_per_scanner_and_unattributed_findings_are_named():
+    counts = ceiling_unreachable_counts(
+        [
+            _finding(scanner="checkov"),
+            _finding(scanner="checkov"),
+            _finding(scanner="cfn-nag"),
+            _finding(scanner=None),
+        ],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {"checkov": 2, "cfn-nag": 1, "unattributed": 1}
+
+
+def test_a_note_level_finding_the_ceiling_does_reach_is_not_reported():
+    """Not every level-only finding is beyond reach; only those whose verdict is
+    unchanged. A `note` is not actionable at CRITICAL and is actionable at LOW,
+    so tightening CRITICAL to LOW does affect it."""
+    counts = ceiling_unreachable_counts(
+        [_finding(level="note", scanner="checkov")],
+        declared_threshold="CRITICAL",
+        effective_threshold="LOW",
+    )
+    assert counts == {}
 
 
 def test_a_json_policy_file_is_read(tmp_path):

--- a/tests/unit/workspace/test_workspace_policy.py
+++ b/tests/unit/workspace/test_workspace_policy.py
@@ -1,0 +1,590 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the workspace-level policy file.
+
+These are the acceptance criteria for Phase 3 (criteria 7, 19, 20, 21).
+
+Two biases run through the whole file, and they point in opposite directions on
+purpose:
+
+* **The ceiling may only tighten.** ``max_severity_threshold`` names the loosest
+  a project may be, so a project that is already stricter is left exactly as it
+  was. A test that cannot tell "tightened" from "replaced" is worthless here,
+  so every threshold case asserts the untouched direction as well.
+* **A pushed-down pattern may only narrow.** A workspace suppression that ASH
+  cannot rewrite soundly for a project is refused, and one that cannot match
+  inside a project is not passed to it. Over-suppression is the dangerous
+  direction because a suppressed finding leaves no trace -- see
+  ``utils/workspace_paths.py``.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from automated_security_helper.config.ash_workspace_config import (
+    AshWorkspaceConfig,
+    WorkspacePolicyConfig,
+)
+from automated_security_helper.core.exceptions import (
+    WorkspaceDefinitionError,
+    WorkspacePatternError,
+)
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+from automated_security_helper.workspace.policy import (
+    WORKSPACE_POLICY_FILE_NAMES,
+    policy_for_project,
+    resolve_workspace_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy(**fields):
+    """A WorkspacePolicyConfig with *fields* set and everything else default."""
+    return WorkspacePolicyConfig(**fields)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _suppression(path, **extra):
+    return AshSuppression(path=path, reason="test", **extra)
+
+
+# ---------------------------------------------------------------------------
+# 1. The schema itself
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_policy_file_is_valid_and_carries_no_policy():
+    """A policy file that sets nothing must not invent a threshold.
+
+    Defaulting max_severity_threshold to MEDIUM here would silently tighten
+    every project in a workspace whose operator wrote an empty file.
+    """
+    config = AshWorkspaceConfig()
+    assert config.workspace.max_severity_threshold is None
+    assert config.workspace.suppressions == []
+    assert config.workspace.ignore_paths == []
+    assert config.workspace.additional_scanners == []
+    assert config.workspace.policy_scanners_gate is False
+
+
+def test_an_unknown_policy_key_is_refused():
+    """extra=forbid, so a typo is an error rather than a silently ignored key."""
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate(
+            {"workspace": {"max_severity_threshhold": "HIGH"}}
+        )
+
+
+def test_an_unknown_top_level_key_is_refused():
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate({"global_settings": {}})
+
+
+@pytest.mark.parametrize("value", ["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"])
+def test_every_ladder_value_is_accepted_as_a_ceiling(value):
+    config = AshWorkspaceConfig.model_validate(
+        {"workspace": {"max_severity_threshold": value}}
+    )
+    assert config.workspace.max_severity_threshold == value
+
+
+@pytest.mark.parametrize("value", ["medium", "SEVERE", "", "NONE"])
+def test_an_off_ladder_ceiling_is_refused(value):
+    """The ladder is case-sensitive, so 'medium' must not be accepted.
+
+    severity_ladder gates an unrecognised threshold like CRITICAL -- the
+    loosest setting -- so accepting 'medium' here would quietly turn a ceiling
+    the operator meant as MEDIUM into no ceiling at all.
+    """
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate(
+            {"workspace": {"max_severity_threshold": value}}
+        )
+
+
+def test_the_generated_schema_includes_the_workspace_config():
+    """The lint job regenerates schemas and fails on a diff, so it must be listed."""
+    from automated_security_helper.schemas.generate_schemas import generate_schemas
+
+    schemas = generate_schemas("dict")
+    assert "AshWorkspaceConfig" in schemas
+    properties = schemas["AshWorkspaceConfig"]["properties"]
+    assert "workspace" in properties
+
+
+# ---------------------------------------------------------------------------
+# 2. The ceiling tightens a lax project and leaves a strict one alone
+# ---------------------------------------------------------------------------
+
+
+def test_a_project_looser_than_the_ceiling_is_tightened():
+    """CRITICAL is the loosest setting, so a MEDIUM ceiling must pull it in."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="MEDIUM"),
+        project_prefix="api",
+        project_threshold="CRITICAL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "MEDIUM"
+    assert resolved.threshold_tightened is True
+
+
+def test_a_project_stricter_than_the_ceiling_is_untouched():
+    """LOW is stricter than MEDIUM, so the ceiling must not loosen it to MEDIUM."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="MEDIUM"),
+        project_prefix="api",
+        project_threshold="LOW",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "LOW"
+    assert resolved.threshold_tightened is False
+
+
+def test_the_strictest_project_setting_survives_the_loosest_ceiling():
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="CRITICAL"),
+        project_prefix="api",
+        project_threshold="ALL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "ALL"
+    assert resolved.threshold_tightened is False
+
+
+def test_no_ceiling_leaves_the_project_threshold_exactly_as_it_was():
+    resolved = policy_for_project(
+        _policy(),
+        project_prefix="api",
+        project_threshold="CRITICAL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "CRITICAL"
+    assert resolved.threshold_tightened is False
+
+
+def test_a_project_with_the_gate_turned_off_is_still_tightened_by_the_ceiling():
+    """A falsy project threshold means "nothing fails", which is looser than any
+    ceiling. The ceiling has to reach it, or an operator could opt out of
+    workspace policy by deleting their own threshold."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="HIGH"),
+        project_prefix="api",
+        project_threshold=None,
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "HIGH"
+    assert resolved.threshold_tightened is True
+
+
+@pytest.mark.parametrize(
+    "project,ceiling,expected",
+    [
+        ("CRITICAL", "HIGH", "HIGH"),
+        ("CRITICAL", "MEDIUM", "MEDIUM"),
+        ("HIGH", "MEDIUM", "MEDIUM"),
+        ("HIGH", "CRITICAL", "HIGH"),
+        ("MEDIUM", "MEDIUM", "MEDIUM"),
+        ("LOW", "HIGH", "LOW"),
+        ("ALL", "LOW", "ALL"),
+    ],
+)
+def test_the_effective_threshold_is_the_stricter_of_the_two(project, ceiling, expected):
+    """The RFC's worked table, plus the untouched direction for each row."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold=ceiling),
+        project_prefix="api",
+        project_threshold=project,
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == expected
+
+
+def test_the_effective_threshold_is_never_looser_than_the_project_asked_for():
+    """Property: over every pair, the ceiling can only tighten or do nothing.
+
+    The strictness order is spelled out here rather than imported from
+    severity_ladder ON PURPOSE. Asserting against ``stricter_of`` would compare
+    the implementation to itself -- both sides would derive from the same
+    function, so an inverted ladder would satisfy the test. This table is an
+    independent statement of the order the RFC specifies, so if the two ever
+    disagree the test fails rather than agreeing with the bug.
+    """
+    # Strictest first. Raising a threshold LOOSENS the gate.
+    order = ["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+    checked = 0
+    for project in order:
+        for ceiling in order:
+            resolved = policy_for_project(
+                _policy(max_severity_threshold=ceiling),
+                project_prefix="api",
+                project_threshold=project,
+                project_scanners=(),
+            )
+            effective = resolved.effective_threshold
+
+            # The result is one of the two inputs, and it is the stricter one --
+            # i.e. the earlier one in the order above.
+            assert effective in (project, ceiling)
+            assert order.index(effective) == min(
+                order.index(project), order.index(ceiling)
+            ), f"project={project} ceiling={ceiling} gave {effective}"
+            # And never looser than the project already was.
+            assert order.index(effective) <= order.index(project)
+            checked += 1
+
+    assert checked == len(order) ** 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Suppressions and ignore_paths are pushed DOWN into each project
+# ---------------------------------------------------------------------------
+
+
+def test_a_suppression_anchored_at_one_project_reaches_only_that_project():
+    """The whole point of the push-down: api's suppression must not silence web."""
+    policy = _policy(suppressions=[_suppression("api/src/legacy.py")])
+
+    for_api = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    for_web = policy_for_project(
+        policy,
+        project_prefix="web",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+
+    assert [s.path for s in for_api.suppressions] == ["src/legacy.py"]
+    assert for_web.suppressions == ()
+
+
+def test_a_double_star_suppression_reaches_every_project():
+    policy = _policy(suppressions=[_suppression("**/generated.py")])
+
+    for prefix in ("api", "web", "services/worker"):
+        resolved = policy_for_project(
+            policy,
+            project_prefix=prefix,
+            project_threshold="MEDIUM",
+            project_scanners=(),
+        )
+        assert [s.path for s in resolved.suppressions] == ["**/generated.py"], prefix
+
+
+def test_a_suppression_naming_only_the_project_directory_is_not_passed_down():
+    """ "api" matches the path "api", not "api/src/x.py", so it covers no file.
+
+    Passing "**" here would suppress an entire project the operator never asked
+    to silence -- the failure the workspace_paths contract sweep caught.
+    """
+    policy = _policy(suppressions=[_suppression("api")])
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.suppressions == ()
+
+
+def test_an_unrewritable_suppression_is_refused_and_names_the_pattern():
+    """A pattern with no sound single-pattern rewrite must not be dropped quietly.
+
+    Dropping it would leave the operator's stated policy unapplied with nothing
+    in the output to say so; ``*/sub/*.py`` is the two-glob-semantics case from
+    workspace_paths.
+    """
+    policy = _policy(suppressions=[_suppression("*/sub/*.py")])
+    with pytest.raises((WorkspaceDefinitionError, WorkspacePatternError)) as excinfo:
+        policy_for_project(
+            policy,
+            project_prefix="api",
+            project_threshold="MEDIUM",
+            project_scanners=(),
+        )
+    assert "*/sub/*.py" in str(excinfo.value)
+
+
+def test_ignore_paths_are_pushed_down_the_same_way_as_suppressions():
+    policy = _policy(
+        ignore_paths=[
+            IgnorePathWithReason(path="api/vendor/**", reason="third party"),
+            IgnorePathWithReason(path="web/dist/**", reason="build output"),
+        ]
+    )
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert [p.path for p in resolved.ignore_paths] == ["vendor/**"]
+
+
+def test_everything_except_the_path_survives_the_push_down_unchanged():
+    """Rewriting the path must not drop the rule_id, reason, lines or expiry.
+
+    A suppression that loses its rule_id widens from "this rule here" to
+    "every rule here".
+    """
+    policy = _policy(
+        suppressions=[
+            AshSuppression(
+                path="api/src/x.py",
+                reason="tracked in TICKET-1",
+                rule_id="B101",
+                line_start=10,
+                line_end=20,
+                expiration="2099-01-01",
+            )
+        ]
+    )
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+
+    (pushed,) = resolved.suppressions
+    assert pushed.path == "src/x.py"
+    assert pushed.reason == "tracked in TICKET-1"
+    assert pushed.rule_id == "B101"
+    assert pushed.line_start == 10
+    assert pushed.line_end == 20
+    assert pushed.expiration == "2099-01-01"
+
+
+def test_the_pushed_down_suppression_is_a_copy_not_the_policy_object():
+    """Each project gets its own object, or rewriting one would rewrite all.
+
+    The policy is shared across projects, so mutating in place would leave the
+    second project's push-down operating on the first project's coordinates.
+    """
+    original = _suppression("api/src/x.py")
+    policy = _policy(suppressions=[original])
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.suppressions[0] is not original
+    assert original.path == "api/src/x.py"
+
+
+# ---------------------------------------------------------------------------
+# 4. additional_scanners are additive, and policy-origin ones do not gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_scanner_the_project_already_declares_is_not_policy_origin():
+    """It runs under the project's own config, so it is the project's finding."""
+    resolved = policy_for_project(
+        _policy(additional_scanners=["bandit"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("bandit", "checkov"),
+    )
+    assert resolved.policy_scanners == ()
+
+
+def test_a_scanner_only_the_policy_names_is_policy_origin():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("bandit",),
+    )
+    assert resolved.policy_scanners == ("semgrep",)
+
+
+def test_policy_origin_scanners_do_not_gate_by_default():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.policy_scanners == ("semgrep",)
+    assert resolved.policy_scanners_gate is False
+
+
+def test_policy_origin_scanners_gate_when_the_operator_opts_in():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"], policy_scanners_gate=True),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.policy_scanners_gate is True
+
+
+def test_the_scanner_comparison_ignores_case_and_separator_style():
+    """--scanners accepts the alias form, so cdk-nag and cdk_nag are one scanner.
+
+    Treating them as different would run a second copy under default config and
+    report its findings as policy-origin duplicates of the project's own.
+    """
+    resolved = policy_for_project(
+        _policy(additional_scanners=["cdk-nag"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("cdk_nag",),
+    )
+    assert resolved.policy_scanners == ()
+
+
+# ---------------------------------------------------------------------------
+# 5. Finding the policy file, and refusing to read a project's config as one
+# ---------------------------------------------------------------------------
+
+
+def test_the_policy_file_names_are_disjoint_from_the_project_config_names():
+    """Structural guarantee that discovery can never pick up a project config."""
+    from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
+
+    assert not set(WORKSPACE_POLICY_FILE_NAMES) & set(ASH_CONFIG_FILE_NAMES)
+
+
+def test_a_policy_file_beside_the_workspace_file_is_discovered(tmp_path):
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: HIGH\n",
+    )
+    config, source = resolve_workspace_policy(tmp_path)
+    assert config.workspace.max_severity_threshold == "HIGH"
+    assert source == (tmp_path / ".ash" / "ash-workspace.yaml").resolve()
+
+
+def test_no_policy_file_at_all_is_not_an_error(tmp_path):
+    """Workspace policy is opt-in; Phase 2b behaviour must survive its absence."""
+    config, source = resolve_workspace_policy(tmp_path)
+    assert config is None
+    assert source is None
+
+
+def test_an_explicit_policy_file_is_used(tmp_path):
+    explicit = _write(
+        tmp_path / "custom-policy.yaml",
+        "workspace:\n  max_severity_threshold: LOW\n",
+    )
+    config, source = resolve_workspace_policy(tmp_path, explicit=explicit)
+    assert config.workspace.max_severity_threshold == "LOW"
+    assert source == explicit.resolve()
+
+
+def test_a_workspace_root_that_is_also_a_project_keeps_both_files_separate(tmp_path):
+    """The collision case from the RFC, stated as behaviour.
+
+    .ash/ash.yaml at the workspace root belongs to the root project. Reading it
+    as workspace policy would apply one project's threshold to its siblings.
+    """
+    _write(
+        tmp_path / ".ash" / "ash.yaml",
+        "global_settings:\n  severity_threshold: CRITICAL\n",
+    )
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: MEDIUM\n",
+    )
+
+    config, source = resolve_workspace_policy(tmp_path)
+    assert source.name == "ash-workspace.yaml"
+    assert config.workspace.max_severity_threshold == "MEDIUM"
+
+
+def test_pointing_the_policy_at_a_project_config_is_refused_naming_the_file(tmp_path):
+    project_config = _write(
+        tmp_path / ".ash" / "ash.yaml",
+        "global_settings:\n  severity_threshold: HIGH\n",
+    )
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path, explicit=project_config)
+
+    message = str(excinfo.value)
+    assert "ash.yaml" in message
+    assert "ash-workspace" in message
+
+
+def test_pointing_the_policy_at_a_named_project_config_is_refused(tmp_path):
+    """Caught by identity against the project's own config path, not by name.
+
+    An operator may name their policy file anything; what makes this a
+    collision is that the file IS a project's config, so a symlink alias to one
+    has to be caught too.
+    """
+    project = tmp_path / "api"
+    project_config = _write(project / ".ash" / "ash.yaml", "global_settings: {}\n")
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(
+            tmp_path,
+            explicit=project_config,
+            project_config_paths=(project_config,),
+        )
+    assert "api" in str(excinfo.value)
+
+
+def test_two_candidate_policy_files_are_refused_rather_than_ranked(tmp_path):
+    """Sort order or mtime would silently pick a different file over time."""
+    _write(tmp_path / ".ash" / "ash-workspace.yaml", "workspace: {}\n")
+    _write(tmp_path / ".ash" / "ash-workspace.yml", "workspace: {}\n")
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+
+    message = str(excinfo.value)
+    assert "ash-workspace.yaml" in message
+    assert "ash-workspace.yml" in message
+
+
+def test_a_malformed_policy_file_is_refused(tmp_path):
+    _write(tmp_path / ".ash" / "ash-workspace.yaml", "workspace: [this is not a map\n")
+    with pytest.raises(WorkspaceDefinitionError):
+        resolve_workspace_policy(tmp_path)
+
+
+def test_an_explicit_policy_file_that_does_not_exist_is_refused(tmp_path):
+    """Silently ignoring it would run with no policy while the operator believes
+    a ceiling is in force."""
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path, explicit=tmp_path / "absent.yaml")
+    assert "absent.yaml" in str(excinfo.value)
+
+
+def test_a_policy_file_with_an_unknown_key_is_refused_naming_the_file(tmp_path):
+    path = _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshhold: HIGH\n",
+    )
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+    assert path.name in str(excinfo.value)
+
+
+def test_a_json_policy_file_is_read(tmp_path):
+    _write(
+        tmp_path / ".ash" / "ash-workspace.json",
+        json.dumps({"workspace": {"max_severity_threshold": "HIGH"}}),
+    )
+    config, _ = resolve_workspace_policy(tmp_path)
+    assert config.workspace.max_severity_threshold == "HIGH"

--- a/tests/unit/workspace/test_workspace_policy_resolution.py
+++ b/tests/unit/workspace/test_workspace_policy_resolution.py
@@ -1,0 +1,382 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workspace policy as resolution applies it -- Phase 3, criteria 19-21.
+
+``test_workspace_policy.py`` covers the policy file and the push-down in
+isolation. This file covers the part an operator actually experiences: policy
+found next to the workspace file, applied to every project, and visible in
+``--dry-run`` BEFORE anything is scanned.
+
+That visibility is the point of the render assertions below rather than an
+aesthetic preference. A severity ceiling silently tightens projects whose own
+config says something else, so an operator has to be able to see which projects
+it moved without running a scan and diffing finding counts.
+"""
+
+import json
+
+import pytest
+
+from automated_security_helper.core.exceptions import WorkspaceDefinitionError
+from automated_security_helper.workspace.resolver import resolve_workspace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _workspace(root, folders, name="dev.code-workspace"):
+    path = root / name
+    path.write_text(
+        json.dumps({"folders": [{"path": p} for p in folders]}), encoding="utf-8"
+    )
+    return path
+
+
+def _project(root, relative, threshold=None, disabled_scanners=None):
+    """A project directory, with a config when a threshold or scanners are given.
+
+    ``disabled_scanners`` rather than ``enabled``: ASH enables all ten builtin
+    scanners by default, so listing a scanner as enabled says nothing. A project
+    that does NOT have a given scanner is one that explicitly turned it off, and
+    that is the only shape in which ``additional_scanners`` has anything to add.
+    """
+    project = root / relative
+    project.mkdir(parents=True, exist_ok=True)
+    if threshold is None and disabled_scanners is None:
+        return project
+
+    lines = ["global_settings:", f"  severity_threshold: {threshold or 'MEDIUM'}"]
+    if disabled_scanners:
+        lines.append("scanners:")
+        for scanner in disabled_scanners:
+            lines.append(f"  {scanner}:")
+            lines.append("    enabled: false")
+    ash_dir = project / ".ash"
+    ash_dir.mkdir(exist_ok=True)
+    (ash_dir / "ash.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return project
+
+
+def _policy_file(root, body, name="ash-workspace.yaml"):
+    ash_dir = root / ".ash"
+    ash_dir.mkdir(parents=True, exist_ok=True)
+    path = ash_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _by_key(plan):
+    return {project.key: project for project in plan.projects}
+
+
+# ---------------------------------------------------------------------------
+# 1. The ceiling reaches every project, and only tightens
+# ---------------------------------------------------------------------------
+
+
+def test_the_ceiling_tightens_a_lax_project_and_leaves_a_strict_one(tmp_path):
+    _project(tmp_path, "lax", threshold="CRITICAL")
+    _project(tmp_path, "strict", threshold="LOW")
+    workspace = _workspace(tmp_path, ["lax", "strict"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # The project's own setting is preserved as declared, so an operator can see
+    # what the ceiling changed rather than only its result.
+    assert projects["lax"].severity_threshold == "CRITICAL"
+    assert projects["lax"].effective_severity_threshold == "MEDIUM"
+    assert projects["lax"].threshold_tightened_by_policy is True
+
+    assert projects["strict"].severity_threshold == "LOW"
+    assert projects["strict"].effective_severity_threshold == "LOW"
+    assert projects["strict"].threshold_tightened_by_policy is False
+
+
+def test_without_a_policy_file_the_effective_threshold_is_the_projects_own(tmp_path):
+    """Phase 2b behaviour has to survive: no policy means nothing changes."""
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+    project = _by_key(plan)["api"]
+
+    assert plan.workspace_config_source is None
+    assert project.effective_severity_threshold == "CRITICAL"
+    assert project.threshold_tightened_by_policy is False
+
+
+def test_a_skipped_project_gets_no_policy_at_all(tmp_path):
+    """Policy must not be applied to a project that will not be scanned.
+
+    Two reasons, and the second is the one with teeth. A threshold recorded for
+    work that never happens is misleading in the plan; and pushing patterns into
+    a skipped project can refuse the ENTIRE workspace over a pattern that is only
+    unrewritable for a project nobody is scanning -- fail-closed aimed at the
+    wrong target.
+    """
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  max_severity_threshold: MEDIUM\n"
+        "  suppressions:\n"
+        "    - path: '**/legacy.py'\n"
+        "      reason: everywhere\n",
+    )
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+    projects = _by_key(plan)
+
+    # Companion assertion: the skip really happened, so the checks below are not
+    # passing because the project was scanned after all.
+    assert projects["absent"].skipped is True
+    assert projects["api"].skipped is False
+
+    assert projects["absent"].effective_severity_threshold is None
+    assert projects["absent"].threshold_tightened_by_policy is False
+    assert projects["absent"].policy_suppressions == []
+    assert projects["absent"].policy_scanners == []
+
+    # The project that does run still gets the full policy.
+    assert projects["api"].effective_severity_threshold == "MEDIUM"
+    assert [s.path for s in projects["api"].policy_suppressions] == ["**/legacy.py"]
+
+
+def test_the_plan_records_which_policy_file_was_used(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    policy = _policy_file(tmp_path, "workspace:\n  max_severity_threshold: HIGH\n")
+
+    plan = resolve_workspace(workspace)
+    assert plan.workspace_config_source == policy.resolve().as_posix()
+
+
+def test_an_explicit_policy_file_overrides_discovery(tmp_path):
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: HIGH\n")
+    chosen = tmp_path / "other-policy.yaml"
+    chosen.write_text("workspace:\n  max_severity_threshold: LOW\n", encoding="utf-8")
+
+    plan = resolve_workspace(workspace, workspace_config=chosen)
+    assert plan.workspace_config_source == chosen.resolve().as_posix()
+    assert _by_key(plan)["api"].effective_severity_threshold == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# 2. The collision the RFC names, at the resolution layer
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_root_that_is_also_a_project_keeps_its_config_separate(tmp_path):
+    """The root's .ash/ash.yaml is the root project's config, not workspace policy.
+
+    Reading it as policy would apply one project's threshold to its siblings.
+    Here the root project declares CRITICAL and the policy declares a MEDIUM
+    ceiling, so mixing them up is visible in the sibling's effective threshold.
+    """
+    root_project = _project(tmp_path, "root-app", threshold="CRITICAL")
+    assert (root_project / ".ash" / "ash.yaml").exists()
+    _project(tmp_path, "sibling", threshold="CRITICAL")
+    # The workspace root's own config, distinct from the policy beside it.
+    (tmp_path / ".ash").mkdir(exist_ok=True)
+    (tmp_path / ".ash" / "ash.yaml").write_text(
+        "global_settings:\n  severity_threshold: ALL\n", encoding="utf-8"
+    )
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+    workspace = _workspace(tmp_path, ["root-app", "sibling"])
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # ALL from the root's own config must not have become the ceiling.
+    assert plan.workspace_config_source.endswith("ash-workspace.yaml")
+    assert projects["sibling"].effective_severity_threshold == "MEDIUM"
+    assert projects["root-app"].effective_severity_threshold == "MEDIUM"
+
+
+def test_naming_a_project_config_as_the_policy_file_is_refused(tmp_path):
+    project = _project(tmp_path, "api", threshold="HIGH")
+    workspace = _workspace(tmp_path, ["api"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace, workspace_config=project / ".ash" / "ash.yaml")
+    assert "ash.yaml" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 3. Patterns land on the right project, or refuse
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_suppression_reaches_only_the_project_it_names(tmp_path):
+    _project(tmp_path, "api")
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  suppressions:\n"
+        "    - path: api/src/legacy.py\n"
+        "      reason: tracked in TICKET-1\n",
+    )
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    assert [s.path for s in projects["api"].policy_suppressions] == ["src/legacy.py"]
+    assert projects["web"].policy_suppressions == []
+
+
+def test_an_unrewritable_policy_pattern_refuses_naming_project_and_pattern(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  suppressions:\n"
+        "    - path: '*/sub/*.py'\n"
+        "      reason: ambiguous on purpose\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "*/sub/*.py" in message
+    assert "api" in message
+
+
+def test_workspace_ignore_paths_are_pushed_into_each_project(tmp_path):
+    _project(tmp_path, "api")
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  ignore_paths:\n"
+        "    - path: '**/vendor'\n"
+        "      reason: third party\n",
+    )
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    for key in ("api", "web"):
+        assert [p.path for p in projects[key].policy_ignore_paths] == ["**/vendor"]
+
+
+def test_a_trailing_double_star_after_a_double_star_is_refused(tmp_path):
+    """``**/vendor/**`` has no sound rewrite, and an operator will write it.
+
+    It is the most natural way to say "any vendor directory, at any depth, in any
+    project", so its refusal is the limitation of the push-down most likely to be
+    hit. Pinned as a test rather than left to be discovered, with the working
+    alternatives named in the message the operator sees.
+
+    The cause is workspace_paths' family 1: the remainder ``vendor/**`` is
+    multi-component and contains a glob, so prefixing it with ``**`` moves the
+    whole pattern from fnmatch to component-anchored matching and silently
+    re-interprets the trailing ``**``.
+    """
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  ignore_paths:\n"
+        "    - path: '**/vendor/**'\n"
+        "      reason: third party\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+    assert "**/vendor/**" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 4. Policy-added scanners, per project
+# ---------------------------------------------------------------------------
+
+
+def test_a_policy_scanner_the_project_already_enables_is_not_policy_origin(tmp_path):
+    """Only the project that turned bandit off gets it back as policy-origin.
+
+    The project that still has it runs bandit under its own config, so those
+    findings are the project's and gate normally.
+    """
+    _project(tmp_path, "has-it", threshold="MEDIUM")
+    _project(tmp_path, "lacks-it", threshold="MEDIUM", disabled_scanners=["bandit"])
+    workspace = _workspace(tmp_path, ["has-it", "lacks-it"])
+    _policy_file(tmp_path, "workspace:\n  additional_scanners:\n    - bandit\n")
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # Companion assertion: confirm the passing path is the one intended, i.e.
+    # has-it really does enable bandit rather than the comparison silently
+    # matching nothing.
+    assert "bandit" in projects["has-it"].scanners
+    assert "bandit" not in projects["lacks-it"].scanners
+
+    assert projects["has-it"].policy_scanners == []
+    assert projects["lacks-it"].policy_scanners == ["bandit"]
+
+
+def test_policy_scanners_do_not_gate_unless_the_operator_opts_in(tmp_path):
+    _project(tmp_path, "api", threshold="MEDIUM", disabled_scanners=["bandit"])
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(tmp_path, "workspace:\n  additional_scanners:\n    - bandit\n")
+
+    plan = resolve_workspace(workspace)
+    # Companion assertion: the gate flag is only meaningful if bandit really is
+    # policy-origin here, so confirm that before asserting on the flag.
+    assert _by_key(plan)["api"].policy_scanners == ["bandit"]
+    assert _by_key(plan)["api"].policy_scanners_gate is False
+
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  additional_scanners:\n"
+        "    - bandit\n"
+        "  policy_scanners_gate: true\n",
+    )
+    plan = resolve_workspace(workspace)
+    assert _by_key(plan)["api"].policy_scanners_gate is True
+
+
+# ---------------------------------------------------------------------------
+# 5. --dry-run shows the policy, so a ceiling is visible before it applies
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_names_the_policy_file_and_marks_the_projects_it_tightened(tmp_path):
+    _project(tmp_path, "lax", threshold="CRITICAL")
+    _project(tmp_path, "strict", threshold="LOW")
+    workspace = _workspace(tmp_path, ["lax", "strict"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+
+    rendered = resolve_workspace(workspace).render()
+
+    assert "ash-workspace.yaml" in rendered
+    # The tightened project shows both values and says policy moved it; the
+    # untouched one must not claim a change it did not undergo.
+    assert "CRITICAL" in rendered and "MEDIUM" in rendered
+    lax_block = rendered.split("1. lax")[1].split("2. strict")[0]
+    strict_block = rendered.split("2. strict")[1]
+    assert "workspace policy" in lax_block
+    assert "workspace policy" not in strict_block
+
+
+def test_dry_run_without_policy_does_not_mention_it(tmp_path):
+    _project(tmp_path, "api", threshold="MEDIUM")
+    workspace = _workspace(tmp_path, ["api"])
+
+    rendered = resolve_workspace(workspace).render()
+    assert "workspace policy" not in rendered
+    assert "policy:" not in rendered


### PR DESCRIPTION
Phase 3 of workspace mode: a workspace-level policy file, so an operator can state something about a workspace as a whole rather than repeating it in every project's config.

Stacked on `feat/workspace-mode-phase2b-reporters`. Draft for the reason in "Not finished" below, not for quality.

## What this adds

A policy file adjacent to the workspace file — `ash-workspace.{yaml,yml,json}` in the workspace root or its `.ash/` directory:

```yaml
workspace:
  max_severity_threshold: MEDIUM      # the LOOSEST any project may be
  suppressions:
    - path: services/api/src/legacy.py
      rule_id: B101
      reason: tracked in TICKET-1
  ignore_paths:
    - path: '**/vendor'
      reason: third-party code
  additional_scanners: [bandit]
  policy_scanners_gate: false
```

- `AshWorkspaceConfig` / `WorkspacePolicyConfig`, `extra="forbid"`, plus the generated `AshWorkspaceConfig.json` (committed — see the note on the schema gate below).
- `--workspace-config` / `ASH_WORKSPACE_CONFIG` to name the file. Absent policy is not an error; policy is opt-in.
- `max_severity_threshold` composes as `stricter_of(project, ceiling)`, so a stricter project is untouched and a looser one is tightened. A project that turned its own gate off is tightened too, or deleting a threshold would be a way to opt out of policy.
- Suppressions and ignore paths are declared workspace-relative and pushed down per project via `to_project_pattern`. One that cannot match inside a project is not applied there; one with no sound rewrite refuses.
- `--dry-run` names the policy file and prints both thresholds for any project the ceiling moved, so a ceiling is inspectable before it changes a verdict.

## The policy file must be distinct from any project config

A workspace root is often also a project, and then `.ash/ash.yaml` there is that project's config and keeps meaning exactly that. Reading it as workspace policy would promote one project's `severity_threshold` into its siblings' ceiling, silently, from a file whose author expected project scope.

Two mechanisms, because the first does not cover the second: the `ash-workspace.*` names are disjoint from `ASH_CONFIG_FILE_NAMES` so discovery cannot land on a project config, and an explicit `--workspace-config` is checked by resolved identity against each project's config path, so a symlink or an alternate spelling of one is caught. Collision is exit 4 naming the file.

## The ceiling's limit, measured and disclosed rather than documented

`max_severity_threshold` tightens findings that carry `properties.issue_severity`. A finding carrying only a SARIF `error` level is read as critical by both of ASH's threshold gates, so it is actionable at every threshold and tightening changes nothing for it.

This predates workspace mode — single-project `severity_threshold` behaves identically. Verified by differential over all 120 level/severity/threshold combinations, driving the real `_compute_exit_code` against the workspace counter: **zero disagreements**, with a positive control that finds exactly one when perturbed. So the cross-mode invariant holds, and the limit is a property of the SARIF level mapping rather than of this feature.

Two alternatives were rejected on evidence. Remapping `error` to HIGH in `severity_ladder` alone was measured to break the invariant at exactly one cell — a level-only `error` at a CRITICAL threshold — and it breaks it in the **loosening** direction, where checkov findings that fail `ash --source-dir P` would pass the workspace gate. Remapping both gates instead keeps them consistent but silently stops failing CRITICAL-threshold single-project scans on `error` findings, which is a change to published exit-code behaviour and does not belong in a workspace feature. Deriving `issue_severity` has no source data: no ASH code writes it, and checkov emits none.

So instead of a caveat in prose, which rots when a scanner starts or stops emitting severity, the reach is computed. When the ceiling tightens a project and some of its findings were beyond that tightening's reach, the project's result carries:

```json
"ceiling_unreachable_findings": { "checkov": 7 }
```

Read as a statement about those findings, not about the tool. Emitted only when load-bearing — absent when the ceiling did not tighten the project, and absent when it reached everything.

## Not finished: three fields reach the plan but not the scanners

`workspace.suppressions`, `workspace.ignore_paths` and `workspace.additional_scanners` are resolved, validated, pushed down per project and recorded on the plan and in `--dry-run`. **They do not yet affect a scan.** That is why this is a draft: a field that parses, validates, appears in the generated schema and the plan, and then silently changes nothing is worse than a field that does not exist, because the operator writes it and believes findings are suppressed.

The reason is a constraint rather than an oversight. Scanners read suppressions and ignore paths from the resolved `AshConfig`. `ASHScanOrchestrator.__init__` unconditionally reassigns its own `config` field by calling `resolve_config` itself (`orchestrator.py:183`), so a caller cannot hand it a config with policy merged in. The other available channel, `config_overrides`, **fails open**: `apply_config_overrides` logs a warning and returns the **original** config when an override does not parse or the merged result does not validate (`resolve_config.py:145-164`). Routing a security policy through that would mean a typo scans with no policy at all.

Both of those are defects on `main` independent of workspace mode, so they are being fixed separately and this PR will wire the three fields on top once that lands.

The severity ceiling is fully wired and does change verdicts; it needed no orchestrator change, because the verdict is computed from the plan.

## Verification

| check | result |
| --- | --- |
| 3.13 `-n auto` | 4289 passed, 114 skipped |
| 3.13 `-n 0` | 4289 passed, 114 skipped |
| 3.10 `-n auto` | 4288 passed, 115 skipped |
| base `7ffdaf9`, fresh worktree | 4207 passed, 114 skipped |

**+82 on both interpreters**, exactly the number of tests added, and the skipped-test ID set is byte-identical to the base — so nothing added is silently not running. The 3.10/3.13 difference of one is the version-gated `test_tar_extractall_uses_filter_on_312_plus`.

Self-scan: every scanner `actionable_finding_count: 0`, none in ERROR. `verify_docs_freshness.py` 7/7 — it caught a missing CLI flag before CI would have.

**`scripts/verify_workspace_policy.py` — 18/18 on a real scan.** Two runs over one three-project fixture, no policy then a MEDIUM ceiling: the lax project goes from 0 actionable of 2 findings and `exceeds_threshold` false to 1 actionable and true; the strict project stays at 2 and 2 and is still judged at its own LOW; the checkov project reports 7 actionable of 7 at CRITICAL and discloses `{"checkov": 7}` under the ceiling while the bandit project discloses nothing. It carries two positive controls, because "the ceiling could not reach these" and "there was nothing to reach" are otherwise indistinguishable.

Every test was watched fail. Three mutation harnesses, 20 mutations, each with an identity-mutation control; all caught. Two of the findings were gaps in the tests rather than the code — an untested `skipped` guard, and two redundant guards where removing either left the suite green.

## Note for reviewers on the schema gate

`AshWorkspaceConfig.json` is the third tracked schema in this repository, and the `lint` job's freshness check is `git diff --exit-code automated_security_helper/schemas/*.json`. `git diff` cannot see a file git has never seen, so a newly registered model generates an **untracked** file and the gate reports clean. The generated file is committed here; verify with `git status --porcelain` rather than `git diff`. That gate blind spot is being fixed separately.
