### PR TITLE
fix(validation): restore the two reporters scan_phase calls, and the guard that discarded one

### DIFF
--- a/automated_security_helper/core/phases/scan_phase.py
+++ b/automated_security_helper/core/phases/scan_phase.py
@@ -1381,13 +1381,25 @@ class ScanPhase(EnginePhase):
                         f"Unexpected scanner completions ({len(unexpected_scanners)}): {', '.join(unexpected_scanners)}"
                     )
 
-                # Add discrepancy report to aggregated results for debugging
-                if not hasattr(
-                    aggregated_results.metadata, "execution_discrepancy_report"
-                ):
-                    aggregated_results.metadata.execution_discrepancy_report = (
-                        discrepancy_report
-                    )
+                # Add discrepancy report to aggregated results for debugging.
+                #
+                # Assigned unconditionally. This was guarded by
+                # `if not hasattr(metadata, "execution_discrepancy_report")`,
+                # which could never be true: ReportMetadata DECLARES that field
+                # with a default of {}, so hasattr is always True and the
+                # assignment was dead code. The report would have stayed {} even
+                # once report_execution_discrepancies existed again.
+                #
+                # Note the asymmetry with result_completeness_report below, which
+                # is NOT a declared field, so its identical-looking guard did
+                # fire. Restoring the two methods without this change would have
+                # left one report populated and the other permanently empty.
+                #
+                # There is nothing to preserve by guarding: this method runs once
+                # per scan and recomputes the report from the checkpoint.
+                aggregated_results.metadata.execution_discrepancy_report = (
+                    discrepancy_report
+                )
 
             # Add validation results to aggregated results for debugging
             checkpoint_dict = {
@@ -1581,15 +1593,19 @@ class ScanPhase(EnginePhase):
                         f"Found unexpected scanners ({len(unexpected_scanners)}): {', '.join(unexpected_scanners)}"
                     )
 
-                # Add completeness report to aggregated results for debugging
-                if not hasattr(
-                    aggregated_results.metadata, "result_completeness_report"
-                ):
-                    setattr(
-                        aggregated_results.metadata,
-                        "result_completeness_report",
-                        completeness_report,
-                    )
+                # Add completeness report to aggregated results for debugging.
+                #
+                # Also unconditional, for the same reason and for symmetry with
+                # the execution report above. This guard did fire today, because
+                # result_completeness_report is not a declared field on
+                # ReportMetadata -- but relying on that is relying on the absence
+                # of a field declaration, which the next person to add one would
+                # silently break. Same one-run-per-scan argument applies.
+                setattr(
+                    aggregated_results.metadata,
+                    "result_completeness_report",
+                    completeness_report,
+                )
 
             # Add validation results to aggregated results for debugging
             checkpoint_dict = {

--- a/automated_security_helper/models/scanner_validation.py
+++ b/automated_security_helper/models/scanner_validation.py
@@ -598,6 +598,44 @@ class ValidationCheckpointer:
             },
         )
 
+    def report_execution_discrepancies(
+        self, execution_checkpoint: ValidationCheckpoint
+    ) -> Dict[str, Any]:
+        """Summarise an execution-completion checkpoint for the scan report.
+
+        A pure function of *execution_checkpoint*: it reads the checkpoint and
+        touches no state on ``self``. It lives here rather than on
+        ``ValidationCheckpoint`` because that is where the caller expects it --
+        ``ScanPhase._validate_execution_completion`` calls it through the
+        manager facade -- and moving it would change a call site this commit is
+        restoring rather than redesigning.
+
+        Note that ``has_discrepancies`` mirrors ``checkpoint.has_issues()``,
+        which reports recorded discrepancies and errors. A missing scanner does
+        NOT by itself set that flag, so ``has_discrepancies`` can be False while
+        ``missing_count`` is non-zero. That asymmetry predates this restoration
+        and is preserved deliberately: the counts are the field to test.
+
+        Args:
+            execution_checkpoint: The checkpoint from
+                :meth:`validate_execution_completion`.
+
+        Returns:
+            The discrepancy report stored on
+            ``AshAggregatedResults.metadata.execution_discrepancy_report``.
+        """
+        missing_scanners = execution_checkpoint.get_missing_scanners()
+        unexpected_scanners = execution_checkpoint.get_unexpected_scanners()
+
+        return {
+            "has_discrepancies": execution_checkpoint.has_issues(),
+            "missing_scanners": missing_scanners,
+            "unexpected_scanners": unexpected_scanners,
+            "missing_count": len(missing_scanners),
+            "unexpected_count": len(unexpected_scanners),
+            "total_discrepancies": len(missing_scanners) + len(unexpected_scanners),
+        }
+
     def ensure_complete_results(
         self, aggregated_results: "AshAggregatedResults"
     ) -> ValidationCheckpoint:
