### PR TITLE
fix(scanner): name the cause when a scan fails, instead of the symptom

### DIFF
--- a/automated_security_helper/base/scanner_plugin.py
+++ b/automated_security_helper/base/scanner_plugin.py
@@ -25,6 +25,11 @@ from abc import abstractmethod
 _VALID_FLAG_KEY_PATTERN = re.compile(r"^-{1,2}[A-Za-z][A-Za-z0-9_\-]*(=.*)?$")
 from pathlib import Path
 
+# How much of a tool's stderr goes into the failure message. The full text stays
+# in the stderr log file, whose path the message names, so this bounds the
+# exception without losing anything.
+_STDERR_EXCERPT_LIMIT = 2000
+
 
 class ScannerPluginConfigBase(PluginConfigBase):
     options: Annotated[ScannerOptionsBase, Field(description="Scanner options")] = (
@@ -373,10 +378,25 @@ class ScannerPluginBase(PluginBase, Generic[T]):
     def _read_results_file(self, results_file: "Path") -> Optional[dict]:
         """Read and parse the scanner results file as JSON.
 
-        Default reads the file as JSON. Subclasses may override to add
-        empty-file detection or alternative parsing. Return None to signal
-        an empty/missing result that should be replaced with the default
-        empty SARIF report (see ``_handle_empty_results``).
+        Returns ``None`` for a file that exists and is EMPTY, which
+        ``scan()`` replaces with the default empty SARIF report (see
+        ``_handle_empty_results``).
+
+        A **missing** file must raise, and that is a constraint rather than an
+        accident of this implementation. Returning ``None`` for it would route a
+        scanner that produced no output at all into ``_handle_empty_results()``,
+        which yields an empty SARIF and lets the scan **succeed** -- reporting a
+        clean result for a tool that died. That is a false negative in a security
+        scanner, so the missing case must stay an exception. ``scan()``'s handler
+        enriches it with the exit code and the tool's stderr; see
+        ``_describe_scan_failure``.
+
+        An earlier version of this docstring said ``None`` signalled an
+        "empty/missing" result, which the code has never done for missing. The
+        wording is corrected here rather than the behaviour.
+
+        Subclasses may override to add their own empty-file detection or
+        alternative parsing, but must preserve the missing-file raise.
         """
         with open(results_file, mode="r", encoding="utf-8") as fh:
             content = fh.read()
@@ -483,6 +503,10 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             self._post_scan(target=target, target_type=target_type)
             return False
 
+        # Bound before the try so the failure handler can name the stderr log
+        # even when _execute_scan itself is what raised.
+        results_file = None
+
         try:
             final_args, results_file, subprocess_env = self._execute_scan(
                 target=target,
@@ -529,7 +553,89 @@ class ScannerPluginBase(PluginBase, Generic[T]):
             return sarif_report
 
         except Exception as e:
-            raise ScannerError(f"{self.__class__.__name__} scan failed: {e}")
+            raise ScannerError(self._describe_scan_failure(e, results_file))
+
+    def _describe_scan_failure(
+        self, exc: Exception, results_file: Optional["Path"]
+    ) -> str:
+        """Build the failure message, naming the cause rather than the symptom.
+
+        Why this exists
+        ---------------
+        A tool that exits non-zero raises nothing:
+        ``run_command_with_output_handling`` passes ``check=False``, so
+        ``_run_subprocess`` returns ``{"returncode": 7}`` normally. ``scan()``
+        then reads a results file the tool never wrote, and the FileNotFoundError
+        from THAT is what surfaced -- two steps from the cause, in a different
+        function, as a different exception type. Two opengrep runs failed in CI
+        this way and the reported error was ``[Errno 2] No such file or
+        directory``, which says nothing about why.
+
+        The stderr was not lost. ``_run_subprocess`` defaults to
+        ``stderr_preference="write"``, so it went to
+        ``<results_dir>/<ClassName>.stderr.log`` and never into ``self.errors``
+        -- ``_process_command_response`` only populates that from a RETURNED
+        stderr, and only 3 of the 8 call sites ask for one. So this reads the log
+        file when ``self.errors`` is empty, which is the common case rather than
+        the exotic one.
+
+        Why the exit code needs a verdict, not just a value
+        --------------------------------------------------
+        ``success_exit_codes`` is ``{0, 1}`` and bandit deliberately exits 1 when
+        it finds issues, so "non-zero" does not mean "failed". The message states
+        the code AND whether this scanner accepts it, because that pair is what
+        separates "the tool ran and signalled findings" from "the tool died". It
+        is also why nothing here branches on ``exit_code != 0``: this method only
+        describes a failure that has already happened and changes no control
+        flow.
+
+        Failure modes
+        -------------
+        * Reading the log is best-effort. If it cannot be read the message says
+          where it looked, so the reader can tell "stderr was empty" from
+          "stderr was not where we checked".
+        * stderr is truncated to keep a scanner that wrote megabytes from
+          swamping the error; the full text stays in the log file, which is
+          named.
+        """
+        detail = f"{self.__class__.__name__} scan failed: {exc}"
+
+        accepted = self.exit_code in self.success_exit_codes
+        verdict = (
+            "an accepted exit code for this scanner"
+            if accepted
+            else f"not an accepted exit code; success_exit_codes="
+            f"{sorted(self.success_exit_codes)}"
+        )
+        detail += f" (exit code {self.exit_code}: {verdict})"
+
+        stderr_text = "\n".join(self.errors).strip()
+        log_path = None
+        if results_file is not None:
+            log_path = (
+                Path(results_file).parent / f"{self.__class__.__name__}.stderr.log"
+            )
+
+        if not stderr_text and log_path is not None:
+            try:
+                stderr_text = log_path.read_text(
+                    encoding="utf-8", errors="replace"
+                ).strip()
+            except OSError:
+                stderr_text = ""
+
+        if stderr_text:
+            if len(stderr_text) > _STDERR_EXCERPT_LIMIT:
+                stderr_text = (
+                    stderr_text[:_STDERR_EXCERPT_LIMIT] + " ...[truncated]"
+                )
+            detail += f". Stderr: {stderr_text}"
+        elif log_path is not None:
+            detail += f". No stderr captured; checked {log_path.as_posix()}"
+        else:
+            detail += ". No stderr captured."
+
+        return detail
 
     ### Methods that require implementation by plugins.
     def validate_plugin(self) -> bool:

--- a/tests/unit/base/test_scanner_failure_diagnostics.py
+++ b/tests/unit/base/test_scanner_failure_diagnostics.py
@@ -1,0 +1,280 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""When a scanner fails, the reported error must name the cause.
+
+The failure this pins
+---------------------
+Two opengrep runs failed in CI with exit code 7 and the reported error was
+``[Errno 2] No such file or directory``. The stderr existed the whole time --
+on disk, in ``<results_dir>/OpengrepScanner.stderr.log`` -- and the error
+message simply never looked there. Nothing was destroyed; the diagnostic was
+just not where anyone reading the error would find it.
+
+Why the stderr is on disk rather than in ``self.errors``
+-------------------------------------------------------
+``_run_subprocess`` defaults to ``stderr_preference="write"``
+(``plugin_base.py``), so stderr is written to a log file and NOT returned in the
+response. ``_process_command_response`` only extends ``self.errors`` from
+``response.get("stderr")``, which is absent under that default. Only 3 of the 8
+production call sites pass a preference that returns stderr, so the empty
+``self.errors`` case is the common one, not the exotic one -- which is why the
+log-file fallback below is the test that matters most.
+
+A non-zero exit is not an exception
+-----------------------------------
+``run_command_with_output_handling`` passes ``check=False``
+(``subprocess_utils.py``), so a tool exiting 7 returns ``{"returncode": 7}`` and
+raises nothing. The scan then proceeds to read a results file the tool never
+wrote, and THAT is what raises. So the failure surfaces two steps away from its
+cause, in a different function, as a different exception type.
+
+Why the assertions include the exit code
+---------------------------------------
+``success_exit_codes`` is ``{0, 1}`` and bandit deliberately exits 1 when it
+finds issues, so "non-zero" does not mean "failed". The reported error therefore
+has to say both the code AND whether that code was acceptable for this scanner:
+that pair is what distinguishes "the tool ran and signalled findings" from "the
+tool died". Asserting only that stderr appears would pass a message that leaves
+the reader unable to tell those apart.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from automated_security_helper.base.scanner_plugin import ScannerPluginBase
+from automated_security_helper.core.exceptions import ScannerError
+
+
+def _make_scanner(
+    tmp_path,
+    *,
+    exit_code: int,
+    stderr_to_log: str = "",
+    stderr_to_errors: str = "",
+    writes_results: str | None = None,
+):
+    """Build a scanner over the REAL base whose subprocess behaviour is fixed.
+
+    The fake behaviour is baked into a per-call subclass as class attributes
+    rather than set on the instance, because ``ScannerPluginBase`` is a pydantic
+    model and undeclared instance attributes do not survive assignment. The
+    class is named ``_FakeScanner`` so the stderr log filename the production
+    code derives from ``self.__class__.__name__`` is predictable.
+    """
+    source_dir = tmp_path / "src"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    # scan() returns early on an empty target (scanner_plugin.py:463), so the
+    # directory needs at least one file or none of the error path runs at all.
+    (source_dir / "app.py").write_text("print('x')\n", encoding="utf-8")
+    output_dir = tmp_path / "out"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results_file = output_dir / "scanners" / "fake" / "results.json"
+
+    class _FakeScanner(ScannerPluginBase):
+        """Subclasses the real base so the real ``scan()`` control flow runs."""
+
+        # ClassVar, or pydantic treats these as unannotated model fields and
+        # refuses to build the class.
+        fake_exit_code: ClassVar[int] = exit_code
+        fake_stderr_to_log: ClassVar[str] = stderr_to_log
+        fake_stderr_to_errors: ClassVar[str] = stderr_to_errors
+        fake_writes_results: ClassVar[str | None] = writes_results
+        fake_results_file: ClassVar[Path] = results_file
+
+        def model_post_init(self, context) -> None:
+            return None
+
+        def validate_plugin_dependencies(self) -> bool:
+            return True
+
+        def _execute_scan(self, target, target_type, global_ignore_paths):
+            return (["fake-tool", "--scan"], self.fake_results_file, None)
+
+        def _run_subprocess(self, command, results_dir=None, **kwargs):
+            """Mirror the real one on a non-zero exit: set exit_code, write
+            stderr to the log file, and RETURN rather than raise -- because
+            run_command_with_output_handling passes check=False."""
+            self.exit_code = self.fake_exit_code
+            if self.fake_stderr_to_log and results_dir is not None:
+                log = Path(results_dir) / f"{self.__class__.__name__}.stderr.log"
+                log.parent.mkdir(parents=True, exist_ok=True)
+                log.write_text(self.fake_stderr_to_log, encoding="utf-8")
+            if self.fake_stderr_to_errors:
+                self.errors.extend(self.fake_stderr_to_errors.splitlines())
+            if self.fake_writes_results is not None:
+                self.fake_results_file.parent.mkdir(parents=True, exist_ok=True)
+                self.fake_results_file.write_text(
+                    self.fake_writes_results, encoding="utf-8"
+                )
+            return {"returncode": self.fake_exit_code}
+
+    context = MagicMock()
+    context.source_dir = source_dir
+    context.output_dir = output_dir
+    context.work_dir = tmp_path / "work"
+
+    scanner = _FakeScanner.model_construct()
+    scanner.context = context
+    scanner.config = MagicMock()
+    scanner.config.name = "fake-tool"
+    scanner.errors = []
+    scanner.output = []
+    scanner.exit_code = 0
+    # model_post_init is overridden to a no-op above, so the field it normally
+    # populates has to be set here -- _post_scan calls self.results_dir.mkdir
+    # (scanner_plugin.py:200) and would fail on None before reaching the error
+    # path under test.
+    scanner.results_dir = output_dir / "scanners" / "fake"
+    return scanner
+
+
+def _run(scanner, tmp_path):
+    return scanner.scan(target=tmp_path / "src", target_type="source")
+
+
+# ---------------------------------------------------------------------------
+# 1. stderr already in self.errors reaches the reported error
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_from_errors_list_reaches_the_reported_error(tmp_path):
+    scanner = _make_scanner(
+        tmp_path,
+        exit_code=7,
+        stderr_to_errors="opengrep: could not reach the rule registry",
+    )
+
+    with pytest.raises(ScannerError) as excinfo:
+        _run(scanner, tmp_path)
+
+    message = str(excinfo.value)
+    assert "could not reach the rule registry" in message, message
+    # "exit code 7", not bare "7" -- pytest tmp paths contain digits, so a bare
+    # substring check would pass on the path alone and prove nothing.
+    assert "exit code 7" in message, message
+
+
+# ---------------------------------------------------------------------------
+# 2. The exit code and its acceptability are both stated
+# ---------------------------------------------------------------------------
+
+
+def test_the_error_states_the_exit_code_and_that_it_was_not_acceptable(tmp_path):
+    """`success_exit_codes` is {0, 1}, so 7 is a real failure and 1 is not.
+
+    The message has to carry that judgement, or a reader cannot tell a tool that
+    died from one that exited non-zero to signal findings.
+    """
+    scanner = _make_scanner(tmp_path, exit_code=7, stderr_to_errors="boom")
+
+    with pytest.raises(ScannerError) as excinfo:
+        _run(scanner, tmp_path)
+
+    message = str(excinfo.value)
+    assert "exit code 7" in message, message
+    # The acceptability verdict, not just the number.
+    assert "not an accepted exit code" in message, message
+    assert "success_exit_codes=[0, 1]" in message, message
+
+
+def test_an_accepted_nonzero_exit_is_reported_as_accepted(tmp_path):
+    """Exit 1 is in success_exit_codes -- bandit uses it for findings.
+
+    If the results file is still missing the scan fails anyway, but the message
+    must not accuse the exit code, or it sends the reader after the wrong thing.
+    """
+    scanner = _make_scanner(tmp_path, exit_code=1, stderr_to_errors="just findings")
+
+    with pytest.raises(ScannerError) as excinfo:
+        _run(scanner, tmp_path)
+
+    message = str(excinfo.value)
+    assert "exit code 1" in message, message
+    assert "an accepted exit code for this scanner" in message, message
+    assert "not an accepted" not in message, message
+
+
+# ---------------------------------------------------------------------------
+# 3. The log-file fallback -- the actual opengrep shape
+# ---------------------------------------------------------------------------
+
+
+def test_stderr_is_recovered_from_the_log_file_when_errors_is_empty(tmp_path):
+    """The case that matters: default stderr_preference="write".
+
+    5 of 8 call sites take this default, so stderr is on disk and self.errors is
+    empty. Without this recovery the reported error names a missing file and the
+    reason sits unread in a log beside it.
+    """
+    scanner = _make_scanner(
+        tmp_path,
+        exit_code=7,
+        stderr_to_log="opengrep: registry fetch failed after 3 attempts",
+    )
+    assert scanner.errors == []
+
+    with pytest.raises(ScannerError) as excinfo:
+        _run(scanner, tmp_path)
+
+    message = str(excinfo.value)
+    assert "registry fetch failed after 3 attempts" in message, message
+
+
+def test_the_log_file_path_is_named_when_there_is_no_stderr_anywhere(tmp_path):
+    """A tool that died silently. Say where we looked, so the next reader does
+    not have to guess whether stderr was empty or merely unread."""
+    scanner = _make_scanner(tmp_path, exit_code=7)
+
+    with pytest.raises(ScannerError) as excinfo:
+        _run(scanner, tmp_path)
+
+    message = str(excinfo.value)
+    assert "stderr" in message.lower(), message
+    assert "_FakeScanner.stderr.log" in message, message
+
+
+# ---------------------------------------------------------------------------
+# 4. Positive control: a successful scan is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_a_successful_scan_still_works(tmp_path):
+    """The control that makes every assertion above meaningful.
+
+    A change that reported everything as an error would satisfy all of them.
+    This scanner exits 0 and writes a valid SARIF, and must come back normally.
+    """
+    scanner = _make_scanner(
+        tmp_path,
+        exit_code=0,
+        writes_results='{"version": "2.1.0", "runs": []}',
+    )
+
+    report = _run(scanner, tmp_path)
+
+    assert report is not None
+    assert getattr(report, "version", None) == "2.1.0"
+
+
+def test_an_accepted_nonzero_exit_with_results_still_succeeds(tmp_path):
+    """Bandit's shape: exit 1 with real output. Must not become an error.
+
+    This is the regression that a fix keying on `exit_code != 0` would cause,
+    and it is why the change is message-only.
+    """
+    scanner = _make_scanner(
+        tmp_path,
+        exit_code=1,
+        writes_results='{"version": "2.1.0", "runs": []}',
+    )
+
+    report = _run(scanner, tmp_path)
+
+    assert report is not None
+    assert scanner.exit_code == 1


### PR DESCRIPTION
Two opengrep runs failed in CI with exit code 7 and the reported error was:

```
OpengrepScanner scan failed: [Errno 2] No such file or directory
```

The triage could not determine what exit 7 meant. **The stderr existed the whole time**, on disk, in `<results_dir>/OpengrepScanner.stderr.log`. Nothing was destroyed — the error message never looked where the answer was.

## Why the cause and the report land two steps apart

Two mechanisms combine, and neither is the broad `except Exception` it looks like:

1. **A non-zero exit is not an exception.** `run_command_with_output_handling` passes `check=False` (`subprocess_utils.py`), so a tool exiting 7 returns `{"returncode": 7}` and raises nothing. `_run_subprocess`'s `except Exception` never fires for it. That handler also does not discard anything — it appends to `self.errors`, logs at ERROR, logs a traceback at DEBUG, and returns a `{"error": ...}` sentinel that **0 of 8** production call sites read.
2. **stderr goes to a file, not to `self.errors`.** `_run_subprocess` defaults to `stderr_preference="write"`, so stderr is written to a log and not returned. `_process_command_response` populates `self.errors` only from a **returned** stderr, and only 3 of the 8 call sites ask for one — so an empty `self.errors` is the common case, not the exotic one.

`scan()` then reads a results file the tool never wrote, and the `FileNotFoundError` from *that* is what surfaced: a different function, a different exception type, no exit code, no stderr.

## The change

`_describe_scan_failure` builds the message that path already raises:

```
FakeScanner scan failed: [Errno 2] No such file or directory: '.../results.json'
  (exit code 7: not an accepted exit code; success_exit_codes=[0, 1]).
  Stderr: opengrep: registry fetch failed after 3 attempts
```

It states the exit code **and whether this scanner accepts it**, then stderr from `self.errors`, falling back to reading the log file, and names the log path when there is no stderr anywhere — so "stderr was empty" is distinguishable from "stderr was not where we looked".

**Message-only, deliberately.** `success_exit_codes` is `{0, 1}` and `bandit_scanner.py` says outright *"Bandit emits exit code 1 when findings are present; treat that as success."* So "non-zero" does not mean "failed": nothing here branches on `exit_code != 0`, the verdict is computed from the existing `success_exit_codes` rather than an invented threshold, and **no scan that passed before fails now**. This only changes what an already-failing path reports.

## Docstring correction, with the constraint stated

`_read_results_file` claimed `None` signalled an "empty/missing" result. It has never done that for **missing**, and must not: routing a missing file to `_handle_empty_results()` yields an empty SARIF and lets the scan **succeed**, reporting a clean result for a tool that died — a false negative in a security scanner.

The docstring now states that as a constraint and names the consequence, rather than merely describing current behaviour, so the next reader does not "fix" the mismatch in the fail-open direction. `MUT6` in the mutation harness makes exactly that change and fails 5 tests.

## Deliberately not in this PR — and the follow-up is now scoped by measurement

Changing the default `stderr_preference` from `"write"` to `"both"` so `self.errors` is complete. The diagnostic goal here is met by the log-file fallback, so that is a different change pursuing a different goal, with its own blast radius: `.errors` has 4 real consumers, two of which (`scanner_executor.py:142`, `:159`) surface them to users.

**That question has now been measured, so nobody needs to re-run it.** A deliberately clean fixture — a trivial `app.py`, a dependency-free `package.json`, a bare `main.tf` — so every scanner runs, finds nothing and exits successfully, which makes anything on stderr benign-on-success by construction rather than by judgement. Real scan, exit 0, all scanners `PASSED`, 0 findings:

| scanner | stderr on a clean, successful scan | content |
| --- | --- | --- |
| **semgrep** | 1,469 chars, **29 lines** | Unicode box-drawing "Scan Status" table |
| **opengrep** | 1,107 chars, **20 lines** | same box-drawing table |
| **bandit** | 323 chars, 6 lines | `[main] INFO` progress lines |
| checkov, detect-secrets, npm-audit | none | — |

Since `_process_command_response` does `self.errors.extend(stderr.splitlines())`, flipping the default would put 29 lines of table borders into semgrep's `self.errors` on every clean scan, and `scanner_executor` would surface them as that scanner's errors. A useful control: on that same clean scan **no scanner surfaces any `errors` at all** today, so the noise is not pre-existing — the flip would author it.

**So the default should not be flipped as originally conceived.** If the underlying goal is that a *failure's* stderr reaches `self.errors`, the narrow version is to capture it only when the exit code is **not in `success_exit_codes`** — the discriminator already established above. That leaves the successful path byte-identical, and would make this PR's log-file fallback redundant for the common case rather than load-bearing.

**What is still unmeasured, and is the follow-up's first deliverable:** 3 of the 8 call sites were covered. Not measured, because the tool or plugin package was not installed in the measuring environment: `cfn_nag_scanner.py:272`, `ferret_scanner.py:870`, `snyk_code_scanner.py:238`, `syft_scanner.py:265`, `trivy_repo_scanner.py:278`. These are also the plugins most likely to have unusual exit-code conventions, which matters for a change keyed on `success_exit_codes`. The table above is a **lower bound** on the noise, not a census.

## Verification

| check | result |
| --- | --- |
| 3.13 `-n auto`, before (`main` 0ac9d3a5, pristine worktree) | 3062 passed, 110 skipped |
| 3.13 `-n auto`, after | **3069 passed, 110 skipped** |
| 3.13 `-n 0`, after | 3069 passed, 110 skipped |
| 3.10, `tests/unit/base` | 105 passed |

**+7**, exactly the tests added; skipped-test ID sets **byte-identical**; **zero tests went from green to red** — expected, since a message-only change on an already-failing path cannot newly fail anything. Zero ruff findings added to `scanner_plugin.py` (30 before, 30 after).

Six mutations, each caught by a named test, with an identity control that must stay green:

```
MUT0 identity                                7 passed          <- control
MUT1 bare message restored                   5 failed
MUT2 log-file fallback removed               1 failed
MUT3 acceptability verdict dropped           2 failed
MUT4 acceptability inverted                  2 failed
MUT5 log path not named                      1 failed
MUT6 missing file returns None (fail-open)   5 failed
```

The tests drive the **real** `ScannerPluginBase.scan()` rather than a reimplementation, and include two positive controls — a successful scan and bandit's exit-1-with-results shape — because a change that reported everything as an error would otherwise satisfy every failure assertion. The third case, `stderr_preference="write"` with an empty `self.errors`, is the actual opengrep shape and the one that matters: 5 of 8 call sites take that default.
