### PR TITLE
fix(core): let callers hand the orchestrator an already-resolved config

### DIFF
--- a/automated_security_helper/core/orchestrator.py
+++ b/automated_security_helper/core/orchestrator.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Annotated, Any, Dict, List, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, ValidationError
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, model_validator
 
 from automated_security_helper.base.plugin_context import PluginContext
 from automated_security_helper.config.default_config import get_default_config
@@ -52,6 +52,21 @@ class ASHScanOrchestrator(BaseModel):
     ] = None
     config: Annotated[
         AshConfig | None, Field(description="The resolved ASH configuration")
+    ] = None
+    resolved_config: Annotated[
+        AshConfig | None,
+        Field(
+            description=(
+                "A configuration the caller has already resolved and merged. When "
+                "set, initialize() adopts it verbatim instead of resolving one of "
+                "its own, and leaves it as the value of `config`. Because "
+                "resolution is skipped entirely, the caller must have applied any "
+                "config_overrides itself before building this config: they cannot "
+                "be supplied alongside it (see _reject_conflicting_config_inputs) "
+                "and nothing here will apply them. A caller that resolves without "
+                "overrides and then passes the result will silently drop them."
+            )
+        ),
     ] = None
 
     strategy: Annotated[
@@ -155,6 +170,42 @@ class ASHScanOrchestrator(BaseModel):
     # Sentinel: True after initialize() has run successfully
     _initialized: bool = False
 
+    @model_validator(mode="after")
+    def _reject_conflicting_config_inputs(self) -> "ASHScanOrchestrator":
+        """Refuse a pre-resolved config alongside the inputs to resolution.
+
+        `resolved_config` says resolution already happened; `config_path` and
+        `config_overrides` say how to perform it. Accepting both would mean
+        honouring one and dropping the other, which is the failure
+        `resolved_config` exists to fix — so refuse instead of picking a winner.
+        Empty values do not conflict: callers routinely pass `... or []`.
+
+        The consequence for the caller is that they own the overrides. Nothing
+        downstream of this point applies them, so a caller that resolves without
+        them and hands the result over drops them silently. The error below says
+        so, because whoever hits it is exactly who needs to know.
+        """
+        if self.resolved_config is None:
+            return self
+        conflicting = [
+            name
+            for name, value in (
+                ("config_path", self.config_path),
+                ("config_overrides", self.config_overrides),
+            )
+            if value
+        ]
+        if conflicting:
+            supplied = " and ".join(conflicting)
+            raise ValueError(
+                f"resolved_config cannot be combined with {supplied}. A resolved "
+                f"config means resolution has already happened, so {supplied} "
+                "would have no effect. Apply them yourself before building the "
+                "config you pass as resolved_config, because nothing else will, "
+                "or drop resolved_config and let the orchestrator resolve."
+            )
+        return self
+
     def model_post_init(self, context):
         """Post initialization — data-only; no filesystem I/O."""
         super().model_post_init(context)
@@ -180,11 +231,17 @@ class ASHScanOrchestrator(BaseModel):
 
         ASH_LOGGER.info(f"Initializing ASH v{get_ash_version()}")
 
-        self.config = resolve_config(
-            config_path=self.config_path,
-            source_dir=self.source_dir,
-            config_overrides=self.config_overrides or [],
-        )
+        if self.resolved_config is not None:
+            ASH_LOGGER.verbose(
+                "Using the configuration supplied by the caller; skipping resolution"
+            )
+            self.config = self.resolved_config
+        else:
+            self.config = resolve_config(
+                config_path=self.config_path,
+                source_dir=self.source_dir,
+                config_overrides=self.config_overrides or [],
+            )
 
         # Surface config resolution warnings prominently
         if self.config._resolution_warnings:

--- a/tests/unit/core/test_orchestrator_resolved_config.py
+++ b/tests/unit/core/test_orchestrator_resolved_config.py
@@ -1,0 +1,172 @@
+"""Tests for handing ASHScanOrchestrator a configuration that is already resolved.
+
+``initialize()`` called ``resolve_config()`` unconditionally and assigned the
+result over ``self.config``, so a caller that had already resolved and merged a
+configuration had no way to hand it in — the orchestrator threw it away and
+re-read from disk. ``resolved_config`` is the way in.
+
+These tests pin three things: the supplied configuration is the one that reaches
+the execution engine, the default path still resolves for every caller that does
+not opt in, and supplying both a resolved configuration and the inputs to
+resolution is refused rather than silently half-honoured.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.core.orchestrator import ASHScanOrchestrator
+
+
+def _dirs(tmp_path):
+    src = tmp_path / "src"
+    src.mkdir()
+    return src, tmp_path / "out"
+
+
+class TestResolvedConfigIsUsedAsIs:
+    """A caller-supplied configuration must survive initialize() untouched."""
+
+    def test_initialize_does_not_re_resolve(self, tmp_path):
+        src, out = _dirs(tmp_path)
+        supplied = AshConfig(project_name="supplied-by-caller")
+
+        with patch(
+            "automated_security_helper.core.orchestrator.resolve_config",
+            return_value=AshConfig(project_name="re-resolved-from-disk"),
+        ) as mock_resolve:
+            orch = ASHScanOrchestrator.create(
+                source_dir=src,
+                output_dir=out,
+                resolved_config=supplied,
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+        assert mock_resolve.call_count == 0, (
+            "resolve_config must not run when the caller supplied a resolved config"
+        )
+        assert orch.config is supplied
+        assert orch.config.project_name == "supplied-by-caller"
+
+    def test_resolved_config_reaches_the_execution_engine(self, tmp_path):
+        """Storing it on the model is not enough — the engine must see it."""
+        src, out = _dirs(tmp_path)
+        supplied = AshConfig(project_name="supplied-by-caller")
+
+        with patch(
+            "automated_security_helper.core.orchestrator.resolve_config",
+            return_value=AshConfig(project_name="re-resolved-from-disk"),
+        ):
+            orch = ASHScanOrchestrator.create(
+                source_dir=src,
+                output_dir=out,
+                resolved_config=supplied,
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+        assert orch.execution_engine is not None
+        assert orch.execution_engine._context.config is supplied
+
+
+class TestDefaultPathUnchanged:
+    """Callers that do not opt in keep resolving exactly as before."""
+
+    def test_initialize_still_resolves_when_not_supplied(self, tmp_path):
+        src, out = _dirs(tmp_path)
+
+        with patch(
+            "automated_security_helper.core.orchestrator.resolve_config",
+            return_value=AshConfig(project_name="re-resolved-from-disk"),
+        ) as mock_resolve:
+            orch = ASHScanOrchestrator.create(
+                source_dir=src,
+                output_dir=out,
+                config_path=None,
+                config_overrides=None,
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+        assert mock_resolve.call_count == 1
+        assert orch.config.project_name == "re-resolved-from-disk"
+
+    def test_config_path_and_overrides_are_forwarded_to_resolution(self, tmp_path):
+        """The resolution inputs must still arrive at resolve_config verbatim."""
+        src, out = _dirs(tmp_path)
+        config_file = tmp_path / "ash.yaml"
+        config_file.write_text("project_name: from-file\n", encoding="utf-8")
+
+        with patch(
+            "automated_security_helper.core.orchestrator.resolve_config",
+            return_value=AshConfig(project_name="re-resolved-from-disk"),
+        ) as mock_resolve:
+            ASHScanOrchestrator.create(
+                source_dir=src,
+                output_dir=out,
+                config_path=config_file,
+                config_overrides=["global_settings.severity_threshold=LOW"],
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+        kwargs = mock_resolve.call_args.kwargs
+        assert kwargs["config_path"] == config_file
+        assert kwargs["config_overrides"] == ["global_settings.severity_threshold=LOW"]
+
+
+class TestConflictingConfigInputsRefused:
+    """resolved_config plus the inputs to resolution is a contradiction."""
+
+    def test_resolved_config_with_config_path_is_refused(self, tmp_path):
+        src, out = _dirs(tmp_path)
+
+        with pytest.raises(ValidationError, match="resolved_config"):
+            ASHScanOrchestrator(
+                source_dir=src,
+                output_dir=out,
+                resolved_config=AshConfig(project_name="supplied-by-caller"),
+                config_path=tmp_path / "ash.yaml",
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+    def test_resolved_config_with_config_overrides_is_refused(self, tmp_path):
+        src, out = _dirs(tmp_path)
+
+        with pytest.raises(ValidationError, match="config_overrides"):
+            ASHScanOrchestrator(
+                source_dir=src,
+                output_dir=out,
+                resolved_config=AshConfig(project_name="supplied-by-caller"),
+                config_overrides=["global_settings.severity_threshold=LOW"],
+                no_cleanup=False,
+                metadata=None,
+                ash_plugin_modules=[],
+            )
+
+    def test_empty_resolution_inputs_are_not_a_conflict(self, tmp_path):
+        """run_ash_scan passes ``config_overrides or []`` — an empty list is fine."""
+        src, out = _dirs(tmp_path)
+        supplied = AshConfig(project_name="supplied-by-caller")
+
+        orch = ASHScanOrchestrator(
+            source_dir=src,
+            output_dir=out,
+            resolved_config=supplied,
+            config_path=None,
+            config_overrides=[],
+            no_cleanup=False,
+            metadata=None,
+            ash_plugin_modules=[],
+        )
+
+        assert orch.resolved_config is supplied


### PR DESCRIPTION
## What broke

`ASHScanOrchestrator.initialize()` resolved a configuration and assigned it over `self.config` unconditionally:

```python
self.config = resolve_config(
    config_path=self.config_path,
    source_dir=self.source_dir,
    config_overrides=self.config_overrides or [],
)
```

The `config` field is public and settable, so a caller could pass `config=` and get no error — but `initialize()` overwrote it and re-read from disk. There was no way to drive the orchestrator from a configuration that had already been resolved and merged elsewhere.

## Why it matters

Anything that composes a configuration before the scan — a wrapper that merges several sources, a long-running host that resolves once and scans many times, a caller that has applied its own overrides — has to either accept a second resolution from disk or reach past the public API. The failure is silent: `config=` is accepted and then discarded, so the caller sees a successful scan run against settings it did not choose.

Today this is latent rather than live. No construction site passes `config=`, so nothing is losing a configuration right now. It becomes live the first time someone tries.

## The change

A `resolved_config` field. When set, `initialize()` adopts it verbatim and skips its own resolution. When unset — every current caller — resolution happens exactly as before. `config` keeps its meaning as the resolved result.

Passing `resolved_config` together with `config_path` or `config_overrides` is **refused at construction**, not resolved by precedence. `config_path` and `config_overrides` are inputs to the resolution that `resolved_config` skips, so any precedence rule means honouring one of the caller's arguments and silently ignoring the other. That is the same silent discard this field exists to remove, so it would be a poor way to fix it. Refusing costs the caller one line — fold the path and the overrides into the resolution they are already performing — and the error names both arguments. An empty `config_overrides` list is not treated as a conflict, because `run_ash_scan` passes `config_overrides=opts.config_overrides or []`.

The refusal is a `@model_validator(mode="after")`, matching the cross-field checks in `base/plugin_context.py`, `base/plugin_base.py` and the built-in scanners.

### The refusal makes the caller responsible for the overrides, and the field says so

Because resolution is skipped entirely, a caller passing `resolved_config` owns the overrides. Nothing downstream applies them. So a caller that resolves *without* overrides and then hands the result over drops them silently — the same shape of fail-open as returning an unmodified config when an override does not validate.

That is a genuinely easy mistake to make, because the natural way to build a `resolved_config` is a plain `resolve_config(config_path=..., source_dir=...)` call, and omitting `config_overrides` there is invisible today: the orchestrator resolves a second time and applies them anyway. The moment such a config is passed as `resolved_config`, `--config-overrides` stop taking effect with no error and no warning.

The field description states this as a requirement rather than describing the mechanism and leaving it implied, and the validator's error repeats it — whoever hits the refusal is exactly the person who has just taken on that responsibility:

> Because resolution is skipped entirely, the caller must have applied any `config_overrides` itself before building this config: they cannot be supplied alongside it (see `_reject_conflicting_config_inputs`) and nothing here will apply them. A caller that resolves without overrides and then passes the result will silently drop them.

### The refusal fires more often than the obvious case

It is not limited to callers who pass `--config-overrides`. `cli/scan.py` normalises `config_overrides` to `[]` (line 329) and then appends `reporters.markdown.options.compact=true` whenever `--compact-report` is given (line 385), forwarding it at line 406. So a plain `--compact-report` makes `config_overrides` non-empty on its own, and any caller combining `resolved_config` with that flag hits the validator without having touched `--config-overrides`. That is the validator working correctly, but it is worth knowing before reading the refusal as an edge case.

The caller-side cost of satisfying it is small. Once `resolved_config` is set, `self.config_path` is used in only three places on this branch: the refusal (line 193), the `resolve_config` call being skipped (line 241), and one verbose log line, `Configuration path: ...` (line 372). Dropping both arguments costs that one diagnostic, which a caller can log itself.

## Call sites checked

Every construction of `ASHScanOrchestrator` in the repository, including markdown, `docs/`, `examples/`, `scripts/`, `quickstart/`, `ci/` and `ash-agent-plugins/`:

- **Production: 1.** `automated_security_helper/interactions/run_ash_scan.py:379`, via `.create()`. Passes `config_path` and `config_overrides`; does not pass `config` or `resolved_config`.
- **Tests: 16.** 13 direct constructor calls (`tests/integration/test_global_suppressions.py` x2, `tests/unit/core/test_orchestrator.py` x6, `tests/unit/core/test_orchestrator_factory.py` x5) and 3 `.create()` calls (`test_orchestrator_factory.py`).
- **Sites already passing `config=`: 0.**
- **Subclasses: 0.** Two duck-typed test doubles (`test_offline_propagation_fix.py`) define `create(cls, **kwargs)` and absorb any keyword.
- **`initialize()` callers: 3** — `create()` itself, plus two in `test_orchestrator_factory.py`.
- No test asserts on the keyword arguments passed to `.create()`; all five call sites use a bare `assert_called_once()`.

## Verification

Four of the seven new tests fail on base `7c10340`, and they fail for the right reason:

| test | on base |
|---|---|
| `test_initialize_does_not_re_resolve` | fails — `resolve_config` still runs |
| `test_resolved_config_reaches_the_execution_engine` | fails — the engine's context holds the re-resolved config |
| `test_resolved_config_with_config_path_is_refused` | fails — `DID NOT RAISE`; `extra="allow"` accepts the unknown keyword with no effect |
| `test_resolved_config_with_config_overrides_is_refused` | fails — same |

The other three pin behaviour that must not change (`initialize()` still resolves when not opted in, `config_path` and `config_overrides` still reach `resolve_config`, an empty override list is not a conflict) and pass on both sides.

Each half of the change was then reverted in isolation to confirm no test is vacuous:

| mutation | reddens |
|---|---|
| `initialize()` always re-resolves | the 2 "uses the supplied config" tests |
| conflict validator returns early | the 2 refusal tests |
| conflict check uses `is not None` instead of truthiness | `test_empty_resolution_inputs_are_not_a_conflict` |
| `initialize()` stops forwarding `config_path`/`config_overrides` | `test_config_path_and_overrides_are_forwarded_to_resolution` |

Counts, taken from a fresh worktree at base `7c10340` rather than by inference. CI runs a bare `uv run pytest`, so `pytest tests` is the CI-equivalent invocation:

| run | base `7c10340` | this branch |
|---|---|---|
| `pytest tests -n auto` | 3054 passed, 110 skipped | 3061 passed, 110 skipped |
| `pytest tests -n 0` | 3054 passed, 110 skipped | 3061 passed, 110 skipped |

`+7`, matching the seven new test functions, and `+7` collected (3164 -> 3171). Skipped-test ID sets are byte-identical between base and branch and between `-n auto` and `-n 0`, so nothing of mine failed to run and nothing existing stopped running.

The constraint wording added to the field description, the validator docstring and the error message is documentation only. It was re-verified after the fact: the tests are byte-identical (only `orchestrator.py` differs from the previous revision), the counts and the skipped-test ID set are unchanged, and re-running the validator mutation still reddens both refusal tests, so the two `pytest.raises(..., match=...)` patterns still bind against the new message text.

Also run: `tests/unit/core` on **Python 3.10.20** (435 passed), since `requires-python` is `>=3.10` and the CI matrix spans 3.10 to 3.13; the `lint` job's two gates, `python -m automated_security_helper.schemas.generate_schemas` followed by `git diff --exit-code automated_security_helper/schemas/` (no drift — the generator covers only `AshConfig` and `AshAggregatedResults`, not this model) and `scripts/verify_docs_freshness.py` (7/7); `cz check` on the commit. `ruff check` reports 0 findings on the new test file, and `ruff format --check` passes on both files. No temp-path literals and no credential-shaped strings in either file, for the MEDIUM self-scan.