@@ -769,6 +807,29 @@ class ValidationCheckpointer:
             self.logger.verbose("Result completeness validation passed without issues")
 
         return checkpoint
+
+    def report_result_completeness(
+        self, completeness_checkpoint: ValidationCheckpoint
+    ) -> Dict[str, Any]:
+        """Summarise a result-completeness checkpoint for the scan report.
+
+        The counterpart to :meth:`report_execution_discrepancies`, and pure in
+        the same way. It carries no counts, because the adjustment total the
+        caller reports is derived from the scanner lists directly.
+
+        Args:
+            completeness_checkpoint: The checkpoint from
+                :meth:`ensure_complete_results`.
+
+        Returns:
+            The completeness report stored on
+            ``AshAggregatedResults.metadata.result_completeness_report``.
+        """
+        return {
+            "has_adjustments": completeness_checkpoint.has_issues(),
+            "missing_scanners": completeness_checkpoint.get_missing_scanners(),
+            "unexpected_scanners": completeness_checkpoint.get_unexpected_scanners(),
+        }
 
     def validate_task_queue(self, queue_contents: List[tuple]) -> ValidationCheckpoint:
         """Validate that all expected scanners have tasks in the queue.
@@ -1018,10 +1079,20 @@ class ScannerValidationManager:
     ) -> ValidationCheckpoint:
         return self._checkpointer.validate_execution_completion(completed_scanners)
 
+    def report_execution_discrepancies(
+        self, execution_checkpoint: ValidationCheckpoint
+    ) -> Dict[str, Any]:
+        return self._checkpointer.report_execution_discrepancies(execution_checkpoint)
+
     def ensure_complete_results(
         self, aggregated_results: "AshAggregatedResults"
     ) -> ValidationCheckpoint:
         return self._checkpointer.ensure_complete_results(aggregated_results)
+
+    def report_result_completeness(
+        self, completeness_checkpoint: ValidationCheckpoint
+    ) -> Dict[str, Any]:
+        return self._checkpointer.report_result_completeness(completeness_checkpoint)
 
     def validate_task_queue(self, queue_contents: List[tuple]) -> ValidationCheckpoint:
         return self._checkpointer.validate_task_queue(queue_contents)

--- a/tests/unit/core/phases/test_scan_phase.py
+++ b/tests/unit/core/phases/test_scan_phase.py
@@ -18,6 +18,9 @@ from automated_security_helper.models.asharp_model import (
     ScannerStatusInfo,
 )
 from automated_security_helper.models.scan_results_container import ScanResultsContainer
+from automated_security_helper.models.scanner_validation import (
+    ScannerValidationManager,
+)
 
 # Pydantic forward references need explicit rebuild for models with deferred refs
 AshConfig.model_rebuild()
@@ -106,11 +109,25 @@ def _make_scanner_class(name="test_scanner", enabled=True, deps_satisfied=True, 
 
 @pytest.fixture
 def scan_phase(mock_plugin_context, mock_progress_display):
-    """ScanPhase with mocked dependencies."""
+    """ScanPhase with mocked dependencies.
+
+    ``spec=ScannerValidationManager`` is load-bearing, not tidiness. This was a
+    bare ``MagicMock()``, which fabricates any attribute that is touched, and it
+    had accumulated stubs for three methods that do not exist on the real class:
+    ``report_execution_discrepancies`` and ``report_result_completeness`` (both
+    dropped by the StateTracker/Checkpointer split and since restored) and
+    ``validate_result_completeness``, which was never a method at all -- the real
+    facade calls it ``ensure_complete_results``. The suite was therefore
+    "covering" two live AttributeErrors in scan_phase.py against a double that
+    agreed with everything.
+
+    With a spec, setting an attribute the real class lacks raises here, in the
+    fixture, instead of passing and letting production fail.
+    """
     with patch(
         "automated_security_helper.core.phases.scan_phase.ScannerValidationManager"
     ) as MockValMgr:
-        mock_val_mgr = MagicMock()
+        mock_val_mgr = MagicMock(spec=ScannerValidationManager)
         mock_val_mgr.validate_registered_scanners.return_value = None
         mock_val_mgr.validate_scanner_enablement.return_value = None
 
@@ -128,8 +145,11 @@ def scan_phase(mock_plugin_context, mock_progress_display):
 
         mock_val_mgr.validate_task_queue.return_value = checkpoint
         mock_val_mgr.validate_execution_completion.return_value = checkpoint
-        mock_val_mgr.validate_result_completeness.return_value = checkpoint
+        # ensure_complete_results, not validate_result_completeness: the latter
+        # was a phantom the bare Mock accepted for as long as it existed here.
+        mock_val_mgr.ensure_complete_results.return_value = checkpoint
         mock_val_mgr.report_execution_discrepancies.return_value = {}
+        mock_val_mgr.report_result_completeness.return_value = {}
         MockValMgr.return_value = mock_val_mgr
 
         phase = ScanPhase(

--- a/tests/unit/core/phases/test_scan_phase_validation_reporting.py
+++ b/tests/unit/core/phases/test_scan_phase_validation_reporting.py
@@ -1,0 +1,214 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""ScanPhase's validation-reporting path, exercised against the REAL manager.
+
+Why this file exists
+--------------------
+``scan_phase.py`` calls ``validation_manager.report_execution_discrepancies``
+and ``report_result_completeness``. Neither existed on
+``ScannerValidationManager``: both were defined when the call sites were added
+(``ba32f87``) and removed by the StateTracker/Checkpointer split that landed
+squashed inside PR #412 (``1641742``), whose own message claimed "all external
+callers (scan_phase.py, tests) continue to work unchanged".
+
+No existing test caught it, and the reason is the point of this file. The
+fixture in ``test_scan_phase.py`` substitutes a bare ``MagicMock`` for the
+manager, and a bare Mock fabricates any attribute that is accessed -- it even
+had ``mock_val_mgr.report_execution_discrepancies.return_value = {}``, a stub
+written for a method that does not exist. A double that agrees with everything
+verifies nothing.
+
+So every test here drives a REAL ``ScannerValidationManager``.
+
+What the defect actually costs, which is more than the missing report
+--------------------------------------------------------------------
+Both call sites sit inside a ``try`` whose handler is ``except Exception``. The
+``AttributeError`` is therefore caught, logged at ERROR, and turned into an
+ERROR event -- the scan does not crash. But the ``except`` abandons the rest of
+the method, and the rest of the method is where
+``aggregated_results.validation_checkpoints`` is appended and
+``metadata.validation_summary`` is written. Those writes sit OUTSIDE the
+``if missing_scanners or unexpected_scanners:`` block, so they are lost for
+every scan that hits a discrepancy, not just the report itself.
+
+That is why the assertions below check the checkpoint and the summary as well as
+the report. Asserting only on the report would pass as soon as the method stops
+raising, while still leaving the larger loss in place.
+
+Reachability
+------------
+The branch fires only when the expected and completed scanner sets differ, which
+a healthy single-project scan never produces -- which is why CI never hit it.
+The tests construct the discrepancy directly by registering a scanner as
+queued-for-execution and then reporting that nothing completed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.core.phases.scan_phase import ScanPhase
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.models.scanner_validation import (
+    ScannerValidationManager,
+)
+
+AshConfig.model_rebuild()
+AshAggregatedResults.model_rebuild()
+
+
+@pytest.fixture
+def plugin_context(tmp_path):
+    ctx = MagicMock()
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    (source_dir / "app.py").write_text("print('hello')\n", encoding="utf-8")
+    work_dir = tmp_path / "work"
+    work_dir.mkdir()
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+    ctx.source_dir = source_dir
+    ctx.work_dir = work_dir
+    ctx.output_dir = output_dir
+    ctx.config = MagicMock()
+    ctx.config.get_plugin_config.return_value = None
+    ctx.config.global_settings.ignore_paths = []
+    ctx.ignore_suppressions = False
+    ctx.cached_source_files = []
+    return ctx
+
+
+@pytest.fixture
+def phase(plugin_context):
+    """A ScanPhase whose validation_manager is the REAL class, not a double."""
+    scan_phase = ScanPhase(
+        plugin_context=plugin_context,
+        plugins=[],
+        progress_display=MagicMock(),
+    )
+    scan_phase.validation_manager = ScannerValidationManager(plugin_context)
+    return scan_phase
+
+
+def _expect_a_scanner_that_never_completes(phase, name="bandit"):
+    """Register *name* as queued, so validating completion finds it missing.
+
+    This is the only shape that reaches the reporting call: a scanner the
+    validator expected to complete, which did not.
+    """
+    manager = phase.validation_manager
+    manager.update_scanner_state(name, registration_status="registered")
+    manager.update_scanner_state(name, enablement_status="enabled")
+    manager.update_scanner_state(name, queued_for_execution=True)
+    # No _completed_scanners, so the phase reports nothing completed.
+    phase._completed_scanners = []
+    return name
+
+
+# ---------------------------------------------------------------------------
+# 1. Execution-completion reporting
+# ---------------------------------------------------------------------------
+
+
+def test_execution_discrepancy_report_reaches_the_results(phase):
+    """The report the call site asks for must land on the results object."""
+    missing = _expect_a_scanner_that_never_completes(phase)
+    results = AshAggregatedResults()
+
+    phase._validate_execution_completion(results)
+
+    report = getattr(results.metadata, "execution_discrepancy_report", None)
+    assert report, (
+        "execution_discrepancy_report is empty; either the call to "
+        "report_execution_discrepancies raised and the except Exception handler "
+        "swallowed it, or the assignment was guarded by a hasattr() that cannot "
+        "be false because ReportMetadata declares the field"
+    )
+    assert missing in report["missing_scanners"]
+    assert report["missing_count"] == 1
+    assert (
+        report["total_discrepancies"]
+        == report["missing_count"] + report["unexpected_count"]
+    )
+    # Deliberately NOT asserting has_discrepancies is True. It mirrors
+    # checkpoint.has_issues(), which tracks *recorded* discrepancies and errors,
+    # and a missing scanner does not set that -- see
+    # test_missing_scanners_detected in test_validation_checkpointer.py, which
+    # pins the same asymmetry on the checkpoint itself. The counts are the field
+    # that carries the information here.
+    assert "has_discrepancies" in report
+
+
+def test_a_discrepancy_still_records_its_checkpoint_and_summary(phase):
+    """The bigger loss: the writes AFTER the report call, outside the if.
+
+    validation_checkpoints and validation_summary are populated below the
+    reporting call but outside the discrepancy branch, so an exception at the
+    report call discards them for every scan that has a discrepancy. Asserting
+    only on the report would pass while this stayed broken.
+    """
+    _expect_a_scanner_that_never_completes(phase)
+    results = AshAggregatedResults()
+
+    phase._validate_execution_completion(results)
+
+    names = [cp.get("checkpoint_name") for cp in results.validation_checkpoints]
+    assert names, (
+        "no validation checkpoint recorded; the method aborted into its "
+        "except handler before reaching the checkpoint write"
+    )
+    summary = getattr(results.metadata, "validation_summary", None)
+    assert summary and "execution_completion_validation" in summary
+
+
+def test_no_discrepancy_leaves_the_report_empty(phase):
+    """Control: the report is populated only for the discrepancy case.
+
+    Without this, a change that populated the report unconditionally would
+    satisfy the two tests above.
+
+    Asserts emptiness rather than absence, and that is forced rather than
+    chosen: ReportMetadata DECLARES execution_discrepancy_report with a default
+    of {}, so the attribute always exists and "never written" is
+    indistinguishable from "written as the default". Emptiness is the strongest
+    assertion available, and it still fails a change that writes a populated
+    report when nothing was wrong.
+    """
+    phase._completed_scanners = []
+    results = AshAggregatedResults()
+
+    phase._validate_execution_completion(results)
+
+    assert not getattr(results.metadata, "execution_discrepancy_report", None)
+
+
+# ---------------------------------------------------------------------------
+# 2. Result-completeness reporting
+# ---------------------------------------------------------------------------
+
+
+def test_result_completeness_report_reaches_the_results(phase):
+    """The second call site, which has the same defect and no stub at all.
+
+    The test fixture in test_scan_phase.py did not even stub
+    report_result_completeness -- it stubbed a differently-named phantom,
+    validate_result_completeness, while the real facade method is
+    ensure_complete_results.
+    """
+    _expect_a_scanner_that_never_completes(phase)
+    results = AshAggregatedResults()
+
+    phase._validate_result_completeness(results)
+
+    report = getattr(results.metadata, "result_completeness_report", None)
+    assert report is not None, (
+        "result_completeness_report was never written; the call to "
+        "report_result_completeness raised and was swallowed"
+    )
+    assert "has_adjustments" in report
+    assert "missing_scanners" in report
+    assert "unexpected_scanners" in report

--- a/tests/unit/models/test_validation_checkpointer.py
+++ b/tests/unit/models/test_validation_checkpointer.py
@@ -92,3 +92,113 @@ class TestRetryRegistrationRemoved:
         mgr = ScannerValidationManager(ctx)
         result = mgr.retry_scanner_registration(["bandit"])
         assert result == []
+
+
+class TestFacadeExposesEveryMethodScanPhaseCalls:
+    """The facade's surface, against the real caller rather than by inspection.
+
+    ``TestRetryRegistrationRemoved`` above already guards one method this way,
+    which is the right instinct -- the split into StateTracker/Checkpointer can
+    silently drop a facade method and nothing else notices. It guarded one of
+    three. ``report_execution_discrepancies`` and ``report_result_completeness``
+    were dropped by that same split and went unnoticed because the scan_phase
+    test fixture substitutes a bare MagicMock, which fabricates them.
+
+    Derived from the source rather than hardcoded, so a new call added to
+    scan_phase.py is covered without anyone remembering to extend this list.
+    """
+
+    def _names_called_on_the_manager(self) -> set:
+        import re
+        from pathlib import Path
+
+        import automated_security_helper
+
+        source = (
+            Path(automated_security_helper.__file__).parent
+            / "core"
+            / "phases"
+            / "scan_phase.py"
+        ).read_text(encoding="utf-8")
+        return set(re.findall(r"self\.validation_manager\.(\w+)\s*\(", source))
+
+    def test_the_source_actually_yielded_names(self):
+        """Positive control. An empty set would make the next test vacuous."""
+        names = self._names_called_on_the_manager()
+        assert len(names) >= 5, f"only found {names!r}; the regex or path is wrong"
+
+    def test_every_called_name_exists_on_the_facade(self):
+        missing = sorted(
+            name
+            for name in self._names_called_on_the_manager()
+            if not hasattr(ScannerValidationManager, name)
+        )
+        assert not missing, (
+            f"scan_phase.py calls {missing} on ScannerValidationManager, and the "
+            f"facade does not define them. Either restore them or remove the calls"
+        )
+
+
+class TestDiscrepancyReporting:
+    """The two restored reporters, on their documented shape."""
+
+    def test_execution_discrepancies_summarises_the_checkpoint(self, manager):
+        checkpoint = manager.create_checkpoint(
+            "cp",
+            expected_scanners=["bandit", "semgrep"],
+            actual_scanners=["bandit", "grype"],
+        )
+        report = manager.report_execution_discrepancies(checkpoint)
+
+        assert report["missing_scanners"] == ["semgrep"]
+        assert report["unexpected_scanners"] == ["grype"]
+        assert report["missing_count"] == 1
+        assert report["unexpected_count"] == 1
+        assert report["total_discrepancies"] == 2
+        # has_discrepancies tracks the checkpoint's own has_issues(), which is
+        # about recorded discrepancies/errors and is NOT implied by a missing
+        # scanner -- see test_missing_scanners_detected above.
+        assert report["has_discrepancies"] == checkpoint.has_issues()
+
+    def test_execution_discrepancies_on_a_clean_checkpoint(self, manager):
+        checkpoint = manager.create_checkpoint(
+            "cp", expected_scanners=["bandit"], actual_scanners=["bandit"]
+        )
+        report = manager.report_execution_discrepancies(checkpoint)
+
+        assert report["missing_scanners"] == []
+        assert report["unexpected_scanners"] == []
+        assert report["total_discrepancies"] == 0
+
+    def test_result_completeness_summarises_the_checkpoint(self, manager):
+        checkpoint = manager.create_checkpoint(
+            "cp",
+            expected_scanners=["bandit", "semgrep"],
+            actual_scanners=["bandit"],
+        )
+        report = manager.report_result_completeness(checkpoint)
+
+        assert report["missing_scanners"] == ["semgrep"]
+        assert report["unexpected_scanners"] == []
+        assert report["has_adjustments"] == checkpoint.has_issues()
+
+    def test_reporters_do_not_mutate_the_checkpoint(self, manager):
+        """They are pure summaries; a reporter that recorded state would make
+        the count depend on how many times it was called."""
+        checkpoint = manager.create_checkpoint(
+            "cp", expected_scanners=["bandit", "semgrep"], actual_scanners=["bandit"]
+        )
+        before = (
+            list(checkpoint.discrepancies),
+            list(checkpoint.errors),
+            list(checkpoint.actual_scanners),
+        )
+
+        manager.report_execution_discrepancies(checkpoint)
+        manager.report_result_completeness(checkpoint)
+
+        assert (
+            list(checkpoint.discrepancies),
+            list(checkpoint.errors),
+            list(checkpoint.actual_scanners),
+        ) == before


### PR DESCRIPTION
`scan_phase.py` calls two methods on `ScannerValidationManager` that the class does not define. Both raise `AttributeError` in production.

| call site | method | on the class? |
| --- | --- | --- |
| `scan_phase.py:1360` | `report_execution_discrepancies` | no |
| `scan_phase.py:1560` | `report_result_completeness` | no |

## Restored, not removed — the archaeology decided it

Searched a **non-shallow** clone of 525 commits, so a "never existed" answer could be trusted, and with a positive control on a name that does exist.

- `ba32f87` (ASH v3 Release, #117) added both definitions **and** both call sites, together.
- `1641742` (PR #412) removed the definitions and left the calls.

`1641742` is PR **#412**, titled *"fix(logging): restore UTF-8 console reconfiguration on Windows"*. It squashes together the logging fix, a ~5,750-line dead-code sweep, three unrelated bug fixes, **and** the StateTracker/Checkpointer split of `ScannerValidationManager`. That refactor's own commit message states:

> all external callers (scan_phase.py, tests) continue to work unchanged

That claim was inaccurate here — the new facade dropped these two methods and the callers were left in place. Flagging it because a reviewer tracing this will find that sentence and be misled by it exactly as I initially was. It is also a concrete argument against squashing unrelated work: the commit subject gives no reason to suspect a validation refactor, so neither `git log --oneline` nor the PR title surfaces where the methods went.

**A dead end worth recording.** Three commits carry that same refactor message — `96741d7`, `fe090c1`, `ba959e9` — and **none of them is an ancestor of main**. The obvious theory ("the refactor that landed removed them") was wrong until I checked ancestry: `git log --all` finding a commit says nothing about whether it is in your history. The refactor reached main only via the squash in #412.

So the validation was wanted. Both are restored on `ValidationCheckpointer` beside the validators that produce their input, with facade delegations beside the matching ones, unchanged from the originals. They are pure functions of the checkpoint.

## A second, independent defect in the same path

Restoring the methods alone would not have made the report appear:

```python
if not hasattr(metadata, "execution_discrepancy_report"):
    metadata.execution_discrepancy_report = discrepancy_report
```

`ReportMetadata` **declares** `execution_discrepancy_report` with a default of `{}`, so `hasattr` is always `True` and the assignment is dead code. The report would have stayed `{}` forever.

The asymmetry is the dangerous part: the identical-looking guard on `result_completeness_report` **does** fire, because that field is *not* declared. A method-only fix would have shipped one report populated and the other permanently empty, silently. Both assignments are now unconditional — each method runs once per scan and recomputes its report, so there is nothing to preserve by guarding.

## The cost was larger than two missing reports

Both call sites sit inside a `try` whose handler is `except Exception`. So the `AttributeError` was caught, logged at ERROR, an ERROR event was emitted, and the scan continued — but the handler **abandons the rest of the method**, and that is where `aggregated_results.validation_checkpoints` is appended and `metadata.validation_summary` is written. Those sit *outside* the discrepancy branch, so every scan with a scanner discrepancy lost them too.

The tests assert the checkpoint and the summary, not only the reports. Asserting only the reports would pass as soon as the method stops raising, while leaving the larger loss in place.

## Why no test caught it, and the fix for that

The `scan_phase` fixture substituted a bare `MagicMock`, which fabricates any attribute that is accessed. It had accumulated stubs for **three** methods the real class does not define:

- `report_execution_discrepancies` — the defect
- `report_result_completeness` — not even stubbed, though it is called
- `validate_result_completeness` — never a method at all; the facade calls it `ensure_complete_results`

A double that agrees with everything verifies nothing. The fixture now uses `spec=ScannerValidationManager`, which refuses unknown attributes. Verified by positive control: a bare Mock accepts a phantom stub, a spec'd one raises. It has teeth — re-removing either facade method now produces **38 setup errors** in that file instead of 38 silent passes.

Two new test groups:

- `tests/unit/core/phases/test_scan_phase_validation_reporting.py` drives the **real** manager through the discrepancy branch. That branch is reachable only when the expected and completed scanner sets differ, which a healthy single-project scan never produces — which is why CI never hit it. The tests construct the discrepancy directly.
- A **source-derived** facade test that greps `scan_phase.py` for every `self.validation_manager.X(` call and asserts the facade defines `X`, so the next dropped method is caught without anyone maintaining a list. It carries a positive control against an empty match set, since a broken regex would make it vacuous.

`test_validation_checkpointer.py` already guarded one facade method this way (`retry_scanner_registration`) — the right instinct, applied to one of three. This generalises it.

## Verification

Re-measured after rebasing onto current `main` (`0ac9d3a5`), because a baseline taken at an older main does not reconcile against the tree CI will use:

| check | result |
| --- | --- |
| 3.13 `-n auto`, before (`main` 0ac9d3a5, fresh worktree) | 3062 passed, 110 skipped |
| 3.13 `-n auto`, after | **3072 passed, 110 skipped** |
| 3.13 `-n 0`, after | 3072 passed, 110 skipped |
| 3.10, touched files | 96 passed |

The ten commits main gained touch `cli/mcp/__init__.py` and `config/resolve_config.py`; neither `scanner_validation.py`, `scan_phase.py`, nor any test file in this PR was among them, so there is no semantic overlap. Confirmed by diffing the paths rather than assuming.

**+10**, exactly the number of tests added, zero failures, and the skipped-test ID sets are **byte-identical** before and after — so nothing was silently disabled to get here.

Five mutations, each caught by a named test, with an identity control that must stay green:

```
MUT0 identity                              56 passed          <- control
MUT1 facade drops report_execution_...      6 failed, 38 errors
MUT2 facade drops report_result_...         4 failed, 38 errors
MUT3 dead hasattr guard restored            1 failed
MUT4 missing_count hardcoded 0              2 failed
MUT5 reporter mutates its checkpoint        1 failed
```

## Note for reviewers

`has_discrepancies` in the execution report mirrors `checkpoint.has_issues()`, which tracks *recorded* discrepancies and errors — a missing scanner does **not** set it. So `has_discrepancies` can be `False` while `missing_count` is non-zero. That asymmetry predates this change and is preserved deliberately; the counts are the field that carries the information. It is documented at the method and asserted in the tests. I initially asserted `has_discrepancies is True` and the code was right, not the test.
