### PR TITLE
feat(reporters): carry the project through every reporter, and add the workspace policy file (phases 2b + 3)

### DIFF
--- a/automated_security_helper/base/reporter_plugin.py
+++ b/automated_security_helper/base/reporter_plugin.py
@@ -1,8 +1,44 @@
-"""Module containing the ReporterPlugin base class."""
+"""Module containing the ReporterPlugin base class.
+
+Workspace mode, and why a reporter has to declare what it does
+--------------------------------------------------------------
+A workspace scan produces one SARIF run per project, all in one
+``AshAggregatedResults``. That shape is new: every reporter in this repository
+was written when there was exactly one run, and several of them read
+``runs[0]`` and stop. ``github_ghas_reporter`` is the clearest case -- against an
+N-run model it emits the first project's findings and drops the rest, with no
+error, no warning, and a smaller output file that looks entirely plausible. A
+security reporter that under-reports in silence is the worst outcome workspace
+mode can have, and it is why no workspace-level report was emitted at all before
+this contract existed.
+
+The fix is not to make every reporter merge. Merging is genuinely wrong for
+some: an SBOM for N independently versioned deliverables is N SBOMs, and a
+reporter that publishes to a shared destination would double-publish. So instead
+each reporter *states* what it does with an N-project model, via
+:class:`ReporterWorkspaceBehaviour`, and
+``automated_security_helper.workspace.reporting`` holds it to that statement.
+
+The default is ``PER_PROJECT``, deliberately
+--------------------------------------------
+An undeclared reporter -- a third-party plugin, or a new built-in whose author
+did not think about workspaces -- gets ``PER_PROJECT``. That is the fail-closed
+choice and it is not a refusal: the reporter's per-project artefacts under
+``projects/<key>/reports/`` are still produced and still correct, because each
+project is scanned as a complete single-project run. All the default withholds
+is a workspace-level file the reporter has not said it can produce correctly,
+and the driver writes a manifest recording that withholding, so nothing is
+silent.
+
+``MERGED`` was rejected as the default because it is fail-open: it hands an
+unprepared reporter a shape it has never seen and trusts it. ``UNSUPPORTED`` was
+rejected because it would fail an entire workspace run for any external plugin.
+"""
 
 from abc import abstractmethod
 from datetime import datetime, timezone
-from typing import Annotated, Generic, TypeVar
+from enum import Enum
+from typing import Annotated, ClassVar, Generic, TypeVar
 from typing_extensions import Self
 
 from pydantic import Field, model_validator
@@ -13,6 +49,51 @@ from automated_security_helper.base.plugin_config import PluginConfigBase
 from automated_security_helper.core.exceptions import ScannerError
 from automated_security_helper.models.asharp_model import AshAggregatedResults
 from automated_security_helper.utils.log import ASH_LOGGER
+
+
+class ReporterWorkspaceBehaviour(str, Enum):
+    """What a reporter does when the model covers more than one project.
+
+    A ``str`` Enum so a declaration reads as its own documentation in a log line
+    and in the workspace report manifest, without a lookup table.
+
+    The four members are exhaustive over the useful answers, and each is a
+    different claim about *why*:
+
+    ``MERGED``
+        One workspace-level artefact covering every project, with the project
+        carried inside it -- a column, a field, a section, or a SARIF run. The
+        reporter has been shown to handle N runs.
+
+    ``PER_PROJECT``
+        No workspace-level artefact. The per-project files the projects' own
+        report phases already wrote are the answer. Chosen when merging would be
+        wrong rather than merely unimplemented: the consumer ingests against a
+        single repository root, or the artefact is an independently versioned
+        deliverable, or the reporter publishes a side effect that a second
+        invocation would duplicate.
+
+    ``WORKSPACE_SCOPED``
+        A workspace-level artefact that is *not* a merge -- it reports on
+        workspace-level state only. Distinct from ``MERGED`` because a consumer
+        must not read it as covering the projects. ``unused_suppressions`` is the
+        only one: merged, it would read the unified file's empty
+        ``used_suppressions`` and declare every suppression unused, which is a
+        false report rather than an incomplete one.
+
+    ``UNSUPPORTED``
+        The reporter refuses to run at workspace level, and the refusal fails the
+        run. Reserved for a reporter that can produce neither a correct merged
+        artefact nor a meaningful per-project one; no reporter shipped in this
+        repository is in that position today. It exists because "silently emit
+        nothing" is the defect this whole contract prevents, so a reporter that
+        genuinely cannot participate needs a way to say so loudly.
+    """
+
+    MERGED = "merged"
+    PER_PROJECT = "per-project"
+    WORKSPACE_SCOPED = "workspace-scoped"
+    UNSUPPORTED = "unsupported"
 
 
 class ReporterPluginConfigBase(PluginConfigBase):
@@ -32,6 +113,20 @@ class ReporterPluginBase(PluginBase, Generic[T]):
 
     config: T | ReporterPluginConfigBase | None = None
     dependencies_satisfied: bool = True
+
+    #: What this reporter does with a multi-project model. See the module
+    #: docstring for why the default is ``PER_PROJECT`` and not ``MERGED``.
+    #:
+    #: A ``ClassVar`` rather than a pydantic field, for two reasons. It is a
+    #: property of the reporter *class*, not of an instance's configuration, so
+    #: it must be readable before instantiation -- the workspace driver decides
+    #: whether to build the instance at all. And ``PluginBase`` sets
+    #: ``use_enum_values=True``, which would coerce a field holding an enum down
+    #: to its bare string on assignment; a ClassVar is untouched by that, so
+    #: identity comparisons against enum members keep working.
+    workspace_behaviour: ClassVar[ReporterWorkspaceBehaviour] = (
+        ReporterWorkspaceBehaviour.PER_PROJECT
+    )
 
     @model_validator(mode="after")
     def setup_paths(self) -> Self:

--- a/automated_security_helper/cli/scan.py
+++ b/automated_security_helper/cli/scan.py
@@ -54,6 +54,7 @@ def _handle_workspace_mode(
     source_dir: str | None,
     allow_missing_projects: bool,
     dry_run: bool,
+    workspace_config: str | None = None,
 ) -> "WorkspacePlan":
     """Resolve a workspace and return the plan, or exit.
 
@@ -88,7 +89,11 @@ def _handle_workspace_mode(
             else Path(workspace)
         )
         plan = resolve_workspace(
-            workspace_file, allow_missing_projects=allow_missing_projects
+            workspace_file,
+            allow_missing_projects=allow_missing_projects,
+            workspace_config=(
+                Path(workspace_config) if workspace_config is not None else None
+            ),
         )
     except WorkspaceDefinitionError as exc:
         _fail_workspace(str(exc))
@@ -315,6 +320,14 @@ def run_ash_scan_cli_command(
             envvar="ASH_WORKSPACE",
         ),
     ] = None,
+    workspace_config: Annotated[
+        str | None,
+        typer.Option(
+            "--workspace-config",
+            help="Path to the workspace policy file (severity ceiling, workspace-wide suppressions and ignore paths, additional scanners). Without this, ASH looks for 'ash-workspace.{yaml,yml,json}' in the workspace root or its '.ash' directory; finding none is not an error. Must not be any project's own ASH config: workspace policy governs every project, so reading one project's config as policy would apply its settings to its siblings.",
+            envvar="ASH_WORKSPACE_CONFIG",
+        ),
+    ] = None,
     allow_missing_projects: Annotated[
         bool,
         typer.Option(
@@ -421,14 +434,19 @@ def run_ash_scan_cli_command(
     # Workspace mode is handled before any cwd-based default is applied, because
     # --workspace and --source-dir are mutually exclusive and defaulting
     # source_dir first would make every invocation look like it had both.
-    if workspace is None and (dry_run or allow_missing_projects):
-        # Neither flag means anything outside workspace mode. Silently ignoring
-        # --dry-run would run a full scan for someone who asked for none.
+    if workspace is None and (
+        dry_run or allow_missing_projects or workspace_config is not None
+    ):
+        # None of these flags mean anything outside workspace mode. Silently
+        # ignoring --dry-run would run a full scan for someone who asked for
+        # none; silently ignoring --workspace-config would scan with no policy
+        # for someone who believes a severity ceiling is in force.
         offending = [
             flag
             for flag, given in (
                 ("--dry-run", dry_run),
                 ("--allow-missing-projects", allow_missing_projects),
+                ("--workspace-config", workspace_config is not None),
             )
             if given
         ]
@@ -444,6 +462,7 @@ def run_ash_scan_cli_command(
             source_dir=source_dir,
             allow_missing_projects=allow_missing_projects,
             dry_run=dry_run,
+            workspace_config=workspace_config,
         )
         # The workspace root is the scan root: it is what container mode mounts at
         # /src, and what every workspace-relative finding path is relative to.

--- a/automated_security_helper/config/ash_workspace_config.py
+++ b/automated_security_helper/config/ash_workspace_config.py
@@ -1,0 +1,211 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The schema of the workspace-level policy file.
+
+Why this module exists
+----------------------
+Workspace mode scans N projects as N independently scoped executions, each
+judged against its own config. That leaves no place for a statement an operator
+needs to make about the workspace as a whole -- "no project here may be laxer
+than MEDIUM", "this vendored directory is not ours in any project". Putting such
+a statement in a project's config would make one project's file govern its
+siblings; putting it in the ``.code-workspace`` file would put ASH policy in a
+file owned by an editor, whose schema ASH does not control (see
+``workspace/workspace_file.py``, which ignores that file's ``settings`` block
+for exactly this reason).
+
+So workspace policy gets its own file with its own schema, and this is that
+schema. ``workspace/policy.py`` finds and loads it and pushes it down into each
+project; nothing here reads the filesystem.
+
+Why this is a DISTINCT file from any project config
+---------------------------------------------------
+A workspace root is frequently also a project. When it is, ``.ash/ash.yaml`` at
+the root is that project's config and must keep meaning exactly that. If policy
+could also be read from it, one project's severity threshold would silently
+become its siblings' ceiling -- and the operator would have written a
+project-scoped file expecting project scope.
+
+``workspace/policy.py`` therefore looks only for ``ash-workspace.*`` names,
+which are disjoint from ``ASH_CONFIG_FILE_NAMES``, and refuses when it is
+pointed at a file that is some project's config. That disjointness is asserted
+by ``tests/unit/workspace/test_workspace_policy.py`` so the two name sets cannot
+drift into overlap.
+
+Why the top-level key is ``workspace``
+--------------------------------------
+It mirrors ``AshConfig.workspace``, so an operator who knows where
+``max_parallel_projects`` goes knows where the ceiling goes. The two blocks are
+deliberately in different FILES rather than merged: ``WorkspaceExecutionConfig``
+holds scheduling knobs that cannot change any project's verdict, and everything
+here can. Its docstring records that split, and this file is the other half of
+it.
+
+Why the ceiling defaults to None rather than to MEDIUM
+------------------------------------------------------
+``None`` means "no ceiling", and it has to be distinguishable from a configured
+one. ASH's own default threshold is MEDIUM, so defaulting this field to MEDIUM
+would mean an operator who created a policy file to add one suppression had
+thereby imposed a MEDIUM ceiling on every project in the workspace -- tightening
+projects they never mentioned, in a file that says nothing about severity. The
+absence of a ceiling is a value in the domain, so it is a value in the schema.
+
+The ceiling is case-SENSITIVE, and that is load-bearing
+-------------------------------------------------------
+``Literal["ALL", ...]`` rejects ``"medium"``. This matches
+``utils.severity_ladder``, which is case-sensitive for the reason recorded
+there: it gates an *unrecognised* threshold like ``CRITICAL``, the loosest
+setting. Accepting ``"medium"`` here and passing it through would therefore turn
+a ceiling the operator meant as MEDIUM into no effective ceiling at all -- the
+one direction a ceiling must never fail in. Refusing the file is the honest
+outcome.
+
+No ``!ENV`` substitution, unlike the project config
+---------------------------------------------------
+``AshConfig.from_file`` resolves ``${VAR}`` in its YAML. The policy loader uses
+plain ``yaml.safe_load`` and does not. A ceiling an environment variable can
+loosen is not a ceiling, and CI is precisely where an unset variable is easy to
+arrange and hard to notice. The failure mode is safe rather than silent: an
+unsubstituted ``${THRESH}`` stays a literal string and fails the ``Literal``
+above, so the workspace is refused with exit 4 instead of scanning with the gate
+quietly off.
+
+Failure modes and known limitations
+-----------------------------------
+* ``extra="forbid"`` on both models, so ``max_severity_threshhold`` is an error
+  rather than an ignored key. A silently-ignored policy key is the worst
+  outcome available here: the operator believes a ceiling is in force and no
+  output contradicts them.
+* ``additional_scanners`` is a list of names, not per-scanner config. A scanner
+  added by policy alone runs with ASH's default config for it, because the
+  workspace has no legitimate source for that project's tuning of a scanner the
+  project never enabled. Operators wanting tuned settings must enable the
+  scanner in the project.
+* ``max_severity_threshold`` tightens the gate only for findings that carry a
+  severity. A finding carrying only a SARIF ``error`` level is treated as
+  CRITICAL and stays actionable at every threshold, so no ceiling excludes it.
+  That is not specific to workspace mode -- single-project ``severity_threshold``
+  behaves identically, and the two paths were verified to agree over all 120
+  level/severity/threshold combinations -- but it means the ceiling cannot
+  quieten a scanner that omits ``properties.issue_severity``, checkov being the
+  one ASH ships. See ``utils/severity_ladder.py``.
+* This schema does not validate that a suppression's ``path`` can be rewritten
+  for any project; that depends on the project list and is
+  ``workspace/policy.py``'s job.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+
+
+class WorkspacePolicyConfig(BaseModel):
+    """Workspace-wide policy: the ``workspace`` block of the policy file.
+
+    Every field here can change a project's verdict, which is why they live in
+    their own file rather than beside the execution knobs in
+    ``AshConfig.workspace``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    max_severity_threshold: Annotated[
+        # A real Literal, not a str with an advertised enum: the enum has to be
+        # ENFORCED, not merely documented, for the case-sensitivity reason in the
+        # module docstring. A value pydantic lets through reaches the ladder,
+        # which reads an unrecognised threshold as CRITICAL -- no ceiling at all.
+        Literal["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"] | None,
+        Field(
+            None,
+            description=(
+                "The LOOSEST severity threshold any project may use. A project "
+                "configuring something stricter keeps it; a project configuring "
+                "something looser is tightened to this value. 'max' refers to "
+                "permissiveness, not to severity: the strictness order is "
+                "ALL < LOW < MEDIUM < HIGH < CRITICAL, so raising this value "
+                "LOOSENS the ceiling. Unset means no ceiling. Case-sensitive."
+            ),
+        ),
+    ] = None
+
+    suppressions: Annotated[
+        list[AshSuppression],
+        Field(
+            description=(
+                "Suppressions that apply across the workspace. Paths are "
+                "WORKSPACE-relative (e.g. 'api/src/legacy.py') and are rewritten "
+                "into each project's own coordinates before being applied. A "
+                "suppression that cannot match inside a project is not passed to "
+                "it; one that cannot be rewritten soundly refuses the workspace."
+            )
+        ),
+    ] = []
+
+    ignore_paths: Annotated[
+        list[IgnorePathWithReason],
+        Field(
+            description=(
+                "Paths excluded across the workspace. Workspace-relative and "
+                "pushed down per project, exactly as 'suppressions' are."
+            )
+        ),
+    ] = []
+
+    additional_scanners: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Scanners every project must run, in addition to whatever it "
+                "enables itself. Additive only -- this cannot disable a scanner "
+                "a project enabled. A scanner the project already declares runs "
+                "under the project's own config and its findings are the "
+                "project's; a scanner added only by this policy runs with "
+                "default config and its findings are tagged "
+                "'origin: workspace-policy' and reported separately."
+            )
+        ),
+    ] = []
+
+    policy_scanners_gate: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether findings from policy-added scanners affect a project's "
+                "exit code. Default false: a workspace that adds a scanner to "
+                "gather visibility should not thereby fail projects that never "
+                "opted into it, and turning it on is the operator saying they "
+                "have triaged what the new scanner reports."
+            ),
+        ),
+    ] = False
+
+
+class AshWorkspaceConfig(BaseModel):
+    """The whole workspace policy file.
+
+    A thin wrapper over one block, kept as its own model so the file has a
+    versionable top-level schema and so ``workspace:`` reads the same here as it
+    does in a project config.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    workspace: Annotated[
+        WorkspacePolicyConfig,
+        Field(
+            description=(
+                "Workspace-wide policy. Distinct from AshConfig.workspace, which "
+                "holds execution scheduling knobs in a project config; nothing "
+                "here can be set from a project's own file."
+            ),
+        ),
+    ] = WorkspacePolicyConfig()

--- a/automated_security_helper/core/orchestrator.py
+++ b/automated_security_helper/core/orchestrator.py
@@ -249,8 +249,58 @@ class ASHScanOrchestrator(BaseModel):
             asharp_model=exec_engine_params.get("asharp_model"),
         )
 
+        self._apply_metadata()
+
         self._initialized = True
         ASH_LOGGER.info("ASH Orchestrator and ScanExecutionEngine initialized")
+
+    def _apply_metadata(self) -> None:
+        """Copy ``self.metadata`` onto the results model's own metadata.
+
+        ``metadata`` has been a declared parameter of this class for its whole
+        life, documented as "Additional metadata for the scan", and read nowhere.
+        Workspace mode is the first caller that needs it, and what it needs it for
+        is the thing that makes the PER_PROJECT reporter ruling honest.
+
+        Every project in a workspace is scanned as a complete single-project run,
+        so its model's ``workspace`` is ``None`` -- a project does not know it is
+        in a workspace. Without something on the metadata, its reports cannot say
+        which project they describe. That mattered concretely rather than
+        aesthetically: ``metadata.project_name`` is hardcoded to ``"ASH"`` in
+        ``AshAggregatedResults``'s default and never derived from
+        ``AshConfig.project_name``, so every project's ``html``, ``markdown`` and
+        ``text`` report printed the same project name; and the ``s3`` reporter
+        derives its object key from a timestamp with one shared prefix, so two
+        projects starting in the same instant overwrote each other's report.
+
+        Applied here, at the end of ``initialize``, because the report phase runs
+        inside ``execute_scan`` -- setting it any later would be after the reports
+        that need it have been written.
+
+        ``project_name`` is set through validation rather than by raw assignment,
+        so an empty or whitespace value is refused and the default kept. Assigning
+        past a pydantic validator produces a model that fails to serialise much
+        later, a long way from the assignment.
+        """
+        if not self.metadata or self.execution_engine is None:
+            return
+        model = getattr(self.execution_engine, "_asharp_model", None)
+        if model is None or model.metadata is None:  # pragma: no cover - defensive
+            return
+
+        for key, value in self.metadata.items():
+            if key == "project_name":
+                if isinstance(value, str) and value.strip():
+                    model.metadata.project_name = value.strip()
+                else:
+                    ASH_LOGGER.warning(
+                        f"Ignoring unusable project_name {value!r} in scan metadata; "
+                        f"keeping {model.metadata.project_name!r}"
+                    )
+                continue
+            # ReportMetadata allows extras, so anything else is carried through
+            # verbatim for a reporter to read.
+            setattr(model.metadata, key, value)
 
     @classmethod
     def create(cls, **kwargs: Any) -> "ASHScanOrchestrator":
@@ -333,7 +383,9 @@ class ASHScanOrchestrator(BaseModel):
                     asharp_model = AshAggregatedResults.from_json(model_data)
 
                     # Update the execution engine's model
-                    if self.execution_engine is not None and hasattr(self.execution_engine, "_asharp_model"):
+                    if self.execution_engine is not None and hasattr(
+                        self.execution_engine, "_asharp_model"
+                    ):
                         self.execution_engine._asharp_model = asharp_model
 
                     # When using existing results, only run the report phase

--- a/automated_security_helper/models/flat_vulnerability.py
+++ b/automated_security_helper/models/flat_vulnerability.py
@@ -186,6 +186,49 @@ def _extract_references(result: "Result") -> List[str]:
     return refs
 
 
+#: The property ``WorkspaceAggregator.rebase_run_for_project`` writes onto every
+#: result. Spelled once here rather than inline, because the reporters, the
+#: aggregator and the workspace payload all have to agree on it.
+WORKSPACE_PROJECT_PROPERTY = "workspace_project"
+
+
+def extract_workspace_project(result: "Result") -> Optional[str]:
+    """The workspace project key a finding was attributed to, or None.
+
+    Read through ``__pydantic_extra__`` as well as by attribute, because
+    ``PropertyBag`` allows extras and a key the schema does not declare lands
+    there rather than on the model -- which is where ``workspace_project`` always
+    lands, since it is added after validation by the aggregator.
+
+    None for a single-directory scan, which is what keeps this field out of
+    ``exclude_none=True`` output and leaves that output byte-identical.
+
+    Only a non-empty ``str`` counts. Not ``str(value)`` on whatever is there:
+    reporters are widely tested against ``MagicMock`` results, where ``getattr``
+    returns a truthy ``Mock`` that stringifies to ``"<MagicMock id=...>"``. That
+    would attribute a finding to a project name that does not exist, which is
+    worse than not attributing it -- and it is not hypothetical, it is what broke
+    the OCSF reporter's severity tests the first time this was written.
+    """
+    # getattr rather than result.properties: a real SARIF Result always has the
+    # attribute, but this is called from OCSF's per-finding path, where a raised
+    # AttributeError is swallowed into a generic "error processing finding"
+    # fallback that loses the finding's severity and message. Attribution must
+    # never be able to degrade a finding it only annotates.
+    props = getattr(result, "properties", None)
+    if props is None:
+        return None
+    value = getattr(props, WORKSPACE_PROJECT_PROPERTY, None)
+    if not isinstance(value, str):
+        extra = getattr(props, "__pydantic_extra__", None)
+        value = (
+            extra.get(WORKSPACE_PROJECT_PROPERTY) if isinstance(extra, dict) else None
+        )
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
 def _extract_snippet_from_message(description: str) -> Optional[str]:
     """Best-effort extraction of a fenced code block out of the message text."""
     if not description or "```" not in description:
@@ -213,6 +256,16 @@ class FlatVulnerability(BaseModel):
     description: str = Field(description="Description of the vulnerability")
     severity: str = Field(
         description="Severity level (CRITICAL, HIGH, MEDIUM, LOW, INFO)"
+    )
+
+    # Workspace attribution
+    workspace_project: Optional[str] = Field(
+        None,
+        description=(
+            "Key of the workspace project this finding belongs to, or None for a "
+            "single-directory scan. The single attribution every tabular and "
+            "flattened reporter groups on."
+        ),
     )
 
     # Source information
@@ -293,9 +346,7 @@ class FlatVulnerability(BaseModel):
             code_snippet = _extract_snippet_from_message(description)
 
         tags = _extract_tags(result)
-        actual_scanner = _extract_scanner_name_from_result(
-            result, tool_name, tags
-        )
+        actual_scanner = _extract_scanner_name_from_result(result, tool_name, tags)
         severity = _resolve_severity(result)
 
         is_suppressed = False
@@ -314,11 +365,18 @@ class FlatVulnerability(BaseModel):
 
         references = _extract_references(result)
 
+        # Read off the finding rather than passed in by the caller, because
+        # WorkspaceAggregator.rebase_run_for_project writes it onto every result
+        # and that is the only place it is decided. A parameter here would give
+        # the flattening path a second chance to get the attribution wrong.
+        workspace_project = extract_workspace_project(result)
+
         return cls(
             id=f"{actual_scanner}-{result.ruleId or 'unknown'}-{hashlib.sha256(description.encode()).hexdigest()[:8]}",
             title=result.ruleId or "Unknown Issue",
             description=description,
             severity=severity,
+            workspace_project=workspace_project,
             is_suppressed=is_suppressed,
             suppression_kind=supp_kind,
             suppression_justification=supp_reas,
@@ -333,9 +391,7 @@ class FlatVulnerability(BaseModel):
             properties=(
                 json.dumps(properties_dict, default=str) if properties_dict else None
             ),
-            references=(
-                json.dumps(references, default=str) if references else None
-            ),
+            references=(json.dumps(references, default=str) if references else None),
             detected_at=datetime.now(timezone.utc).isoformat(),
             raw_data=result.model_dump_json(exclude_none=True),
         )
@@ -350,9 +406,7 @@ class FlatVulnerability(BaseModel):
         severity_raw = entry.get("severity", "MEDIUM") or "MEDIUM"
         severity = severity_raw.upper() if isinstance(severity_raw, str) else "MEDIUM"
 
-        detected_at = entry.get(
-            "detected_at", datetime.now(timezone.utc).isoformat()
-        )
+        detected_at = entry.get("detected_at", datetime.now(timezone.utc).isoformat())
 
         return cls(
             id=f"{scanner_name}-{entry.get('id', hash(str(entry)) % 10000)}",

--- a/automated_security_helper/models/workspace.py
+++ b/automated_security_helper/models/workspace.py
@@ -143,7 +143,7 @@ skipped, and does affect the status.
 from __future__ import annotations
 
 from enum import Enum, IntEnum
-from typing import Annotated, Dict, Iterable, List, Literal, Optional
+from typing import Annotated, Any, Dict, Iterable, List, Literal, Optional
 
 from pydantic import BaseModel, Field, computed_field
 
@@ -354,6 +354,24 @@ class WorkspaceProjectResult(BaseModel):
             description="Final status per scanner name, for this project alone.",
         ),
     ]
+    ceiling_unreachable_findings: Annotated[
+        Dict[str, int],
+        Field(
+            default_factory=dict,
+            description=(
+                "Per scanner, how many of this project's findings the workspace "
+                "severity ceiling could not affect, because they carry no "
+                "properties.issue_severity and are therefore judged from the "
+                "SARIF level -- where `error` is read as critical and so is "
+                "actionable at every threshold. Populated only when the ceiling "
+                "actually tightened this project AND some of its findings were "
+                "beyond that tightening's reach, so an empty mapping means the "
+                "ceiling did what it says. An observation about these findings, "
+                "not a claim about the scanner: it is recomputed every scan, so "
+                "it stops appearing if a scanner starts emitting severity."
+            ),
+        ),
+    ]
     skip_reason: Annotated[
         Optional[SkippedProjectReason],
         Field(None, description="Why the project was skipped, when it was."),
@@ -480,6 +498,25 @@ class WorkspaceResults(BaseModel):
         """
         entries = (project.as_skipped_project() for project in self.projects)
         return [entry for entry in entries if entry is not None]
+
+
+def is_workspace_scan(model: Any) -> bool:
+    """Whether *model* is the result of a workspace scan rather than one directory.
+
+    The single discriminator every reporter uses to decide whether to emit
+    workspace attribution. ``model.workspace`` is ``None`` for a single-directory
+    scan, which is the contract ``AshAggregatedResults.workspace`` documents.
+
+    Checked with ``isinstance`` rather than ``is not None``, and that is not
+    defensiveness. Reporters are widely tested against ``MagicMock`` models, where
+    ``getattr(model, "workspace")`` returns a truthy ``Mock`` -- so a truthiness
+    test silently reads every mocked single-directory scan as a workspace one. The
+    observable symptom was a ``KeyError`` on a column that had been added to a
+    header but not to the rows, which is a loud failure; the same weakness in a
+    reporter that tolerates a missing key would instead have added an empty
+    project column to real single-directory output and gone unnoticed.
+    """
+    return isinstance(getattr(model, "workspace", None), WorkspaceResults)
 
 
 def workspace_exit_code(

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_summary_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/bedrock_summary_reporter.py
@@ -14,6 +14,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.log import ASH_LOGGER
@@ -257,7 +258,23 @@ class BedrockSummaryReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class BedrockSummaryReporter(ReporterPluginBase[BedrockSummaryReporterConfig]):
-    """Generates a summary of security findings using Amazon Bedrock."""
+    """Generates a summary of security findings using Amazon Bedrock.
+
+    Workspace mode: per project.
+
+    A useful remediation summary is specific to one codebase -- its language, its
+    frameworks, its conventions. Handing a model N projects' findings at once
+    produces advice that is either generic across all of them or silently focused
+    on whichever project dominates the prompt, and there is no way for a reader to
+    tell which happened. Per project, each summary is grounded in one codebase,
+    exactly as ``ash --source-dir P`` would produce it.
+
+    Cost is a secondary argument in the same direction: this reporter makes a paid
+    inference call, and a workspace-level invocation would add an N+1st call whose
+    output is worse than the N it duplicates.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/cloudwatch_logs_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/cloudwatch_logs_reporter.py
@@ -22,6 +22,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -109,7 +110,36 @@ class CloudWatchLogsReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class CloudWatchLogsReporter(ReporterPluginBase[CloudWatchLogsReporterConfig]):
-    """Formats results and publishes to CloudWatch Logs."""
+    """Formats results and publishes to CloudWatch Logs.
+
+    Workspace mode: per project. The RFC's reporter table did not rule on this
+    one, so the reasoning is recorded here.
+
+    This is a delivery mechanism rather than a format, and it has a side effect --
+    ``PutLogEvents``. Each project's own scan already publishes its own event, so
+    a workspace-level invocation would add an N+1st event to the same log stream
+    describing the same findings, and a CloudWatch Logs Insights query would then
+    double-count every one of them.
+
+    What the extra event would contain is the stronger argument. It publishes
+    ``model.to_simple_dict()``, whose two substantive keys at workspace level are
+    the *lossy* ``scanner_results`` rollup -- per-scanner counts summed across
+    projects, status taken as the worst across projects -- and an ``ash_config``
+    that is no project's config, because workspace-level config does not exist
+    until Phase 3. The event would describe a scan that never ran, in a stream
+    where it sits indistinguishably beside N events that did.
+
+    A size limit also applies, though it is not the binding argument here because
+    ``to_simple_dict()`` omits findings and SARIF: PutLogEvents caps a single
+    event at 1 MB and a batch at 1,048,576 bytes
+    (https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_PutLogEvents.html).
+    It is worth naming because it forecloses the obvious alternative -- publishing
+    the merged findings instead of the summary -- which would exceed it for any
+    workspace of consequence, and this reporter's error path returns the exception
+    text as its report rather than failing the run.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/s3_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/s3_reporter.py
@@ -14,6 +14,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.log import ASH_LOGGER
@@ -92,7 +93,68 @@ class S3ReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class S3Reporter(ReporterPluginBase[S3ReporterConfig]):
-    """Formats results and uploads to an S3 bucket."""
+    """Formats results and uploads to an S3 bucket.
+
+    Workspace mode: per project. The RFC's reporter table did not rule on this
+    one, so the reasoning is recorded here.
+
+    Same shape of argument as ``cloudwatch_logs_reporter``: a delivery mechanism
+    rather than a format, with a side effect -- ``PutObject``. Each project's own
+    scan already uploads its own object, and a workspace-level invocation would
+    add an N+1st object holding the lossy ``scanner_results`` rollup and an
+    ``ash_config`` belonging to no project.
+
+    The object key needs care for this ruling to hold, and the reason is worse
+    than a race.
+
+    The key is ``f"{key_prefix}ash-report-{timestamp}.{ext}"`` with ``timestamp``
+    taken from ``model.metadata.summary_stats.start``. That field is **not set
+    yet** when a reporter runs: ``ScanExecutionEngine.execute_phases`` assigns it
+    in a ``finally`` block (``execution_engine.py`` around line 547) that runs
+    *after* ``ReportPhase`` (around line 492). So every reporter observes ``None``,
+    and the key every scan computes is literally ``ash-report-None.json``.
+
+    Verified rather than reasoned about, by probing ``ReportPhase._execute_phase``
+    during a real scan: ``start`` is ``None`` there and
+    ``'2026-08-26T00:38:09+00:00'`` once the scan returns -- a second-granular
+    string, so even if it were available in time it would not separate concurrent
+    projects reliably.
+
+    Consequences, in order of how much they matter here:
+
+    * All N projects in a workspace compute the same key and overwrite each other.
+      ``PutObject`` overwrites silently, so N-1 projects' reports vanish with no
+      message -- a false negative with extra steps, in the feature this PR
+      completes. The project segment below closes this, which is the part this
+      ruling owns.
+    * Every *run* of a single-directory scan also overwrites the previous one,
+      because the key is a constant. That is a pre-existing defect orthogonal to
+      workspace mode, and it is deliberately **not** fixed here.
+
+      Not deferred for convenience: both behaviours are defensible and either
+      choice breaks someone. A constant key loses every run but the last. A
+      varying key breaks anyone treating that object as a stable "latest report"
+      pointer, and accumulates objects indefinitely for anyone without a
+      lifecycle policy. That is a product decision about a customer-facing AWS
+      integration, and it belongs to whoever owns that integration rather than to
+      a workspace-mode change.
+
+      Also deliberately not fixed by making the timestamp available earlier:
+      ``summary_stats.start`` is read by more than this reporter, so moving when
+      it is assigned has a much wider blast radius than the key does.
+
+      ``tests/unit/workspace/test_project_attribution.py::TestS3KeysCannotCollideAcrossProjects::test_the_start_timestamp_is_unset_when_a_reporter_runs``
+      pins the premise, so if the timestamp ever does become available the
+      assumption fails loudly rather than silently producing a different key.
+
+    The project is read from ``metadata.workspace_project`` rather than from
+    ``model.workspace``, because a project inside a workspace is scanned as a
+    complete single-project run and its own model's ``workspace`` is ``None`` --
+    a project does not know it is in a workspace.
+    ``ASHScanOrchestrator._apply_metadata`` is what puts the project there.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:
@@ -134,11 +196,21 @@ class S3Reporter(ReporterPluginBase[S3ReporterConfig]):
         if isinstance(self.config, dict):
             self.config = S3ReporterConfig.model_validate(self.config)
 
-        # Create a unique key for the S3 object
+        # Create a key for the S3 object.
+        #
+        # `timestamp` is None here in every real scan -- summary_stats.start is
+        # assigned after the report phase, not before it -- so without the
+        # project segment every project in a workspace computes the identical key
+        # and PutObject silently overwrites all but the last. See the class
+        # docstring for the verification and for why the single-project key is
+        # left exactly as it is.
         timestamp = model.metadata.summary_stats.start
         file_extension = "json" if self.config.options.file_format == "json" else "yaml"
+        project = getattr(model.metadata, "workspace_project", None)
+        project_segment = f"{project}/" if isinstance(project, str) and project else ""
         s3_key = (
-            f"{self.config.options.key_prefix}ash-report-{timestamp}.{file_extension}"
+            f"{self.config.options.key_prefix}{project_segment}"
+            f"ash-report-{timestamp}.{file_extension}"
         )
 
         # Format the results based on the specified format

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/security_hub_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/security_hub_reporter.py
@@ -12,6 +12,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.log import ASH_LOGGER
@@ -69,7 +70,24 @@ class SecurityHubReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class SecurityHubReporter(ReporterPluginBase[SecurityHubReporterConfig]):
-    """Sends security findings to AWS Security Hub in ASFF format."""
+    """Sends security findings to AWS Security Hub in ASFF format.
+
+    Workspace mode: per project.
+
+    This reporter has a side effect -- it calls ``BatchImportFindings`` -- so the
+    behaviour is not only about document shape. Each project's own scan already
+    publishes that project's findings. Invoking it again at workspace level would
+    import every finding a second time, and ASFF findings are keyed on ``Id``, so
+    the duplicates would either overwrite the per-project imports or land beside
+    them depending on how the ids collide. Neither outcome is one an operator
+    asked for, and both are silent.
+
+    Per project is also the correct scope for the data: an ASFF finding is
+    attributed to one resource in one account, and a workspace's projects are
+    independently owned.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/csv_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/csv_reporter.py
@@ -8,8 +8,15 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
+from automated_security_helper.models.workspace import is_workspace_scan
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
+
+#: The workspace-mode column header. First rather than appended, because a
+#: spreadsheet consumer sorts and filters on the leftmost columns and the project
+#: is the coarsest grouping a workspace report has.
+PROJECT_COLUMN = "workspace_project"
 
 
 class CSVReporterConfigOptions(ReporterOptionsBase):
@@ -25,7 +32,20 @@ class CSVReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class CsvReporter(ReporterPluginBase[CSVReporterConfig]):
-    """Formats results as CSV."""
+    """Formats results as CSV.
+
+    Workspace mode: one merged artefact with a leading ``workspace_project``
+    column. A row is one finding either way, so N projects are N groups of rows
+    rather than a different document -- which is exactly what a spreadsheet or a
+    ``pandas.read_csv`` consumer wants.
+
+    The column is emitted only when the model is a workspace scan. Emitting it
+    unconditionally would add an always-empty column to every single-directory
+    CSV, and a consumer that indexes by column *position* rather than by header
+    would silently read the wrong field from then on.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -56,6 +76,12 @@ class CsvReporter(ReporterPluginBase[CSVReporterConfig]):
         output = StringIO()
         writer = csv.writer(output)
 
+        # Whether to emit the project column at all. Read off the workspace block
+        # rather than off the findings: a workspace whose projects all came back
+        # clean has no findings to inspect, and its header must still declare the
+        # column so a consumer's parser does not change shape run to run.
+        is_workspace = is_workspace_scan(model)
+
         # Get flattened vulnerabilities
         flat_vulns = [
             item.model_dump(
@@ -68,34 +94,25 @@ class CsvReporter(ReporterPluginBase[CSVReporterConfig]):
 
         if not flat_vulns:
             # If no vulnerabilities, return a header-only CSV
-            writer.writerow(
-                [
-                    "ID",
-                    "Title",
-                    "Description",
-                    "Severity",
-                    "Scanner",
-                    "Scanner Type",
-                    "Rule ID",
-                    "File Path",
-                    "Line Start",
-                    "Line End",
-                    "CVE ID",
-                    "CWE ID",
-                    "Fix Available",
-                    "Is Suppressed",
-                    "Suppression Kind",
-                    "Suppression Justification",
-                    "Detected At",
-                    "Tags",
-                    "Properties",
-                    "References",
-                ]
-            )
+            writer.writerow(self._header(is_workspace))
             return output.getvalue()
 
         # Get all field names from the first vulnerability
         fields = list(flat_vulns[0].keys())
+        if not is_workspace:
+            # Dropped rather than never added, so that a single-directory CSV is
+            # byte-identical to what it has always been. Leaving an always-empty
+            # column in would shift every following column, and a consumer that
+            # reads by position rather than by header would silently read the
+            # wrong field from then on.
+            fields = [field for field in fields if field != PROJECT_COLUMN]
+        else:
+            # Leading, because a spreadsheet or pandas consumer groups and sorts
+            # on the first columns and the project is the coarsest grouping a
+            # workspace report has.
+            fields = [PROJECT_COLUMN] + [
+                field for field in fields if field != PROJECT_COLUMN
+            ]
 
         # Write header row
         writer.writerow(fields)
@@ -104,8 +121,33 @@ class CsvReporter(ReporterPluginBase[CSVReporterConfig]):
         for vuln in flat_vulns:
             row = []
             for field in fields:
-                value = vuln[field]
+                # .get rather than [], because the header is assembled from the
+                # first finding's keys plus the project column. A later finding
+                # missing a key -- or a project column added to the header of a
+                # scan whose findings predate it -- would otherwise raise a
+                # KeyError and lose the whole report rather than one cell.
+                value = vuln.get(field)
                 row.append(value if value is not None else "")
             writer.writerow(row)
 
         return output.getvalue()
+
+    @staticmethod
+    def _header(is_workspace: bool) -> list[str]:
+        """The header for a scan with no findings at all.
+
+        Derived from ``FlatVulnerability``'s own field order rather than written
+        out, so the empty form and the populated form cannot drift apart. The
+        hardcoded list this replaced had already drifted: it spelled the columns
+        in title case ("Rule ID") while the populated form emitted field names
+        ("rule_id"), so a consumer parsing by header name worked against one form
+        and not the other depending on whether the scan found anything.
+        """
+        from automated_security_helper.models.flat_vulnerability import (
+            FlatVulnerability,
+        )
+
+        fields = list(FlatVulnerability.model_fields)
+        if not is_workspace:
+            return [field for field in fields if field != PROJECT_COLUMN]
+        return [PROJECT_COLUMN] + [field for field in fields if field != PROJECT_COLUMN]

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/cyclonedx_reporter.py
@@ -8,6 +8,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -25,7 +26,30 @@ class CycloneDXReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class CycloneDXReporter(ReporterPluginBase[CycloneDXReporterConfig]):
-    """Formats results as CycloneDX."""
+    """Formats results as CycloneDX.
+
+    Workspace mode: per project. A workspace of independently versioned
+    deliverables is N SBOMs, not one.
+
+    A CycloneDX document describes the bill of materials of a single subject, and
+    its ``metadata.component`` names that subject. Concatenating N projects'
+    components under one subject produces a document that is true of nothing an
+    operator can ship, sign, or hand to a downstream consumer: two projects
+    pinning different versions of the same library appear as one deliverable
+    depending on both.
+
+    There is also a mechanical consequence worth naming, because it is what makes
+    the ruling safe rather than merely principled. The unified workspace file
+    carries no ``cyclonedx`` at all -- ``WorkspaceAggregator`` omits it for
+    exactly the reason above -- so ``model.cyclonedx.model_dump_json()`` here
+    would raise ``AttributeError`` on ``None``. ``ReportPhase`` catches reporter
+    exceptions and logs them, so at workspace level this would have produced no
+    artefact and no clear reason, which is the silence this contract exists to
+    prevent. Declaring per project means the reporter is never invoked with that
+    model, so the crash is unreachable rather than merely unlikely.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/flatjson_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/flatjson_reporter.py
@@ -10,7 +10,9 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
+from automated_security_helper.models.workspace import is_workspace_scan
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
     ReportContentEmitter,
@@ -36,7 +38,19 @@ class FlatJSONReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class FlatJSONReporter(ReporterPluginBase[FlatJSONReporterConfig]):
-    """Formats results as a flattened JSON array of findings."""
+    """Formats results as a flattened JSON array of findings.
+
+    Workspace mode: one merged artefact. Each finding carries
+    ``workspace_project``, and a ``workspace`` block carries the per-project
+    verdicts so a consumer can group without re-deriving anything.
+
+    The per-finding field needs no code here: ``FlatVulnerability`` reads it off
+    ``result.properties.workspace_project``, which the aggregator sets on every
+    result, and ``model_dump(exclude_none=True)`` omits it for a single-directory
+    scan. So this output is unchanged outside workspace mode.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -86,12 +100,22 @@ class FlatJSONReporter(ReporterPluginBase[FlatJSONReporterConfig]):
         # Add top hotspots
         report_data["top_hotspots"] = emitter.get_top_hotspots(10)
 
-        # Add findings
+        # Add findings. Each carries workspace_project when the scan was a
+        # workspace one; exclude_none drops it otherwise, so single-directory
+        # output is unchanged.
         flat_vulns = model.to_flat_vulnerabilities()
         report_data["findings"] = [
             vuln.model_dump(exclude_none=True, exclude_unset=True, mode="json")
             for vuln in flat_vulns
         ]
+
+        # The per-project verdicts, so a consumer can group and judge without
+        # re-deriving anything. Re-deriving would mean applying one threshold to
+        # every project, and projects in a workspace are independently
+        # configured -- so the consumer's answer would differ from the exit code
+        # for the same run, with no rule for which is authoritative.
+        if is_workspace_scan(model):
+            report_data["workspace"] = model.workspace.model_dump(mode="json")
 
         # Return the JSON string
         return json.dumps(report_data, indent=2, default=str)

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/github_ghas_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/github_ghas_reporter.py
@@ -14,6 +14,36 @@ Key differences from the generic SARIF reporter:
 3. Strips verbose fields (full markdown help, relationships, deprecated fields)
    to reduce file size significantly.
 4. Excludes suppressed findings (GitHub has its own dismissal workflow).
+
+Workspace mode: per project, never merged -- and this reporter is the reason the
+whole reporter-behaviour contract exists
+--------------------------------------------------------------------------------
+``report()`` reads ``sarif.runs[0]`` and stops. Against the N-run SARIF a
+workspace scan produces, that emits the first project's findings and drops every
+other project: no exception, no warning, just a smaller file that a reviewer has
+no way to tell is incomplete. A security reporter that under-reports in silence
+is the worst thing this feature could ship, and it is why no workspace-level
+report was emitted at all before Phase 2b.
+
+The fix is not to make it iterate the runs. GitHub code scanning ingests a SARIF
+document against *one* repository root: it resolves every result URI relative to
+the repository the upload is attributed to. A merged document declaring N roots
+either mis-locates results into paths that do not exist in the repo it was
+uploaded for, or is rejected outright. Iterating would have replaced a silent
+false negative with a silently mis-located finding, which is not better.
+
+So the correct workspace answer is N documents, one per project, which is what
+``projects/<key>/reports/ash.ghas.sarif`` already is -- each written from that
+project's own single-run scan, each anchored to that project's own root, each
+uploadable on its own. The workspace driver declines to invoke this reporter at
+workspace level and records where the N artefacts are, so the absence of a
+merged file is stated rather than silent.
+
+``runs[0]`` is left in place deliberately. Under this contract the reporter is
+never handed a multi-run model, so the index is correct for every input it can
+receive, and rewriting it would imply a multi-project capability the format does
+not have. ``tests/unit/workspace/test_workspace_reporting.py`` pins the
+declaration, so a future change to MERGED reintroduces the bug loudly.
 """
 
 import json
@@ -26,6 +56,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.get_ash_version import get_ash_version
@@ -67,7 +98,13 @@ class GHASReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class GHASReporter(ReporterPluginBase[GHASReporterConfig]):
-    """Produces a SARIF report optimized for GitHub Advanced Security Code Scanning."""
+    """Produces a SARIF report optimized for GitHub Advanced Security Code Scanning.
+
+    Per project in workspace mode; see the module docstring for why merging is
+    wrong rather than merely unimplemented.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_cyclonedx_reporter.py
@@ -28,6 +28,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.log import ASH_LOGGER
@@ -323,7 +324,22 @@ class GitLabCycloneDXReporter(ReporterPluginBase[GitLabCycloneDXReporterConfig])
 
     Produces ``gl-dependency-scanning-report.cdx.json`` suitable for upload as
     ``artifacts:reports:cyclonedx`` in GitLab CI pipelines.
+
+    Workspace mode: per project, for both of the reasons its two parents have. It
+    is an SBOM, so N deliverables are N documents (see ``cyclonedx_reporter``);
+    and it is a GitLab CI report artefact resolved against one project's
+    repository root (see ``gitlab_sast_reporter``).
+
+    The GitLab taxonomy this reporter injects makes merging worse rather than
+    just wrong. ``_resolve_dominant_type`` and ``_dominant_input_file`` pick a
+    single ecosystem and a single manifest path by majority vote across
+    components. Across N projects the majority is whichever project has the most
+    dependencies, so a merged document would label a Python project's components
+    with a JavaScript project's ``package_manager`` and point at its lockfile --
+    plausible-looking metadata that is simply false.
     """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/gitlab_sast_reporter.py
@@ -12,6 +12,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -44,7 +45,26 @@ class GitLabSASTReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class GitLabSASTReporter(ReporterPluginBase[GitLabSASTReporterConfig]):
-    """Formats vulnerability findings report as GitLab SAST format."""
+    """Formats vulnerability findings report as GitLab SAST format.
+
+    Workspace mode: per project, one artefact each, never merged.
+
+    Not for the reason ``github_ghas`` is per project -- this reporter already
+    iterates every run correctly (see the ``runs[0]``-only regression pinned in
+    ``tests/unit/plugin_modules/test_reporter_regression.py``), so a merged
+    document would contain every finding. It is per project because of what the
+    document *is*: ``gl-sast-report.json`` is consumed as
+    ``artifacts:reports:sast`` for one GitLab project, and its
+    ``location.file`` paths are resolved against that project's repository root.
+    A merged report uploaded for one project would show findings at paths that do
+    not exist in it.
+
+    ``projects/<key>/reports/`` gives one report per project, each already
+    correct for its own upload, which is also the shape a monorepo pipeline with
+    a job per project wants.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/html_reporter.py
@@ -11,6 +11,10 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
+    html_workspace_section,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
@@ -32,7 +36,21 @@ class HTMLReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class HtmlReporter(ReporterPluginBase[HTMLReporterConfig]):
-    """Formats results as HTML."""
+    """Formats results as HTML.
+
+    Workspace mode: one merged artefact with a per-project section. A human
+    reading a workspace report is asking "which project is in trouble", so the
+    project has to be the top-level structure and not a column buried in the
+    findings table.
+
+    The workspace section is added ahead of the existing content rather than
+    replacing it. The whole-workspace severity and scanner tables stay useful --
+    they answer "how bad is it overall" -- and reshaping the entire document
+    around projects would have made a workspace report and a single-project
+    report two different things to read.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -65,6 +83,12 @@ class HtmlReporter(ReporterPluginBase[HTMLReporterConfig]):
         # Get top hotspots
         top_hotspots = emitter.get_top_hotspots(10)
         hotspots_section = self._format_hotspots_section(top_hotspots)
+
+        # The per-project table, placed after the metadata block and before the
+        # whole-workspace scanner table. Empty string for a single-directory scan,
+        # so that output is unchanged. Every value inside is escaped by the
+        # renderer -- a project label arrives from a project's own config file.
+        workspace_section = html_workspace_section(model)
 
         template = f"""
 <!DOCTYPE html>
@@ -157,6 +181,8 @@ class HtmlReporter(ReporterPluginBase[HTMLReporterConfig]):
             <p><strong>Report generated:</strong> {html.escape(metadata["report_time"])}</p>
             <p><strong>ASH version:</strong> {html.escape(metadata["tool_version"])}</p>
         </div>
+
+        {workspace_section}
 
         <h2>Scanner Results</h2>
         <div class="help-text">

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/junitxml_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/junitxml_reporter.py
@@ -8,6 +8,10 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.models.flat_vulnerability import (
+    extract_workspace_project,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.severity_ladder import (
@@ -33,7 +37,25 @@ class JUnitXMLReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class JunitXmlReporter(ReporterPluginBase[JUnitXMLReporterConfig]):
-    """Formats results as JUnitXML."""
+    """Formats results as JUnitXML.
+
+    Workspace mode: one merged artefact, with the project in the testsuite name
+    as ``<project>/<scanner>``.
+
+    A deliberate deviation from the RFC, which said the project *becomes* the
+    testsuite name. Taken literally that discards the per-scanner grouping
+    single-directory mode has, and every CI front end that renders JUnit XML
+    groups by suite name -- so a reader would lose the ability to see that
+    bandit failed and checkov did not. The compound name costs nothing, keeps
+    the project as the primary sort key (it is the leading segment, so suites
+    for one project sort together), and makes the workspace artefact a strict
+    refinement of the per-project ones rather than a lossy reshape of them.
+
+    A single-directory scan is unaffected: with no project attribution the suite
+    name stays the bare scanner name it has always been.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         with warnings.catch_warnings():
@@ -189,11 +211,26 @@ class JunitXmlReporter(ReporterPluginBase[JUnitXMLReporterConfig]):
                 ):
                     if hasattr(result.properties.scanner_details, "tool_name"):
                         actual_scanner = result.properties.scanner_details.tool_name
-                if actual_scanner not in test_suite_dict:
-                    test_suite_dict[actual_scanner] = TestSuite(name=actual_scanner)
-                test_suite_dict[actual_scanner].add_testcase(test_case)
+                # In workspace mode the suite is named "<project>/<scanner>".
+                # Project leads so that one project's suites sort together in
+                # every CI front end that groups by suite name; the scanner is
+                # kept because discarding it -- the RFC's literal reading -- would
+                # lose a grouping single-directory mode has, for no gain.
+                #
+                # Read through the shared helper rather than inline, so this and
+                # the flattening path cannot disagree about where the attribution
+                # lives -- which is how a finding ends up under the wrong project
+                # in one report and the right one in another.
+                project = extract_workspace_project(result)
+                suite_name = (
+                    f"{project}/{actual_scanner}" if project else actual_scanner
+                )
+                if suite_name not in test_suite_dict:
+                    test_suite_dict[suite_name] = TestSuite(name=suite_name)
+                test_suite_dict[suite_name].add_testcase(test_case)
 
-        for scanner, test_suite in test_suite_dict.items():
+        for suite_name, test_suite in test_suite_dict.items():
+            del suite_name  # keyed for grouping; the name is already on the suite
             report.add_testsuite(test_suite)
         # Return the XML string representation of all test suites
         report_bytes: bytes = report.tostring()

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -10,9 +10,13 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
     ReportContentEmitter,
+)
+from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
+    markdown_workspace_section,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -46,7 +50,15 @@ class MarkdownReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
-    """Formats results as a human-readable Markdown document."""
+    """Formats results as a human-readable Markdown document.
+
+    Workspace mode: one merged artefact with a per-project section, placed
+    immediately after the header so it survives ``compact`` mode. Compact exists
+    for PR comments, and in a monorepo PR the single most useful line is which
+    project the findings are in -- so this is the one section compact must keep.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -87,6 +99,13 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
 
             md_parts.append(f"- **Time since scan**: {delta_str}")
         md_parts.append("")
+
+        # The per-project table goes here, before everything else and outside the
+        # compact gate. Compact mode exists for PR comments, and in a monorepo PR
+        # the single most useful line is which project the findings are in -- so
+        # this is the one section compact must not drop. Empty for a
+        # single-directory scan, which leaves that output unchanged.
+        md_parts.extend(markdown_workspace_section(model))
 
         # Add metadata section (skip in compact mode)
         if not compact:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/ocsf_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/ocsf_reporter.py
@@ -9,6 +9,10 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.models.flat_vulnerability import (
+    extract_workspace_project,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.schemas.ocsf.ocsf_vulnerability_finding import (
@@ -31,6 +35,42 @@ from typing import Optional, List, Tuple
 from automated_security_helper.utils.log import ASH_LOGGER
 
 
+#: Prefix for the ``metadata.labels`` entry carrying workspace attribution.
+#: ``key:value`` is OCSF's conventional shape for a label, and the prefix is what
+#: lets a SIEM query for it without matching a project name by accident.
+WORKSPACE_PROJECT_LABEL_PREFIX = "workspace_project:"
+
+
+def _metadata_for_project(metadata: Metadata, result: Result) -> Metadata:
+    """*metadata* with this finding's workspace project recorded in ``labels``.
+
+    Returns the shared object unchanged for a single-directory scan, so that
+    output is byte-identical and no needless copies are made.
+
+    Why ``labels`` and not a ``metadata.workspace_project`` field
+    -------------------------------------------------------------
+    The RFC asked for the project "in metadata", and OCSF's ``Metadata`` sets
+    ``extra="forbid"``. Worse than forbidding, pydantic's ``model_copy(update=...)``
+    *silently drops* a key the schema does not declare -- so the obvious
+    implementation would have produced findings with no attribution at all and no
+    error to show for it. ``labels`` is the schema's own slot for free-form
+    annotation, is indexed by SIEMs, and needs no schema extension.
+
+    Copied per finding rather than mutated in place: one ``Metadata`` instance is
+    shared across every finding in the report, so appending to its ``labels``
+    would give every finding every project's label.
+    """
+    project = extract_workspace_project(result)
+    if not project:
+        return metadata
+    existing = metadata.labels
+    labels = list(existing) if isinstance(existing, list) else []
+    label = f"{WORKSPACE_PROJECT_LABEL_PREFIX}{project}"
+    if label not in labels:
+        labels.append(label)
+    return metadata.model_copy(update={"labels": labels})
+
+
 class OCSFReporterConfigOptions(ReporterOptionsBase):
     pass
 
@@ -44,7 +84,20 @@ class OCSFReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class OcsfReporter(ReporterPluginBase[OCSFReporterConfig]):
-    """Formats results as an array of Open Cybersecurity Schema Framework (OCSF) VulnerabilityFinding objects."""
+    """Formats results as an array of Open Cybersecurity Schema Framework (OCSF) VulnerabilityFinding objects.
+
+    Workspace mode: one merged artefact, with the project carried in each
+    finding's ``metadata``.
+
+    ``metadata`` rather than ``resources`` or the finding title, because OCSF's
+    ``Metadata`` object is where provenance belongs and a SIEM ingesting these
+    can index on it without parsing a string. Each finding gets its own copy: the
+    array is flat, an event is routed individually, and a project stated once at
+    the top of the file would be lost the moment a consumer split the array --
+    which is the normal way a SIEM ingests one.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -528,7 +581,7 @@ class OcsfReporter(ReporterPluginBase[OCSFReporterConfig]):
                 "category_uid": 2,  # Vulnerability Finding category ID
                 "category_name": "Findings",
                 "time": current_time_ms,
-                "metadata": metadata,
+                "metadata": _metadata_for_project(metadata, result),
                 "finding_info": finding_info,
                 "vulnerabilities": [vulnerability],
             }

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/sarif_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/sarif_reporter.py
@@ -8,6 +8,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -25,7 +26,23 @@ class SARIFReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class SarifReporter(ReporterPluginBase[SARIFReporterConfig]):
-    """Formats results as SARIF."""
+    """Formats results as SARIF.
+
+    Workspace mode: one merged artefact carrying one run per project, each with
+    its own ``originalUriBaseIds`` -- which is exactly the shape
+    ``WorkspaceAggregator`` already built, so this reporter needs no code change
+    beyond declaring that it passes it through whole.
+
+    That "whole" is the load-bearing part, and it is why this reporter is tested
+    in workspace mode rather than assumed correct. A future optimisation that
+    collapsed the runs -- ``SarifReport.merge_sarif_report`` does precisely that,
+    and it is a method on the object being dumped here -- would produce a
+    document declaring one root for findings relative to N different roots, which
+    GitHub code scanning mis-locates or rejects. The test that pins the run count
+    fails first.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/spdx_reporter.py
@@ -9,6 +9,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.utils.log import ASH_LOGGER
@@ -27,7 +28,23 @@ class SPDXReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class SpdxReporter(ReporterPluginBase[SPDXReporterConfig]):
-    """Formats results as SPDX."""
+    """Formats results as SPDX.
+
+    Workspace mode: per project, on the same ground as ``cyclonedx_reporter`` --
+    an SPDX document describes one package with one set of licence and
+    provenance conclusions, and N independently versioned deliverables are N
+    documents.
+
+    Worth stating explicitly here because this reporter would not have *failed*
+    at workspace level. It dumps the whole model, so it would have emitted a
+    file: a workspace-shaped YAML blob presented as an SPDX document. An artefact
+    that is confidently wrong is harder to notice than one that is missing, and
+    the ruling is what keeps it from being produced. (The document is not valid
+    SPDX in single-directory mode either -- see the stub warning in ``report()``
+    -- but that is a separate gap and not one this phase closes.)
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
 
     def model_post_init(self, context):
         if self.config is None:
@@ -42,4 +59,9 @@ class SpdxReporter(ReporterPluginBase[SPDXReporterConfig]):
             "not yet implemented. The returned YAML is a raw model dump, not a valid "
             "SPDX document."
         )
-        return yaml.dump(model.model_dump(by_alias=True), indent=2)
+        # mode="json" for the same reason as yaml_reporter: without it the enums
+        # in the model become !!python/object/apply: tags that yaml.safe_load
+        # refuses. Fixed here as well rather than only there, because it is the
+        # identical line and leaving one of the two emitting unloadable YAML is
+        # harder to explain than fixing both.
+        return yaml.dump(model.model_dump(by_alias=True, mode="json"), indent=2)

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/text_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/text_reporter.py
@@ -10,6 +10,10 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
+    text_workspace_section,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
@@ -43,7 +47,15 @@ class TextReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class TextReporter(ReporterPluginBase[TextReporterConfig]):
-    """Formats results as a human-readable plain text document."""
+    """Formats results as a human-readable plain text document.
+
+    Workspace mode: one merged artefact with a per-project section. This is what
+    ends up in a CI job log, so the section is fixed-width and aligned like the
+    scanner table beside it -- a workspace summary that a reader has to count
+    columns in is worse than no summary.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -87,6 +99,11 @@ class TextReporter(ReporterPluginBase[TextReporterConfig]):
         text_parts.append(f"Scan executed: {metadata['scan_time']}")
         text_parts.append(f"ASH version: {metadata['tool_version']}")
         text_parts.append("")
+
+        # The per-project table, ahead of the summary because in a workspace the
+        # first question is which project failed and a merged count cannot answer
+        # it. Empty for a single-directory scan.
+        text_parts.extend(text_workspace_section(model))
 
         # Add summary section if enabled
         if isinstance(self.config, dict):

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/unused_suppressions_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/unused_suppressions_reporter.py
@@ -12,7 +12,9 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
+from automated_security_helper.models.workspace import is_workspace_scan
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 from automated_security_helper.models.core import AshSuppression
 
@@ -56,7 +58,33 @@ class UnusedSuppressionsReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class UnusedSuppressionsReporter(ReporterPluginBase[UnusedSuppressionsReporterConfig]):
-    """Identifies and reports suppressions that were not applied to any findings."""
+    """Identifies and reports suppressions that were not applied to any findings.
+
+    Workspace mode: ``WORKSPACE_SCOPED``. The per-project artefacts under
+    ``projects/<key>/reports/`` answer the per-project question, and the
+    workspace-level artefact reports only on *workspace-level* suppressions.
+
+    Not ``MERGED``, and the distinction is the difference between an incomplete
+    report and a false one. This reporter subtracts ``model.used_suppressions``
+    from the suppressions its own config declares. The unified workspace file
+    carries ``used_suppressions: []`` -- suppression matching happened inside each
+    project's own scan, against that project's own config -- so a merged run
+    would find nothing used and declare *every* suppression unused. An operator
+    acting on that would delete suppressions that are load-bearing.
+
+    Not ``PER_PROJECT`` either, because a workspace-level suppression that matched
+    nothing in any project is a real thing to report and no per-project file can
+    see it: each project only knows its own config.
+
+    In this phase there are no workspace-level suppressions -- workspace-level
+    config arrives in Phase 3 -- so the workspace artefact states a count of zero
+    and says where the per-project reports are. It says that explicitly rather
+    than being absent, because "no file" and "no findings" are the two readings a
+    security report must never leave ambiguous, and this is the slot Phase 3 fills
+    without changing the contract.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.WORKSPACE_SCOPED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -96,6 +124,32 @@ class UnusedSuppressionsReporter(ReporterPluginBase[UnusedSuppressionsReporterCo
                 self._suppression_to_dict(s) for s in unused_suppressions
             ],
         }
+
+        # In workspace mode the scope has to be stated, because the numbers above
+        # are honest only about workspace-level suppressions. Read as a merge,
+        # "unused_suppressions: 0" would mean "nothing unused anywhere in the
+        # workspace"; what it means is "no workspace-level suppression went
+        # unused", and the per-project answers live in the per-project reports.
+        # Leaving that implicit would let an operator conclude their per-project
+        # suppressions are all in use on the strength of no evidence at all.
+        if is_workspace_scan(model):
+            workspace = model.workspace
+            report_data["scope"] = "workspace"
+            report_data["scope_detail"] = (
+                "Counts cover workspace-level suppressions only. Each project's "
+                "own suppressions were matched during that project's scan, "
+                "against that project's own config, and are reported under "
+                "per_project_reports."
+            )
+            report_data["per_project_reports"] = [
+                {
+                    "project": project.project,
+                    "path": (
+                        f"{project.output_path}/reports/ash.{self.config.extension}"
+                    ),
+                }
+                for project in workspace.projects
+            ]
 
         # Check if we should generate both formats
         output_format = getattr(self.config.options, "output_format", "both")

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/workspace_section.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/workspace_section.py
@@ -1,0 +1,222 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The per-project section the three human-readable reporters share.
+
+Why this is one module and not three tables
+-------------------------------------------
+``html``, ``markdown`` and ``text`` all need to answer the same question -- which
+project is in trouble -- and each renders it in its own markup. Written three
+times, the three would drift: a column added to one, a status spelling changed in
+another, a verdict computed slightly differently in the third. The rows are built
+once here and only the rendering differs, so a change to *what* is reported lands
+in all three at once and a change to *how* stays local to one function.
+
+The rows come from the workspace payload, not from the findings
+--------------------------------------------------------------
+``exceeds_threshold`` and ``actionable_finding_count`` are read off
+``model.workspace.projects``, where each project's own scan recorded them against
+that project's own effective threshold. They are deliberately not recomputed from
+the findings in the merged model.
+
+Recomputing would apply one threshold to every project, and projects in a
+workspace are independently configured -- a project with a HIGH threshold and a
+project with a LOW one would be judged the same way. The section would then
+disagree with the exit code for the same run, and an operator would have two
+verdicts and no rule for which is authoritative. The whole invariant workspace
+mode holds is that a project's verdict is what ``ash --source-dir P`` would
+produce; re-deriving it here would break that in the most visible artefact.
+
+The finding *counts* per project are also taken from the payload for the same
+reason, with one consequence worth naming: they count unsuppressed findings as
+the per-project scan counted them, which is not necessarily the number of rows a
+reader can find for that project elsewhere in the same document if a reporter
+filters differently. That is a real inconsistency, and it is the correct one --
+the alternative makes the table disagree with the verdict beside it.
+
+Failure modes and known limitations
+-----------------------------------
+* A project with no verdict -- skipped, or failed -- has no threshold and no
+  counts. It appears with its status and its reason rather than being omitted:
+  omitting it would let a project the operator asked for vanish from the one
+  table they read, which is the silent-omission failure this feature exists
+  against.
+* ``display_label`` is not unique by construction (see ``ProjectPlan``), so the
+  key is shown when the two differ. Showing only the label would make two
+  projects indistinguishable in the table while the findings under them differ.
+* Every value that reaches HTML is escaped. A label arrives from a project's own
+  config file, which is untrusted text as far as this code is concerned.
+"""
+
+from __future__ import annotations
+
+import html as html_escape
+from typing import Any, Dict, List, Optional, Sequence, TYPE_CHECKING
+
+from automated_security_helper.models.workspace import is_workspace_scan
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from automated_security_helper.models.asharp_model import AshAggregatedResults
+
+#: The HTML section's anchor id, so a test and a stylesheet can find it without
+#: matching on prose.
+HTML_SECTION_ID = "workspace-projects"
+
+#: Column order, shared by all three renderers so they cannot present the same
+#: data in different orders.
+COLUMNS = ("Project", "Status", "Findings", "Actionable", "Threshold", "Result")
+
+
+def workspace_project_rows(model: "AshAggregatedResults") -> List[Dict[str, Any]]:
+    """One row per project, in workspace-file order, or ``[]`` for a single scan.
+
+    Returning ``[]`` rather than raising for a non-workspace model is what lets
+    every call site be a single ``if rows:`` -- the alternative is the same
+    ``model.workspace is None`` test repeated in three reporters, which is one
+    place for it to be spelled wrong.
+    """
+    if not is_workspace_scan(model):
+        return []
+    workspace = model.workspace
+
+    rows: List[Dict[str, Any]] = []
+    for project in workspace.projects:
+        status = getattr(project.status, "value", project.status)
+        if project.skip_reason is not None:
+            # The reason matters more than the word "skipped": a no-changes skip
+            # is a successful optimisation and an error skip is a project that
+            # was not looked at, and they must not read the same.
+            reason = getattr(project.skip_reason, "value", project.skip_reason)
+            result = f"SKIPPED ({reason})"
+        elif project.error:
+            result = "FAILED"
+        elif project.exceeds_threshold:
+            result = "FAILED"
+        else:
+            result = "PASSED"
+
+        label = project.display_label
+        if label != project.project:
+            label = f"{label} ({project.project})"
+
+        rows.append(
+            {
+                "project": label,
+                "key": project.project,
+                "status": str(status).upper(),
+                "findings": project.finding_count,
+                "actionable": project.actionable_finding_count,
+                "threshold": project.severity_threshold or "n/a",
+                "result": result,
+                "detail": project.error or project.skip_detail or "",
+            }
+        )
+    return rows
+
+
+def _cells(row: Dict[str, Any]) -> Sequence[str]:
+    """One row's values in :data:`COLUMNS` order, as strings."""
+    return (
+        str(row["project"]),
+        str(row["status"]),
+        str(row["findings"]),
+        str(row["actionable"]),
+        str(row["threshold"]),
+        str(row["result"]),
+    )
+
+
+def markdown_workspace_section(model: "AshAggregatedResults") -> List[str]:
+    """The section as markdown lines, or ``[]`` when this is not a workspace scan.
+
+    Lines rather than one string, because the markdown reporter assembles its
+    document from a list and joins once; handing it a block would make it the only
+    element that had to be spliced.
+    """
+    rows = workspace_project_rows(model)
+    if not rows:
+        return []
+
+    lines = ["## Projects\n"]
+    lines.append(
+        "Each project is scanned independently and judged against its own "
+        "threshold, so a workspace fails when any project does.\n"
+    )
+    lines.append("| " + " | ".join(COLUMNS) + " |")
+    lines.append("| --- | --- | ---: | ---: | --- | --- |")
+    for row in rows:
+        # Escaped for markdown tables specifically: a pipe in a project label
+        # would otherwise split the row into extra columns and silently shift
+        # every value after it.
+        lines.append(
+            "| " + " | ".join(cell.replace("|", "\\|") for cell in _cells(row)) + " |"
+        )
+    lines.append("")
+    return lines
+
+
+def text_workspace_section(
+    model: "AshAggregatedResults", *, widths: Optional[Sequence[int]] = None
+) -> List[str]:
+    """The section as fixed-width plain-text lines, or ``[]`` for a single scan.
+
+    Column widths are computed from the content rather than hardcoded, so a long
+    project label widens its column instead of pushing every later column out of
+    alignment. This lands in a CI job log, where a table a reader has to count
+    columns in is worse than no table -- and misalignment in the neighbouring
+    scanner table was a real defect once already, pinned by
+    ``TestTextReporterColumnAlignment``.
+    """
+    rows = workspace_project_rows(model)
+    if not rows:
+        return []
+
+    cells = [_cells(row) for row in rows]
+    if widths is None:
+        widths = [
+            max(len(COLUMNS[index]), *(len(cell[index]) for cell in cells))
+            for index in range(len(COLUMNS))
+        ]
+
+    def line(values: Sequence[str]) -> str:
+        return "  ".join(
+            value.ljust(widths[index]) for index, value in enumerate(values)
+        )
+
+    lines = ["", "PROJECTS", "-" * len(line(COLUMNS))]
+    lines.append(line(COLUMNS))
+    lines.append("-" * len(line(COLUMNS)))
+    lines.extend(line(cell) for cell in cells)
+    lines.append("")
+    return lines
+
+
+def html_workspace_section(model: "AshAggregatedResults") -> str:
+    """The section as an HTML fragment, or ``""`` when this is not a workspace scan.
+
+    Every interpolated value goes through ``html.escape``. A project label comes
+    from a project's own config file, so it is untrusted text: unescaped, a label
+    containing markup would rewrite the surrounding report, and ASH self-scans
+    this repository at MEDIUM where an unescaped interpolation is an actionable
+    finding.
+    """
+    rows = workspace_project_rows(model)
+    if not rows:
+        return ""
+
+    header = "".join(f"<th>{html_escape.escape(column)}</th>" for column in COLUMNS)
+    body = []
+    for row in rows:
+        cells = "".join(f"<td>{html_escape.escape(cell)}</td>" for cell in _cells(row))
+        css_class = "failed" if row["result"].startswith("FAILED") else "passed"
+        body.append(f'<tr class="{css_class}">{cells}</tr>')
+
+    return (
+        f'<div class="section" id="{HTML_SECTION_ID}">'
+        "<h2>Projects</h2>"
+        "<p>Each project is scanned independently and judged against its own "
+        "threshold, so a workspace fails when any project does.</p>"
+        f"<table><thead><tr>{header}</tr></thead>"
+        f"<tbody>{''.join(body)}</tbody></table>"
+        "</div>"
+    )

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/yaml_reporter.py
@@ -10,6 +10,7 @@ from automated_security_helper.base.options import ReporterOptionsBase
 from automated_security_helper.base.reporter_plugin import (
     ReporterPluginBase,
     ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
 )
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
@@ -27,7 +28,18 @@ class YAMLReporterConfig(ReporterPluginConfigBase):
 
 @ash_reporter_plugin
 class YamlReporter(ReporterPluginBase[YAMLReporterConfig]):
-    """Formats results as YAML."""
+    """Formats results as YAML.
+
+    Workspace mode: one merged artefact, and the field the RFC asks for needs no
+    code. This reporter dumps the whole model, so it already carries the
+    ``workspace`` block, every SARIF run, and ``properties.workspace_project`` on
+    every finding. The declaration is what makes that a *stated* behaviour rather
+    than a coincidence, and ``tests/unit/workspace/test_workspace_reporting.py``
+    holds it -- a future change that dropped ``workspace`` from the dump, or
+    narrowed it to one run, would fail there rather than passing quietly.
+    """
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
 
     def model_post_init(self, context):
         if self.config is None:
@@ -35,6 +47,24 @@ class YamlReporter(ReporterPluginBase[YAMLReporterConfig]):
         return super().model_post_init(context)
 
     def report(self, model: "AshAggregatedResults") -> str:
-        """Format ASH model as YAML string."""
+        """Format ASH model as YAML string.
 
-        return yaml.dump(model.model_dump(by_alias=True), indent=2)
+        ``mode="json"`` is what makes the output loadable at all, and its absence
+        was a live defect rather than a workspace-mode concern.
+
+        Without it ``model_dump`` leaves enum *objects* in the tree, and
+        ``yaml.dump`` serialises those as ``!!python/object/apply:`` tags. Any
+        real scan has at least one -- every ``scanner_results`` entry carries a
+        ``ScannerStatus`` -- so ``ash.yaml`` could not be read by
+        ``yaml.safe_load`` and could only be parsed by a loader that will
+        construct arbitrary Python objects from the file. Workspace mode is how
+        this surfaced (it adds ``ProjectRunStatus`` and ``SkippedProjectReason``),
+        but the fix applies to every scan, and it is what makes the workspace
+        attribution this reporter carries actually reachable by a consumer.
+
+        Existing consumers are unaffected in the direction that matters: a status
+        that was an unloadable tag becomes the plain string ``"FAILED"``, which a
+        loader using ``yaml.load`` parses just as happily.
+        """
+
+        return yaml.dump(model.model_dump(by_alias=True, mode="json"), indent=2)

--- a/automated_security_helper/schemas/AshAggregatedResults.json
+++ b/automated_security_helper/schemas/AshAggregatedResults.json
@@ -21048,6 +21048,14 @@
           "title": "Actionable Finding Count",
           "type": "integer"
         },
+        "ceiling_unreachable_findings": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Per scanner, how many of this project's findings the workspace severity ceiling could not affect, because they carry no properties.issue_severity and are therefore judged from the SARIF level -- where `error` is read as critical and so is actionable at every threshold. Populated only when the ceiling actually tightened this project AND some of its findings were beyond that tightening's reach, so an empty mapping means the ceiling did what it says. An observation about these findings, not a claim about the scanner: it is recomputed every scan, so it stops appearing if a scanner starts emitting severity.",
+          "title": "Ceiling Unreachable Findings",
+          "type": "object"
+        },
         "display_label": {
           "description": "What a human reads. Not unique.",
           "minLength": 1,

--- a/automated_security_helper/schemas/AshWorkspaceConfig.json
+++ b/automated_security_helper/schemas/AshWorkspaceConfig.json
@@ -1,0 +1,189 @@
+{
+  "$defs": {
+    "AshSuppression": {
+      "description": "Represents a finding suppression rule.",
+      "properties": {
+        "expiration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Expiration date (YYYY-MM-DD)",
+          "title": "Expiration"
+        },
+        "line_end": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Ending line number",
+          "title": "Line End"
+        },
+        "line_start": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Starting line number",
+          "title": "Line Start"
+        },
+        "path": {
+          "description": "Path or pattern to exclude",
+          "title": "Path",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason for exclusion",
+          "title": "Reason",
+          "type": "string"
+        },
+        "rule_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Rule ID to suppress",
+          "title": "Rule Id"
+        }
+      },
+      "required": [
+        "path",
+        "reason"
+      ],
+      "title": "AshSuppression",
+      "type": "object"
+    },
+    "IgnorePathWithReason": {
+      "description": "Represents a path exclusion entry.",
+      "properties": {
+        "expiration": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "(Optional) Expiration date (YYYY-MM-DD)",
+          "title": "Expiration"
+        },
+        "path": {
+          "description": "Path or pattern to exclude",
+          "title": "Path",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Reason for exclusion",
+          "title": "Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "path",
+        "reason"
+      ],
+      "title": "IgnorePathWithReason",
+      "type": "object"
+    },
+    "WorkspacePolicyConfig": {
+      "additionalProperties": false,
+      "description": "Workspace-wide policy: the ``workspace`` block of the policy file.\n\nEvery field here can change a project's verdict, which is why they live in\ntheir own file rather than beside the execution knobs in\n``AshConfig.workspace``.",
+      "properties": {
+        "additional_scanners": {
+          "default": [],
+          "description": "Scanners every project must run, in addition to whatever it enables itself. Additive only -- this cannot disable a scanner a project enabled. A scanner the project already declares runs under the project's own config and its findings are the project's; a scanner added only by this policy runs with default config and its findings are tagged 'origin: workspace-policy' and reported separately.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Additional Scanners",
+          "type": "array"
+        },
+        "ignore_paths": {
+          "default": [],
+          "description": "Paths excluded across the workspace. Workspace-relative and pushed down per project, exactly as 'suppressions' are.",
+          "items": {
+            "$ref": "#/$defs/IgnorePathWithReason"
+          },
+          "title": "Ignore Paths",
+          "type": "array"
+        },
+        "max_severity_threshold": {
+          "anyOf": [
+            {
+              "enum": [
+                "ALL",
+                "LOW",
+                "MEDIUM",
+                "HIGH",
+                "CRITICAL"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The LOOSEST severity threshold any project may use. A project configuring something stricter keeps it; a project configuring something looser is tightened to this value. 'max' refers to permissiveness, not to severity: the strictness order is ALL < LOW < MEDIUM < HIGH < CRITICAL, so raising this value LOOSENS the ceiling. Unset means no ceiling. Case-sensitive.",
+          "title": "Max Severity Threshold"
+        },
+        "policy_scanners_gate": {
+          "default": false,
+          "description": "Whether findings from policy-added scanners affect a project's exit code. Default false: a workspace that adds a scanner to gather visibility should not thereby fail projects that never opted into it, and turning it on is the operator saying they have triaged what the new scanner reports.",
+          "title": "Policy Scanners Gate",
+          "type": "boolean"
+        },
+        "suppressions": {
+          "default": [],
+          "description": "Suppressions that apply across the workspace. Paths are WORKSPACE-relative (e.g. 'api/src/legacy.py') and are rewritten into each project's own coordinates before being applied. A suppression that cannot match inside a project is not passed to it; one that cannot be rewritten soundly refuses the workspace.",
+          "items": {
+            "$ref": "#/$defs/AshSuppression"
+          },
+          "title": "Suppressions",
+          "type": "array"
+        }
+      },
+      "title": "WorkspacePolicyConfig",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "The whole workspace policy file.\n\nA thin wrapper over one block, kept as its own model so the file has a\nversionable top-level schema and so ``workspace:`` reads the same here as it\ndoes in a project config.",
+  "properties": {
+    "workspace": {
+      "$ref": "#/$defs/WorkspacePolicyConfig",
+      "default": {
+        "additional_scanners": [],
+        "ignore_paths": [],
+        "max_severity_threshold": null,
+        "policy_scanners_gate": false,
+        "suppressions": []
+      },
+      "description": "Workspace-wide policy. Distinct from AshConfig.workspace, which holds execution scheduling knobs in a project config; nothing here can be set from a project's own file."
+    }
+  },
+  "title": "AshWorkspaceConfig",
+  "type": "object"
+}

--- a/automated_security_helper/schemas/generate_schemas.py
+++ b/automated_security_helper/schemas/generate_schemas.py
@@ -6,16 +6,24 @@ from typing import Literal
 
 def generate_schemas(output: Literal["file", "json", "dict"] = "file"):
     """Generate JSON schemas for the models."""
-    from pathlib import Path
-    from automated_security_helper.config.ash_config import AshConfig
-    from automated_security_helper.models.asharp_model import AshAggregatedResults
     import json
+    from pathlib import Path
+
+    from automated_security_helper.config.ash_config import AshConfig
+    from automated_security_helper.config.ash_workspace_config import (
+        AshWorkspaceConfig,
+    )
+    from automated_security_helper.models.asharp_model import AshAggregatedResults
 
     cur_file_path = Path(__file__)
     # create schemas dir if not existing
     schemas_dir = cur_file_path.parent
     resp = {}
-    for model in [AshConfig, AshAggregatedResults]:
+    # AshWorkspaceConfig is the workspace policy file's schema. It is a separate
+    # model, not a block of AshConfig, because it lives in a separate file -- see
+    # config/ash_workspace_config.py for why policy must not be readable from a
+    # project's config.
+    for model in [AshConfig, AshAggregatedResults, AshWorkspaceConfig]:
         json_schema_path = schemas_dir.joinpath(f"{model.__name__}.json").resolve()
         schema = model.model_json_schema()
         if output == "dict":

--- a/automated_security_helper/workspace/aggregation.py
+++ b/automated_security_helper/workspace/aggregation.py
@@ -638,8 +638,13 @@ class WorkspaceAggregator:
         # project's own total.
         if outcome.actionable_finding_count:
             for name, results in by_scanner.items():
+                # gate_threshold, matching what the project's own verdict was
+                # computed from. Using severity_threshold here made the two
+                # derivations of one number disagree the moment a workspace
+                # ceiling tightened anything: the project reported 1 actionable
+                # and this split summed to 0, with no rule for which to trust.
                 actionable = count_actionable_results(
-                    results, project.severity_threshold
+                    results, project.gate_threshold
                 )
                 self._scanner_actionable[name] = (
                     self._scanner_actionable.get(name, 0) + actionable

--- a/automated_security_helper/workspace/execution.py
+++ b/automated_security_helper/workspace/execution.py
@@ -9,12 +9,40 @@ Phase 1 produced a plan and refused to act on it. This is the part that acts, an
 its whole job is to hold one invariant while doing so:
 
     For any project P, the findings reported for P and the pass/fail verdict for P
-    are identical to what ``ash --source-dir P`` would produce.
+    are identical to what ``ash --source-dir P`` would produce, ABSENT workspace
+    policy.
 
-Everything below follows from that. Nothing here applies a workspace-level policy,
-because a workspace-level policy can change a project's verdict and that arrives
-in a later phase, explicitly and visibly, rather than sneaking in with an
-execution change.
+Everything below follows from that. The qualification was added in Phase 3 and is
+not a weakening of the invariant; it is the one thing allowed to change a verdict,
+and it does so only where an operator wrote a policy file saying so.
+
+Where policy enters, and where it deliberately does not
+------------------------------------------------------
+Exactly one line applies it: the verdict reads ``project.gate_threshold`` rather
+than ``project.severity_threshold``, so a workspace severity ceiling decides which
+findings are actionable. Everything else about a project's scan -- which scanners
+run, what config they read, what they report -- is still the project's own.
+
+That single point is deliberate. The ceiling changes only the JUDGEMENT of
+findings, never their discovery, so a project scanned under a ceiling reports the
+same findings as ``ash --source-dir P`` and differs only in how many of them are
+counted actionable. An operator can therefore always reproduce a workspace
+verdict locally by passing the effective threshold, which ``--dry-run`` prints.
+
+Two policy fields do NOT yet reach the scan, and the reason is a real constraint
+rather than an omission. ``workspace.suppressions``, ``workspace.ignore_paths``
+and ``workspace.additional_scanners`` have to be visible to the scanners
+themselves, which read them from the resolved ``AshConfig``.
+``ASHScanOrchestrator.__init__`` unconditionally overwrites its ``config`` field
+by calling ``resolve_config`` itself, so a caller cannot hand it a config with
+policy merged in. The other available channel, ``config_overrides``, is
+string-keyed and FAILS OPEN: ``apply_config_overrides`` logs a warning and
+returns the ORIGINAL config when an override does not parse or the result does
+not validate. Routing a security policy through it would mean a typo silently
+scans with no policy at all, which is the failure direction this whole feature
+exists to prevent. Those fields are resolved, validated, pushed down per project
+and recorded on the plan; wiring them into the scan needs the orchestrator to
+accept a pre-resolved config, which touches the single-project path.
 
 How the scoping is achieved, and why it needs almost no new code
 ---------------------------------------------------------------
@@ -220,10 +248,19 @@ from automated_security_helper.workspace.aggregation import (
     has_finding_at_min_severity,
 )
 from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.policy import ceiling_unreachable_counts
+from automated_security_helper.workspace.reporting import (
+    WorkspaceReportOutcome,
+    emit_workspace_reports,
+    unsupported_reporter_names,
+)
 
 #: How often the outer loop wakes to check per-project deadlines. Small enough
 #: that a timeout is reported promptly, large enough not to spin.
 _DEADLINE_POLL_SECONDS = 0.05
+
+#: The phase name that selects report generation, as ``run_ash_scan`` spells it.
+_REPORT_PHASE = "report"
 
 #: The subtree each project's own output lands in.
 PROJECTS_DIR_NAME = "projects"
@@ -275,6 +312,11 @@ class WorkspaceRunResult:
     exit_code: int
     payload: WorkspaceResults
     project_durations: Dict[str, float] = field(default_factory=dict)
+    #: What the workspace-level report step produced, or ``None`` when the
+    #: operator did not ask for the report phase. ``None`` rather than an empty
+    #: outcome, so a caller can tell "no reports were requested" from "reports
+    #: were requested and every one was withheld".
+    report_outcome: Optional["WorkspaceReportOutcome"] = None
 
 
 @dataclass
@@ -380,7 +422,7 @@ def _skipped_outcome(
             relative_path=project.relative_path,
             display_label=project.display_label,
             status=ProjectRunStatus.SKIPPED,
-            severity_threshold=project.severity_threshold,
+            severity_threshold=project.gate_threshold,
             output_path=_project_output_dir(settings, project)
             .relative_to(Path(settings.output_dir))
             .as_posix(),
@@ -404,7 +446,7 @@ def _failed_outcome(
             relative_path=project.relative_path,
             display_label=project.display_label,
             status=ProjectRunStatus.FAILED,
-            severity_threshold=project.severity_threshold,
+            severity_threshold=project.gate_threshold,
             output_path=_project_output_dir(settings, project)
             .relative_to(Path(settings.output_dir))
             .as_posix(),
@@ -533,7 +575,15 @@ def _scan_one_project(
             python_based_plugins_only=settings.python_based_plugins_only,
             ignore_suppressions=settings.ignore_suppressions,
             ash_plugin_modules=list(settings.ash_plugin_modules),
-            metadata=None,
+            # The project's own identity, so that its per-project reports can say
+            # which project they describe. Ten of the nineteen reporters are ruled
+            # PER_PROJECT, and that ruling is only honest if the N artefacts are
+            # distinguishable -- which for the four that publish to a shared
+            # destination they were not. See ASHScanOrchestrator._apply_metadata.
+            metadata={
+                "project_name": project.display_label,
+                "workspace_project": project.key,
+            },
         )
         results = orchestrator.execute_scan(phases=list(settings.phases))
     except ASHConfigValidationError as exc:
@@ -565,7 +615,11 @@ def _scan_one_project(
     results_list = list(run.get("results") or []) if run else []
 
     unsuppressed = [entry for entry in results_list if not entry.get("suppressions")]
-    threshold = project.severity_threshold
+    # gate_threshold, not severity_threshold: this is where a workspace severity
+    # ceiling takes effect on the verdict. Reading the declared value here would
+    # leave the ceiling visible in the plan and in --dry-run while changing
+    # nothing about which projects fail.
+    threshold = project.gate_threshold
     actionable = count_actionable_results(results_list, threshold)
     if actionable and not has_finding_at_min_severity(
         results_list, settings.min_severity
@@ -597,6 +651,19 @@ def _scan_one_project(
 
     _write_project_results(project_output, results)
 
+    # Where the ceiling could not reach, computed from the findings actually
+    # present rather than asserted about a scanner. Only when the ceiling really
+    # did tighten this project: a disclosure printed on every scan is noise, and
+    # noise gets skipped. ceiling_unreachable_counts returns {} when the two
+    # thresholds are equal, so this is belt and braces rather than the only guard.
+    unreachable: Dict[str, int] = {}
+    if project.threshold_tightened_by_policy:
+        unreachable = ceiling_unreachable_counts(
+            results_list,
+            declared_threshold=project.severity_threshold,
+            effective_threshold=threshold,
+        )
+
     outcome = WorkspaceProjectResult(
         project=project.key,
         relative_path=project.relative_path,
@@ -609,6 +676,7 @@ def _scan_one_project(
         duration_seconds=time.monotonic() - started,
         output_path=output_path,
         scanners=_scanner_statuses(results),
+        ceiling_unreachable_findings=unreachable,
     )
     return _ProjectRun(outcome=outcome, run=run)
 
@@ -677,6 +745,7 @@ def execute_workspace(
     settings: ProjectScanSettings,
     *,
     orchestrator_factory: Optional[OrchestratorFactory] = None,
+    reporter_classes: Optional[List[type]] = None,
 ) -> WorkspaceRunResult:
     """Scan every active project in *plan* and write the unified results.
 
@@ -687,15 +756,18 @@ def execute_workspace(
         orchestrator_factory: Builds one project's orchestrator. Defaults to
             ``ASHScanOrchestrator.create``; injected only by tests, so production
             callers never pass it.
+        reporter_classes: The reporters the workspace-level report step considers.
+            Defaults to the plugin registry; injected only by tests.
 
     Returns:
         The unified results path, the process exit code, and the payload.
 
     Raises:
         WorkspaceDefinitionError: When a project is not a git repository under
-            ``precommit`` without ``--allow-missing-projects``. Raised rather than
-            recorded because nothing has been scanned yet and the operator's flags
-            are contradictory -- that is an exit-2 refusal, not a project failure.
+            ``precommit`` without ``--allow-missing-projects``, or when an enabled
+            reporter declares itself unsupported in workspace mode. Raised rather
+            than recorded because nothing has been scanned yet -- that is an
+            exit-4 refusal, not a project failure.
     """
     if orchestrator_factory is None:
         from automated_security_helper.core.orchestrator import ASHScanOrchestrator
@@ -736,6 +808,39 @@ def execute_workspace(
     # first project to touch it would otherwise freeze the scanner set for all.
     prewarm_plugin_registry(plan, settings)
 
+    reports_requested = _REPORT_PHASE in settings.phases
+    if reports_requested:
+        # Before the scan, for two reasons. The operator learns immediately
+        # rather than after paying for the whole workspace; and once
+        # ``aggregator.write`` has recorded the exit code *into* the results
+        # file, a refusal could only be surfaced by exiting with a status that
+        # file does not contain -- two answers to one question, which is what
+        # models.workspace's exit-code contract exists to avoid.
+        #
+        # After prewarm_plugin_registry, and that order is load-bearing rather
+        # than incidental: reading the reporter set from a cold registry would
+        # memoise whatever was resolvable at that moment into
+        # ``_resolved_plugins["reporter"]``, and prewarm would then hand every
+        # project the memoised subset. That is exactly the defect prewarm exists
+        # to fix, reintroduced from the other end.
+        #
+        # Gated on the report phase because a reporter that cannot produce a
+        # workspace artefact is not an operator's problem until they ask for one.
+        refusing = unsupported_reporter_names(
+            plan,
+            output_dir,
+            output_formats=settings.output_formats,
+            python_based_plugins_only=settings.python_based_plugins_only,
+            reporter_classes=reporter_classes,
+        )
+        if refusing:
+            raise WorkspaceDefinitionError(
+                f"reporter(s) {', '.join(refusing)} declare that they cannot "
+                f"produce a correct report in workspace mode, and are enabled. "
+                f"Nothing was scanned. Disable them, narrow --output-format to "
+                f"exclude them, or scan the projects separately."
+            )
+
     bound = min(configured_bound, len(active) or 1)
     ASH_LOGGER.info(
         f"Scanning {len(active)} workspace project(s), "
@@ -772,6 +877,23 @@ def execute_workspace(
         max_parallel_projects=configured_bound,
         project_timeout=settings.project_timeout,
     )
+
+    # After the results file, because the merged reporters read it back -- see
+    # "Why the whole model is loaded back" in workspace.reporting. Reading the
+    # written file rather than a parallel in-memory model is what makes it
+    # impossible for the workspace reports to disagree with it.
+    report_outcome: Optional[WorkspaceReportOutcome] = None
+    if reports_requested:
+        report_outcome = emit_workspace_reports(
+            plan=plan,
+            output_dir=output_dir,
+            results_path=results_path,
+            output_formats=settings.output_formats,
+            python_based_plugins_only=settings.python_based_plugins_only,
+            ignore_suppressions=settings.ignore_suppressions,
+            reporter_classes=reporter_classes,
+        )
+
     return WorkspaceRunResult(
         results_path=results_path,
         exit_code=exit_code,
@@ -779,6 +901,7 @@ def execute_workspace(
         project_durations={
             key: entry.outcome.duration_seconds for key, entry in collected.items()
         },
+        report_outcome=report_outcome,
     )
 
 

--- a/automated_security_helper/workspace/plan.py
+++ b/automated_security_helper/workspace/plan.py
@@ -71,6 +71,10 @@ from typing import Annotated, Dict, List, Optional
 
 from pydantic import BaseModel, Field, computed_field
 
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
 from automated_security_helper.models.workspace import (
     SkippedProject,
     SkippedProjectReason,
@@ -158,13 +162,84 @@ class ProjectPlan(BaseModel):
         Field(
             None,
             description=(
-                "The project's own global_settings.severity_threshold. A "
-                "workspace-level ceiling is a later phase; when one exists the "
-                "effective value becomes severity_ladder.stricter_of(this, "
-                "ceiling)."
+                "The project's own global_settings.severity_threshold, exactly as "
+                "its config declared it. Kept alongside "
+                "effective_severity_threshold rather than being overwritten, so "
+                "an operator can see what a workspace ceiling changed instead of "
+                "only its result."
             ),
         ),
     ] = None
+    effective_severity_threshold: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "The threshold this project is actually judged against: "
+                "severity_ladder.stricter_of(severity_threshold, the workspace "
+                "ceiling). Equal to severity_threshold when there is no policy, "
+                "or when the project was already stricter than the ceiling."
+            ),
+        ),
+    ] = None
+    threshold_tightened_by_policy: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether the workspace ceiling actually moved this project's "
+                "threshold. Recorded rather than left to be re-derived, so "
+                "--dry-run and the reporters can state where policy took effect "
+                "without comparing two fields and reaching their own conclusion."
+            ),
+        ),
+    ] = False
+    policy_suppressions: Annotated[
+        List[AshSuppression],
+        Field(
+            default_factory=list,
+            description=(
+                "Workspace-level suppressions rewritten into THIS project's "
+                "coordinates. Only those whose pattern can match inside it; a "
+                "workspace suppression naming a sibling is absent here rather "
+                "than present and inert."
+            ),
+        ),
+    ]
+    policy_ignore_paths: Annotated[
+        List[IgnorePathWithReason],
+        Field(
+            default_factory=list,
+            description=(
+                "Workspace-level ignore paths, rewritten for this project on the "
+                "same terms as policy_suppressions."
+            ),
+        ),
+    ]
+    policy_scanners: Annotated[
+        List[str],
+        Field(
+            default_factory=list,
+            description=(
+                "Scanners the workspace policy adds that this project does not "
+                "itself enable. These run with ASH's default config and their "
+                "findings are tagged 'origin: workspace-policy'. A scanner the "
+                "project already declares is absent here, because it runs under "
+                "the project's own config and its findings are the project's."
+            ),
+        ),
+    ]
+    policy_scanners_gate: Annotated[
+        bool,
+        Field(
+            False,
+            description=(
+                "Whether findings from policy_scanners affect this project's exit "
+                "code. Carried per project so no consumer has to reach back into "
+                "the policy to interpret policy_scanners."
+            ),
+        ),
+    ] = False
     scanner_pins: Annotated[
         Dict[str, str],
         Field(
@@ -203,6 +278,27 @@ class ProjectPlan(BaseModel):
         Optional[str],
         Field(None, description="Human-readable explanation of the skip."),
     ] = None
+
+    @property
+    def gate_threshold(self) -> Optional[str]:
+        """The threshold this project's verdict must actually be judged against.
+
+        One accessor rather than each call site choosing, because a call site
+        that reads ``severity_threshold`` directly silently ignores the workspace
+        ceiling -- the ceiling would appear in the plan and in ``--dry-run`` while
+        changing no verdict, which is worse than not having it.
+
+        Falls back to ``severity_threshold`` when the effective value was never
+        computed. That happens for plans not built by ``resolve_workspace`` --
+        which this module's docstring says can exist -- and for skipped projects.
+        The fallback is not a silent default: when policy HAS been applied the
+        effective value is always set, equal to the declared one where the
+        ceiling did not bite. Returning ``None`` instead would turn the gate off
+        for those plans, which is the one failure direction that must not happen.
+        """
+        if self.effective_severity_threshold is not None:
+            return self.effective_severity_threshold
+        return self.severity_threshold
 
     def as_skipped_project(self) -> Optional[SkippedProject]:
         """This project as a ``skipped_projects`` payload entry, or None.
@@ -267,6 +363,18 @@ class WorkspacePlan(BaseModel):
             ),
         ),
     ] = False
+    workspace_config_source: Annotated[
+        Optional[str],
+        Field(
+            None,
+            description=(
+                "Path of the workspace policy file that was applied, or null when "
+                "the workspace declares no policy. Recorded because a ceiling "
+                "changes verdicts, so which file imposed it has to be answerable "
+                "from the output rather than by re-running discovery."
+            ),
+        ),
+    ] = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property
@@ -299,8 +407,14 @@ class WorkspacePlan(BaseModel):
             f"{len(self.active_projects)} to scan, {len(skipped)} skipped",
             f"{_INDENT}{'missing ok:':<{_FIELD_WIDTH}}"
             f"{'yes' if self.allow_missing_projects else 'no'}",
-            "",
         ]
+        # Only shown when there is policy. A "policy: none" line on every plan
+        # would train the reader to skip the line that matters.
+        if self.workspace_config_source:
+            lines.append(
+                f"{_INDENT}{'policy:':<{_FIELD_WIDTH}}{self.workspace_config_source}"
+            )
+        lines.append("")
 
         for position, project in enumerate(self.projects, start=1):
             suffix = ""
@@ -326,14 +440,34 @@ class WorkspacePlan(BaseModel):
                 f"{_INDENT}{'config:':<{_FIELD_WIDTH}}"
                 f"{project.config_source or 'ASH default config'}"
             )
-            lines.append(
-                f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}"
-                f"{project.severity_threshold or 'none'}"
-            )
+            # Both values when policy moved the threshold, so the reader can see
+            # what was declared and what will be enforced. One value otherwise:
+            # printing "CRITICAL -> CRITICAL" everywhere would bury the real cases.
+            declared = project.severity_threshold or "none"
+            if project.threshold_tightened_by_policy:
+                effective = project.effective_severity_threshold or "none"
+                lines.append(
+                    f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}"
+                    f"{effective}  (workspace policy tightened {declared})"
+                )
+            else:
+                lines.append(f"{_INDENT}{'threshold:':<{_FIELD_WIDTH}}{declared}")
             lines.append(
                 f"{_INDENT}{'scanners:':<{_FIELD_WIDTH}}"
                 f"{', '.join(project.scanners) or 'none enabled'}"
             )
+            if project.policy_scanners:
+                gating = "gating" if project.policy_scanners_gate else "not gating"
+                lines.append(
+                    f"{_INDENT}{'+policy:':<{_FIELD_WIDTH}}"
+                    f"{', '.join(project.policy_scanners)} ({gating})"
+                )
+            if project.policy_suppressions or project.policy_ignore_paths:
+                lines.append(
+                    f"{_INDENT}{'policy:':<{_FIELD_WIDTH}}"
+                    f"{len(project.policy_suppressions)} suppression(s), "
+                    f"{len(project.policy_ignore_paths)} ignore path(s)"
+                )
             if project.scanner_pins:
                 pins = ", ".join(
                     f"{scanner} {pin}"

--- a/automated_security_helper/workspace/policy.py
+++ b/automated_security_helper/workspace/policy.py
@@ -1,0 +1,557 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Find the workspace policy file, and push its policy down into one project.
+
+Why this module exists
+----------------------
+``config/ash_workspace_config.py`` says what workspace policy IS; this module
+decides which file carries it and what it means for a given project. Those are
+separate jobs because the second one needs the project list and the filesystem,
+and because every judgement here can change a project's verdict and so wants its
+reasoning written down next to it.
+
+Two things happen here, and they fail in opposite directions
+------------------------------------------------------------
+1. **Resolution** -- locate and parse the policy file. Everything is refused
+   with :class:`WorkspaceDefinitionError` (exit 4), because a policy file that
+   cannot be read is a policy that cannot be applied, and applying no policy
+   while the operator believes a ceiling is in force is a fail-open outcome.
+   The one non-refusal is a policy file that is simply absent: workspace policy
+   is opt-in, so its absence is the Phase 2b behaviour and not an error.
+2. **Push-down** -- rewrite the policy for one project. Here a pattern that
+   cannot match inside the project is DROPPED for that project rather than
+   refused, because it is legitimately about a different project. A pattern that
+   has no sound rewrite is refused, because silently dropping it would leave the
+   operator's stated suppression unapplied with nothing in the output to say so.
+
+Why the policy file cannot be a project's config
+------------------------------------------------
+A workspace root is often also a project, and then ``.ash/ash.yaml`` there is
+that project's config. Reading it as workspace policy would promote one
+project's ``severity_threshold`` into its siblings' ceiling, silently, from a
+file whose author expected project scope.
+
+Two mechanisms keep that from happening, and the second exists because the first
+is not sufficient:
+
+* ``WORKSPACE_POLICY_FILE_NAMES`` is disjoint from ``ASH_CONFIG_FILE_NAMES``, so
+  *discovery* can never land on a project config. A test asserts the
+  disjointness rather than trusting it to stay true.
+* ``--workspace-config`` can name any path, so discovery's guarantee does not
+  cover it. An explicit file is checked by RESOLVED IDENTITY against each
+  project's config path, not by filename, so a symlink or a ``./`` -prefixed
+  spelling of the same file is caught too. This mirrors the resolver's overlap
+  check, which compares real paths for the same reason.
+
+Ambiguity is refused, never ranked
+----------------------------------
+Two candidate policy files in one workspace is an error listing both. Picking by
+sort order or mtime would mean the effective ceiling changes when an operator
+adds a file they thought was inert -- and a ceiling that moves on its own is
+worse than no ceiling, because it is believed.
+
+What the ceiling can and cannot reach
+-------------------------------------
+``effective_threshold`` is ``stricter_of(project, ceiling)``, so a stricter
+project is untouched and a looser one is tightened. That composition is correct
+for every finding that carries ``properties.issue_severity``.
+
+It cannot tighten a finding that carries only a SARIF ``error`` level. Both
+ASH threshold gates map ``error`` to CRITICAL -- ``severity_ladder`` and
+``run_ash_scan``'s ``_THRESHOLD_QUALIFYING_LEVELS``, which agree over all 120
+level/severity/threshold combinations -- and CRITICAL is actionable at every
+threshold, including CRITICAL. So for such findings no threshold has ever
+changed anything, in workspace mode or single-project mode. checkov is the
+scanner ASH ships that omits ``issue_severity``.
+
+That was left as-is rather than remapped, deliberately. Remapping ``error`` to
+HIGH in ``severity_ladder`` alone was measured to break the central invariant at
+exactly one cell -- a level-only ``error`` at a CRITICAL threshold, which
+single-project mode calls actionable and workspace mode would not -- and it
+breaks it in the loosening direction, which is the one that hides findings.
+Remapping both gates instead keeps them consistent but silently stops failing
+CRITICAL-threshold single-project scans on ``error`` findings, a change to
+published exit-code behaviour well outside a workspace feature. Deriving
+``issue_severity`` for checkov has no source data: ASH reads checkov's SARIF
+verbatim and checkov does not emit severity.
+
+``threshold_tightened`` records whether the ceiling actually moved this project,
+so a reporter can say where policy took effect instead of leaving the operator
+to diff two numbers.
+
+Failure modes and known limitations
+-----------------------------------
+* Resolution is a point-in-time read; the file can change before the scan.
+* ``policy_scanners`` is computed by comparing normalised scanner names
+  (lower-cased, ``-`` and ``_`` folded together), because ``--scanners`` and the
+  config accept ``cdk-nag`` while the Python field is ``cdk_nag``. Treating
+  those as two scanners would run a second copy under default config and report
+  its findings as policy-origin duplicates of the project's own.
+* A policy suppression is pushed down per project, so one workspace-level entry
+  can become N project-level entries. Each is a copy: mutating in place would
+  leave the second project rewriting the first project's already-rewritten path.
+* ``additional_scanners`` is not validated against the set of scanners ASH knows
+  about. A typo therefore surfaces when execution cannot find the scanner rather
+  than at policy-resolution time. Validating here would need the plugin registry,
+  which is not loaded at resolution and whose contents depend on each project's
+  ``ash_plugin_modules``.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from pydantic import ValidationError
+
+from automated_security_helper.config.ash_workspace_config import (
+    AshWorkspaceConfig,
+    WorkspacePolicyConfig,
+)
+from automated_security_helper.core.exceptions import (
+    WorkspaceDefinitionError,
+    WorkspacePatternError,
+)
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+from automated_security_helper.utils.severity_ladder import (
+    SEVERITIES,
+    sarif_level_fails_threshold,
+    stricter_of,
+)
+from automated_security_helper.utils.workspace_paths import to_project_pattern
+
+# Written as `str | Path` rather than `Union[...]` -- evaluated eagerly at import,
+# and PEP 604 unions are runtime-valid from 3.10, this project's floor.
+PathLike = str | Path
+
+#: Names a workspace policy file may take. Deliberately disjoint from
+#: ``ASH_CONFIG_FILE_NAMES`` -- see "Why the policy file cannot be a project's
+#: config" in the module docstring.
+WORKSPACE_POLICY_FILE_NAMES: list[str] = [
+    ".ash-workspace.yml",
+    ".ash-workspace.yaml",
+    ".ash-workspace.json",
+    "ash-workspace.yml",
+    "ash-workspace.yaml",
+    "ash-workspace.json",
+]
+
+#: Subdirectory of the workspace root also searched, matching where project
+#: configs may live so an operator keeps one habit for both.
+_POLICY_SUBDIR = ".ash"
+
+
+@dataclass(frozen=True)
+class ProjectPolicy:
+    """Workspace policy as it applies to ONE project.
+
+    Attributes:
+        effective_threshold: ``stricter_of(project, ceiling)``. ``None`` when
+            neither side configures a threshold, which means the gate is off --
+            not a synonym for CRITICAL. See ``severity_ladder``.
+        threshold_tightened: Whether the ceiling changed this project's
+            threshold. Recorded rather than re-derived so a reporter can state
+            where policy took effect without comparing two values itself.
+        suppressions: Workspace suppressions rewritten into this project's
+            coordinates. Only those that can match inside it.
+        ignore_paths: The same, for ``ignore_paths``.
+        policy_scanners: Scanners this policy adds that the project does not
+            already declare. These run with default config and their findings
+            are tagged ``origin: workspace-policy``.
+        policy_scanners_gate: Whether those findings affect the project's exit
+            code. Carried per project so a caller never has to reach back into
+            the policy to interpret ``policy_scanners``.
+    """
+
+    effective_threshold: str | None
+    threshold_tightened: bool
+    suppressions: tuple[AshSuppression, ...]
+    ignore_paths: tuple[IgnorePathWithReason, ...]
+    policy_scanners: tuple[str, ...]
+    policy_scanners_gate: bool
+
+
+def _refuse(message: str) -> WorkspaceDefinitionError:
+    return WorkspaceDefinitionError(message)
+
+
+def ceiling_unreachable_counts(
+    results: Iterable[Mapping[str, Any]],
+    declared_threshold: str | None,
+    effective_threshold: str | None,
+) -> dict[str, int]:
+    """Per scanner, how many findings the severity ceiling could not affect.
+
+    This is the mechanised form of the limitation described in the module
+    docstring. Rather than documenting "the ceiling does not apply to checkov",
+    which goes stale the moment checkov starts emitting severity, it counts the
+    findings actually present for which tightening the threshold changed nothing,
+    and lets a reporter state that as an observation about those findings.
+
+    A finding counts when BOTH hold:
+
+    * It carries no usable ``properties.issue_severity``, so it is judged from
+      the SARIF ``level``. This is the discriminator, and it is why a genuinely
+      CRITICAL severity-carrying finding is NOT counted: that finding is
+      actionable at both thresholds too, but correctly so, and reporting it would
+      tell the operator the ceiling failed at something it never claimed.
+    * Its actionable verdict is identical at both thresholds, so the tightening
+      did not reach it. A level-only ``note`` under a CRITICAL-to-LOW tightening
+      IS reached, and so is not counted.
+
+    Suppressed findings are skipped: they are not actionable at any threshold, so
+    the ceiling is irrelevant to them.
+
+    Args:
+        results: The project's SARIF results.
+        declared_threshold: The threshold the project's own config asked for.
+        effective_threshold: The threshold after the workspace ceiling.
+
+    Returns:
+        Scanner name to count, for scanners with at least one such finding.
+        Empty when the two thresholds are equal -- no tightening means there is
+        no claim to qualify, which is what keeps this disclosure load-bearing
+        rather than printed on every scan.
+    """
+    if declared_threshold == effective_threshold:
+        return {}
+
+    counts: dict[str, int] = {}
+    for result in results:
+        if not isinstance(result, Mapping):
+            continue
+        if result.get("suppressions"):
+            continue
+
+        properties = result.get("properties")
+        issue_severity = ""
+        if isinstance(properties, Mapping):
+            issue_severity = str(properties.get("issue_severity") or "").upper()
+        if issue_severity in SEVERITIES:
+            # The ceiling reaches severity-carrying findings; nothing to disclose.
+            continue
+
+        level = result.get("level")
+        if sarif_level_fails_threshold(
+            level, declared_threshold
+        ) != sarif_level_fails_threshold(level, effective_threshold):
+            # The tightening changed this finding's verdict, so it was reached.
+            continue
+        if not sarif_level_fails_threshold(level, effective_threshold):
+            # Not actionable either way -- below both thresholds, not beyond reach.
+            continue
+
+        scanner = None
+        if isinstance(properties, Mapping):
+            scanner = properties.get("scanner_name")
+        # "unattributed" matches the name the aggregator uses for a finding with
+        # no scanner_name, so the two payloads agree on what to call it.
+        name = str(scanner) if scanner else "unattributed"
+        counts[name] = counts.get(name, 0) + 1
+
+    return counts
+
+
+def _normalise_scanner_name(name: str) -> str:
+    """Fold a scanner name to the form used for comparison.
+
+    ``cdk-nag`` and ``cdk_nag`` are one scanner: the former is what
+    ``--scanners`` and the config file accept, the latter is the Python field
+    name. Comparing raw strings would make policy add a duplicate.
+    """
+    return name.strip().lower().replace("-", "_")
+
+
+def _read_policy_document(path: Path) -> object:
+    """Parse the policy file, refusing anything unreadable.
+
+    Uses ``yaml.safe_load`` rather than ``AshConfig``'s ``!ENV``-aware loader.
+    See "No ``!ENV`` substitution" in ``config/ash_workspace_config.py``: a
+    ceiling an environment variable can loosen is not a ceiling.
+    """
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' could not be read: {exc}"
+        ) from exc
+    except UnicodeDecodeError as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' is not valid UTF-8: {exc}"
+        ) from exc
+
+    try:
+        if path.suffix.lower() == ".json":
+            return json.loads(raw)
+        return yaml.safe_load(raw)
+    except (yaml.YAMLError, json.JSONDecodeError) as exc:
+        raise _refuse(
+            f"workspace policy file '{path.as_posix()}' could not be parsed: {exc}"
+        ) from exc
+
+
+def load_workspace_policy(path: PathLike) -> AshWorkspaceConfig:
+    """Parse and validate the policy file at *path*.
+
+    Args:
+        path: The policy file. Must exist.
+
+    Returns:
+        The validated policy.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, for every unusable file -- absent,
+            unreadable, unparseable, not a mapping, or failing the schema. The
+            message names the file, because a workspace may have several config
+            files and "validation error" alone does not say which to open.
+    """
+    resolved = Path(path)
+    if not resolved.exists():
+        raise _refuse(f"workspace policy file '{resolved.as_posix()}' does not exist")
+    if not resolved.is_file():
+        raise _refuse(f"workspace policy file '{resolved.as_posix()}' is not a file")
+
+    resolved = resolved.resolve()
+    document = _read_policy_document(resolved)
+
+    # An empty file parses to None. Treated as "declares no policy" rather than
+    # refused: a commented-out policy file is a reasonable thing to keep in a
+    # repository, and it states no policy, which is representable.
+    if document is None:
+        return AshWorkspaceConfig()
+
+    if not isinstance(document, dict):
+        raise _refuse(
+            f"workspace policy file '{resolved.as_posix()}' must contain a "
+            f"mapping at the top level, found {type(document).__name__}"
+        )
+
+    try:
+        return AshWorkspaceConfig.model_validate(document)
+    except ValidationError as exc:
+        raise _refuse(
+            f"workspace policy file '{resolved.as_posix()}' is not valid: {exc}"
+        ) from exc
+
+
+def discover_workspace_policy_file(root: PathLike) -> Path | None:
+    """Find the one policy file for the workspace rooted at *root*.
+
+    Looks in *root* itself and in ``root/.ash``, non-recursively. Recursing would
+    let a vendored checkout supply workspace policy.
+
+    Returns:
+        The canonical path, or ``None`` when there is none.
+
+    Raises:
+        WorkspaceDefinitionError: When more than one candidate exists. Listed,
+            not ranked -- see the module docstring.
+    """
+    directory = Path(root)
+    candidates: list[Path] = []
+    for parent in (directory, directory / _POLICY_SUBDIR):
+        for name in WORKSPACE_POLICY_FILE_NAMES:
+            candidate = parent / name
+            if candidate.is_file():
+                candidates.append(candidate)
+
+    if not candidates:
+        return None
+
+    if len(candidates) > 1:
+        listed = "\n  - ".join(candidate.as_posix() for candidate in sorted(candidates))
+        raise _refuse(
+            f"Found {len(candidates)} workspace policy files under "
+            f"'{directory.as_posix()}'; there must be exactly one. Remove the "
+            f"extras or name one with '--workspace-config':\n  - {listed}"
+        )
+
+    return candidates[0].resolve()
+
+
+def _refuse_project_config_as_policy(
+    policy_path: Path, project_config_paths: Sequence[Path]
+) -> None:
+    """Refuse a policy file that is actually some project's config.
+
+    Compared by resolved path rather than by name, so a symlink to a project's
+    config, or a differently-spelled path to it, is caught as well.
+    """
+    from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
+
+    for project_config in project_config_paths:
+        try:
+            same = policy_path.resolve() == Path(project_config).resolve()
+        except OSError:  # pragma: no cover - unresolvable path
+            same = False
+        if same:
+            raise _refuse(
+                f"'{policy_path.as_posix()}' is a project's own ASH config, so it "
+                f"cannot also be the workspace policy file. A project config "
+                f"governs one project; workspace policy governs all of them, and "
+                f"reading one as the other would apply a single project's "
+                f"settings to its siblings. Put workspace policy in "
+                f"'{_POLICY_SUBDIR}/ash-workspace.yaml' instead."
+            )
+
+    # Also refuse by name. This catches the workspace root's own config even when
+    # the caller passed no project list -- the common CLI shape, since the root
+    # project's config path is not known to argument parsing.
+    if policy_path.name in ASH_CONFIG_FILE_NAMES:
+        raise _refuse(
+            f"'{policy_path.as_posix()}' is named like an ASH project config "
+            f"('{policy_path.name}'), so it cannot be the workspace policy file. "
+            f"Workspace policy must live in a distinct file -- "
+            f"'{_POLICY_SUBDIR}/ash-workspace.yaml', or any name passed to "
+            f"'--workspace-config' that is not a project config name."
+        )
+
+
+def resolve_workspace_policy(
+    root: PathLike,
+    *,
+    explicit: PathLike | None = None,
+    project_config_paths: Iterable[PathLike] = (),
+) -> tuple[AshWorkspaceConfig | None, Path | None]:
+    """Locate and load the workspace policy, if there is one.
+
+    Args:
+        root: The workspace root -- the directory holding the ``.code-workspace``
+            file. Policy is looked for here and in ``root/.ash``.
+        explicit: The value of ``--workspace-config``. When given, it is used
+            instead of discovery and must exist: silently falling back to
+            discovery would run with different policy than the operator named.
+        project_config_paths: Each project's own config file, where it has one.
+            Used to refuse a policy file that is one of them.
+
+    Returns:
+        ``(policy, source)``. Both are ``None`` when the workspace declares no
+        policy, which is not an error -- workspace policy is opt-in.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4. The named file is absent, the
+            workspace has two candidates, the file is unusable, or it is a
+            project's config. The message names the file in every case.
+    """
+    if explicit is not None:
+        policy_path = Path(explicit)
+        if not policy_path.exists():
+            raise _refuse(
+                f"workspace policy file '{policy_path.as_posix()}' does not "
+                f"exist. '--workspace-config' names the file to use; ASH does "
+                f"not fall back to searching, because that would apply different "
+                f"policy than the one asked for."
+            )
+    else:
+        discovered = discover_workspace_policy_file(root)
+        if discovered is None:
+            return None, None
+        policy_path = discovered
+
+    _refuse_project_config_as_policy(
+        policy_path, [Path(p) for p in project_config_paths]
+    )
+
+    return load_workspace_policy(policy_path), policy_path.resolve()
+
+
+def _push_down(
+    entries: Sequence[IgnorePathWithReason], project_prefix: PathLike
+) -> tuple[IgnorePathWithReason, ...]:
+    """Rewrite each entry's path into *project_prefix*'s coordinates.
+
+    Entries whose pattern cannot match inside the project are dropped -- they are
+    about a different project. Entries with no sound rewrite are refused, because
+    dropping one would leave a stated suppression unapplied and invisible.
+
+    Each surviving entry is a COPY, so the shared policy object is not mutated
+    as it is pushed into successive projects.
+    """
+    pushed: list[IgnorePathWithReason] = []
+    for entry in entries:
+        try:
+            rewritten = to_project_pattern(entry.path, project_prefix)
+        except WorkspacePatternError as exc:
+            raise _refuse(
+                f"workspace policy pattern '{entry.path}' cannot be applied to "
+                f"project '{Path(project_prefix).as_posix()}': {exc}"
+            ) from exc
+        if rewritten is None:
+            continue
+        # model_copy rather than reconstruction, so every field the model gains
+        # later is carried over without this call site needing to learn about it.
+        pushed.append(entry.model_copy(update={"path": rewritten}))
+    return tuple(pushed)
+
+
+def policy_for_project(
+    policy: WorkspacePolicyConfig | None,
+    *,
+    project_prefix: PathLike,
+    project_threshold: str | None,
+    project_scanners: Iterable[str],
+) -> ProjectPolicy:
+    """Apply workspace *policy* to one project.
+
+    Args:
+        policy: The workspace policy block, or ``None`` for no policy.
+        project_prefix: The project's workspace-relative path, e.g. ``api`` or
+            ``services/worker``. The coordinate system the patterns are rewritten
+            into.
+        project_threshold: The threshold the project's own config resolved to.
+            ``None`` or ``""`` means the project turned its gate off, which is
+            LOOSER than any ceiling and so is tightened by one.
+        project_scanners: The scanners the project already enables. Used to tell
+            a scanner the project owns from one this policy adds.
+
+    Returns:
+        The policy as it applies to this project.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, when a policy pattern has no sound
+            rewrite for this project.
+    """
+    if policy is None:
+        return ProjectPolicy(
+            effective_threshold=project_threshold,
+            threshold_tightened=False,
+            suppressions=(),
+            ignore_paths=(),
+            policy_scanners=(),
+            policy_scanners_gate=False,
+        )
+
+    ceiling = policy.max_severity_threshold
+    # Argument order is not arbitrary: stricter_of is commutative, so this is
+    # safe either way, but the ceiling is passed second to read as "the project
+    # asked for X, capped by Y".
+    effective = stricter_of(project_threshold, ceiling)
+
+    declared = {_normalise_scanner_name(name) for name in project_scanners}
+    policy_scanners = tuple(
+        name
+        for name in policy.additional_scanners
+        if _normalise_scanner_name(name) not in declared
+    )
+
+    return ProjectPolicy(
+        effective_threshold=effective,
+        threshold_tightened=effective != project_threshold,
+        suppressions=tuple(
+            # _push_down returns the base type; suppressions keep their own type
+            # because model_copy preserves the class it was called on.
+            entry  # type: ignore[misc]
+            for entry in _push_down(policy.suppressions, project_prefix)
+        ),
+        ignore_paths=_push_down(policy.ignore_paths, project_prefix),
+        policy_scanners=policy_scanners,
+        policy_scanners_gate=policy.policy_scanners_gate,
+    )

--- a/automated_security_helper/workspace/reporting.py
+++ b/automated_security_helper/workspace/reporting.py
@@ -1,0 +1,619 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Emit the workspace-level reports, and account for the ones deliberately not emitted.
+
+Why this module exists
+----------------------
+Phase 2a scanned N projects and wrote a unified ``ash_aggregated_results.json``,
+and stopped there. It emitted no workspace-level *report* at all, and the reason
+was one line in ``github_ghas_reporter``: ``run = sarif.runs[0]``. Against an
+N-run SARIF that emits the first project's findings and drops the rest -- no
+exception, no warning, a smaller file nobody can tell is incomplete. Shipping a
+workspace-level report step meant first making it impossible for a reporter to
+fail that way quietly.
+
+So each reporter declares a
+:class:`~automated_security_helper.base.reporter_plugin.ReporterWorkspaceBehaviour`
+and this module holds it to the declaration. It never asks a reporter to handle a
+shape the reporter has not said it handles, and it never lets a withheld artefact
+be merely absent -- every reporter, including the ones that deliberately produce
+nothing here, gets an entry in ``reports/workspace-reports.json`` saying what
+happened and where the alternative is.
+
+The manifest is the point, not a convenience
+-------------------------------------------
+An operator who ran a workspace scan and looks for ``reports/ash.cdx.json`` will
+not find one, because an SBOM for N independently versioned deliverables is N
+SBOMs. Without the manifest that absence is indistinguishable from a bug, from a
+disabled reporter, and from a reporter that crashed. With it, the answer is a
+machine-readable list of the N per-project files that replace it -- and a list of
+which of those actually exist on disk, because a per-project report is written by
+that project's own report phase and a project can be skipped or can fail.
+
+Why the whole model is loaded back, giving up Phase 2a's streaming bound
+----------------------------------------------------------------------
+``WorkspaceAggregator`` streams: it holds one project's SARIF at a time, so peak
+memory is bounded by ``max_parallel_projects`` rather than by project count. A
+merged reporter cannot work that way -- ``csv``, ``html`` and the rest need every
+finding at once, and there is no streaming reporter API to give them.
+
+So this reads the unified file back as one ``AshAggregatedResults``. Three things
+make that acceptable rather than a regression:
+
+* It happens after every scan has finished, so the *scanning* peak -- which is
+  the one that scales with concurrency -- is unchanged. The two peaks do not add.
+* The peak here is the size of a file the operator already has on disk and that
+  any consumer of it faces anyway.
+* Reading the written file rather than keeping a parallel in-memory model means
+  the workspace reports cannot disagree with the results file. An in-memory model
+  would have been cheaper and would have introduced a second source of truth.
+
+Reporter enablement comes from the default config, not from any project's
+------------------------------------------------------------------------
+There is no workspace-level config in this phase; it arrives in Phase 3. So which
+reporters run *here* is decided by ASH's default config plus ``--output-format``.
+
+The consequence is worth stating plainly: a project that disables ``html`` still
+gets a workspace-level ``html`` report. That is defensible -- the workspace
+artefact is a workspace-level concern, and a project's config governs its own
+``projects/<key>/reports/`` subtree, which is untouched by this module -- but it
+is a real limitation and not a design anyone would choose from scratch. The
+alternative considered was to withhold a merged artefact whenever any project
+disabled that reporter, which was rejected because it makes one project's config
+silently govern a workspace-level output, and because the operator has no way to
+express the override until Phase 3 gives them one.
+
+Failure modes and known limitations
+-----------------------------------
+* A reporter that raises is recorded in the manifest with its error and does not
+  stop the others. One broken reporter must not cost an operator every other
+  report. The failure does *not* fail the run: a reporter error is not a finding,
+  and ``execute_workspace``'s exit code is a verdict about code under scan.
+* An ``UNSUPPORTED`` reporter *does* fail the run, at
+  ``WorkspaceExitCode.INTERNAL_ERROR``, and only when the run would otherwise
+  have succeeded. It does not override exit 2 or 3, for the reason recorded in
+  ``models.workspace``: a finding is a certainty and must not be suppressed by
+  anything weaker. No reporter shipped here declares ``UNSUPPORTED``; the path is
+  built and tested so the enum member is a mechanism rather than a comment.
+* The per-project artefact paths in the manifest are derived from each reporter's
+  configured ``extension``, which is how ``ReportPhase`` derives the filename it
+  writes. A reporter that writes extra files under its own steam -- as
+  ``unused_suppressions`` does with its markdown companion -- is not fully
+  enumerated. Enumerating by globbing the directory instead was rejected: it
+  would attribute any stale file left by a previous run to a reporter that did
+  not write it.
+* Nothing here validates that a merged reporter's output is well-formed for its
+  format. That belongs to the reporter, and the per-reporter tests in
+  ``tests/unit/workspace/test_workspace_reporting.py`` assert content rather than
+  only existence.
+"""
+
+from __future__ import annotations
+
+import json
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from automated_security_helper.base.reporter_plugin import (
+    ReporterPluginBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.utils.log import ASH_LOGGER
+from automated_security_helper.workspace.plan import WorkspacePlan
+
+#: Where workspace-level reports land, mirroring the ``reports/`` directory a
+#: single-directory scan produces so existing tooling needs no new path.
+REPORTS_DIR_NAME = "reports"
+
+#: The account of what every reporter did. Named for what it is rather than
+#: ``manifest.json``, so it is obvious in a directory listing beside the reports.
+MANIFEST_FILENAME = "workspace-reports.json"
+
+#: The subtree holding each project's own complete output, as
+#: ``execution.PROJECTS_DIR_NAME`` writes it. Duplicated as a literal rather than
+#: imported, because importing ``execution`` here would make the dependency
+#: circular once ``execution`` calls this module.
+PROJECTS_DIR_NAME = "projects"
+
+#: Why a reporter was not considered at workspace level. Recorded distinctly
+#: rather than collapsed into one "skipped" flag, because each sends the operator
+#: somewhere different: to the config, to ``--output-format``, or to the
+#: reporter's own missing dependencies.
+SKIP_DISABLED = "disabled"
+SKIP_UNSATISFIED_DEPENDENCIES = "dependencies-unsatisfied"
+SKIP_NOT_REQUESTED = "not-in-requested-output-formats"
+SKIP_NOT_PYTHON_ONLY = "non-python-dependencies-excluded"
+
+#: Behaviours that produce a workspace-level artefact. ``WORKSPACE_SCOPED`` is in
+#: the set but is not a merge, which is why ``covers_projects`` is recorded
+#: separately in the manifest.
+_EMITTING_BEHAVIOURS = frozenset(
+    {
+        ReporterWorkspaceBehaviour.MERGED,
+        ReporterWorkspaceBehaviour.WORKSPACE_SCOPED,
+    }
+)
+
+
+@dataclass
+class WorkspaceReportOutcome:
+    """What the workspace-level report step produced, and what it refused to."""
+
+    manifest_path: Path
+    workspace_artifacts: Dict[str, Path] = field(default_factory=dict)
+    per_project_reporters: Tuple[str, ...] = ()
+    unsupported_reporters: Tuple[str, ...] = ()
+    failed_reporters: Dict[str, str] = field(default_factory=dict)
+
+    @property
+    def refused(self) -> bool:
+        """Whether any enabled reporter declared itself unusable at this level.
+
+        Separate from ``failed_reporters`` on purpose. A reporter that raised is
+        a bug in that reporter; a reporter that declared ``UNSUPPORTED`` is a
+        correct statement that the operator has asked for something the format
+        cannot express. The first is logged, the second changes the exit code.
+        """
+        return bool(self.unsupported_reporters)
+
+
+def _reporter_name(instance: ReporterPluginBase) -> str:
+    """The reporter's configured name, or its class name as a last resort.
+
+    The configured name is what an operator writes in ``--output-format`` and in
+    config, so it is what the manifest is keyed on. A reporter whose config
+    somehow carries no name still has to appear in the manifest -- being
+    unnameable is not a reason to go unrecorded.
+    """
+    name = getattr(getattr(instance, "config", None), "name", None)
+    return str(name) if name else instance.__class__.__name__
+
+
+def _report_filename(instance: ReporterPluginBase) -> str:
+    """The filename ``ReportPhase`` would give this reporter's output.
+
+    Mirrors ``ReportPhase._execute_phase`` exactly, including its ``ash.txt``
+    fallback for a reporter that declares no extension, so a workspace-level
+    report and a per-project one are never named differently for the same
+    reporter.
+    """
+    extension = getattr(getattr(instance, "config", None), "extension", None)
+    return f"ash.{extension}" if extension else "ash.txt"
+
+
+def _disabled_by_config(instance: ReporterPluginBase) -> bool:
+    """Whether the operator turned this reporter off. Cheap, and never touches IO."""
+    config = getattr(instance, "config", None)
+    return config is not None and getattr(config, "enabled", True) is False
+
+
+def _dependencies_unsatisfied(instance: ReporterPluginBase) -> bool:
+    """Whether the reporter's own dependency check refuses.
+
+    Separate from :func:`_disabled_by_config`, and reported as a different reason,
+    because the two send the operator somewhere different: the config, versus
+    credentials or an install. Conflating them told an operator with no AWS
+    credentials that they had disabled the reporter.
+
+    Also separate because this one performs IO. ``SecurityHubReporter`` and
+    ``BedrockSummaryReporter`` call AWS inside it, so it must not be on any path
+    that runs before a scan -- see :func:`unsupported_reporter_names`.
+    """
+    try:
+        return not instance.validate_plugin_dependencies()
+    except Exception as exc:  # noqa: BLE001 -- a broken check must not stop the step
+        ASH_LOGGER.warning(
+            f"Reporter {_reporter_name(instance)} raised while validating its "
+            f"dependencies and is treated as unavailable: {exc}"
+        )
+        return True
+
+
+def _matches_requested_formats(
+    instance: ReporterPluginBase, output_formats: Sequence[str]
+) -> bool:
+    """Whether ``--output-format`` selected this reporter.
+
+    An empty request means every reporter, matching ``ReportPhase``: an operator
+    who passed no ``--output-format`` asked for the default set, not for nothing.
+    """
+    if not output_formats:
+        return True
+    extension = getattr(getattr(instance, "config", None), "extension", None)
+    return extension in output_formats
+
+
+def _load_workspace_model(results_path: Path):
+    """The unified results, as the model reporters expect.
+
+    Validated through ``AshAggregatedResults`` rather than handed round as a dict
+    because every reporter is written against the model -- and because validation
+    is the check that the hand-assembled JSON the aggregator streams is actually
+    well formed. A malformed unified file surfaces here, before any reporter
+    reads half of it.
+    """
+    from automated_security_helper.models.asharp_model import AshAggregatedResults
+
+    return AshAggregatedResults.model_validate_json(
+        results_path.read_text(encoding="utf-8")
+    )
+
+
+def _per_project_artifacts(
+    plan: WorkspacePlan, output_dir: Path, filename: str
+) -> Tuple[List[Dict[str, str]], List[str]]:
+    """Where a per-project reporter's N artefacts are, and which are missing.
+
+    Every project in the plan is listed, including skipped ones, so that a
+    consumer reading the manifest sees the full set the operator asked for. The
+    missing list is what distinguishes "this project was skipped" from "the
+    manifest is pointing at nothing", which an operator would otherwise have to
+    resolve by checking the filesystem by hand.
+    """
+    entries: List[Dict[str, str]] = []
+    missing: List[str] = []
+    for project in plan.projects:
+        relative = (
+            Path(PROJECTS_DIR_NAME) / project.key / REPORTS_DIR_NAME / filename
+        ).as_posix()
+        entries.append({"project": project.key, "path": relative})
+        if not (output_dir / relative).is_file():
+            missing.append(project.key)
+    return entries, missing
+
+
+def _default_reporter_classes() -> List[type]:
+    """Every reporter class the plugin registry resolved.
+
+    ``execution.prewarm_plugin_registry`` has already resolved the ``reporter``
+    type before any project ran, so this reads a warm, complete registry rather
+    than triggering discovery here -- which under the old lazy behaviour would
+    have made the resolved set depend on when it was first asked for.
+    """
+    from automated_security_helper.plugins import ash_plugin_manager
+
+    return list(ash_plugin_manager.plugin_modules("reporter"))
+
+
+def _build_instance(
+    reporter_class: type, context, config_lookup
+) -> Optional[ReporterPluginBase]:
+    plugin_name = getattr(reporter_class, "__name__", "Unknown")
+    try:
+        return reporter_class(
+            context=context,
+            config=config_lookup(plugin_name.lower()),
+        )
+    except Exception as exc:  # noqa: BLE001 -- mirrors ReportPhase's tolerance
+        ASH_LOGGER.error(
+            f"Could not construct reporter {plugin_name} for workspace-level "
+            f"reporting: {exc}"
+        )
+        return None
+
+
+def _selected_reporters(
+    *,
+    context,
+    config_lookup,
+    output_formats: Sequence[str],
+    python_based_plugins_only: bool,
+    reporter_classes: Optional[Sequence[type]],
+    check_dependencies: bool = True,
+):
+    """Every constructible reporter, with its declared behaviour and skip reason.
+
+    Yields ``(instance, behaviour, skipped)``. ``skipped`` is ``None`` for a
+    reporter that will run, and otherwise one of the ``SKIP_*`` reasons -- yielded
+    rather than filtered out, because the manifest has to account for those too.
+    Filtering them here is what made six of the nineteen shipped reporters absent
+    from a real run's manifest with nothing to say why.
+
+    One place, because two callers need exactly the same selection and a
+    divergence between them would be invisible: :func:`unsupported_reporter_names`
+    refuses a run *before* any project is scanned, and
+    :func:`emit_workspace_reports` accounts for the same set *after*. If the
+    pre-flight checked a different set than the report step, a reporter could
+    pass the gate and then refuse -- at which point the results file on disk and
+    the process exit status would disagree about the same run, with no rule for
+    which one a consumer should believe.
+    """
+    classes = (
+        list(reporter_classes)
+        if reporter_classes is not None
+        else _default_reporter_classes()
+    )
+    for reporter_class in classes:
+        instance = _build_instance(reporter_class, context, config_lookup)
+        if instance is None:
+            continue
+        name = _reporter_name(instance)
+        behaviour = getattr(
+            reporter_class,
+            "workspace_behaviour",
+            ReporterWorkspaceBehaviour.PER_PROJECT,
+        )
+
+        # Each reason is reported distinctly rather than collapsed into "skipped",
+        # because they route the operator to different knobs: disabled means edit
+        # the config, not-requested means widen --output-format, and unavailable
+        # means the reporter's own dependencies are unsatisfied.
+        skipped: Optional[str] = None
+        if _disabled_by_config(instance):
+            skipped = SKIP_DISABLED
+        elif check_dependencies and _dependencies_unsatisfied(instance):
+            skipped = SKIP_UNSATISFIED_DEPENDENCIES
+        if skipped is None and python_based_plugins_only:
+            if not instance.is_python_only():
+                skipped = SKIP_NOT_PYTHON_ONLY
+        if skipped is None and not _matches_requested_formats(instance, output_formats):
+            skipped = SKIP_NOT_REQUESTED
+
+        if skipped is not None:
+            ASH_LOGGER.debug(
+                f"Reporter {name} not considered at workspace level: {skipped}"
+            )
+        yield instance, behaviour, skipped
+
+
+def _workspace_context(
+    workspace_root: str, output_dir: Path, ignore_suppressions: bool = False
+):
+    """The plugin context and config-lookup workspace-level reporters are built with.
+
+    The config is ASH's default, because no workspace-level config exists in this
+    phase. See "Reporter enablement" in the module docstring for what that means
+    and what was rejected.
+    """
+    from automated_security_helper.base.plugin_context import PluginContext
+    from automated_security_helper.config.ash_config import AshConfig
+
+    config = AshConfig()
+    context = PluginContext(
+        source_dir=Path(workspace_root),
+        output_dir=Path(output_dir),
+        config=config,
+        ignore_suppressions=ignore_suppressions,
+    )
+
+    def config_lookup(plugin_name: str):
+        try:
+            return config.get_plugin_config(
+                plugin_type="reporter", plugin_name=plugin_name
+            )
+        except Exception:  # noqa: BLE001 -- an unknown reporter takes its default
+            return None
+
+    return context, config_lookup
+
+
+def unsupported_reporter_names(
+    plan: WorkspacePlan,
+    output_dir: Path,
+    *,
+    output_formats: Sequence[str] = (),
+    python_based_plugins_only: bool = False,
+    reporter_classes: Optional[Sequence[type]] = None,
+) -> Tuple[str, ...]:
+    """Enabled reporters that declare they cannot work in workspace mode.
+
+    Answered from declarations and config alone -- no model, no results file, no
+    scan, and deliberately no dependency validation.
+
+    That last exclusion is not an optimisation. ``SecurityHubReporter`` and
+    ``BedrockSummaryReporter`` call AWS inside
+    ``validate_plugin_dependencies``, so validating here would put live API calls
+    on the path *before every workspace scan* -- latency and log noise on a run
+    they cannot affect, since a reporter whose dependencies are unsatisfied is
+    already skipped by :func:`emit_workspace_reports`. It also means the two
+    answers differ in one narrow case, on purpose: a reporter that is enabled,
+    declares ``UNSUPPORTED``, and has unsatisfied dependencies refuses the run
+    here rather than being quietly skipped later. That is the right direction --
+    the operator's configuration asks for something the format cannot do, and
+    telling them so does not depend on whether an unrelated credential happens to
+    be present.
+
+    Why a pre-flight at all:
+
+    An operator who has enabled a reporter that cannot produce a correct artefact
+    for a workspace should be told before ASH spends the scan, not after. Failing
+    at the end would also put the results file and the process exit status in
+    conflict, because ``WorkspaceAggregator.write`` records the exit code *into*
+    the file: a reporting refusal discovered afterwards could only be surfaced by
+    exiting with a status the file does not contain. Refusing up front means
+    nothing is scanned and nothing is written, so the two cannot disagree -- the
+    same argument ``models.workspace`` makes for keeping exit 4 distinct from
+    exit 2.
+
+    Returns:
+        The configured names, in registry order. Empty is the normal case: no
+        reporter shipped in this repository declares ``UNSUPPORTED``.
+    """
+    context, config_lookup = _workspace_context(plan.workspace_root, Path(output_dir))
+    return tuple(
+        _reporter_name(instance)
+        for instance, behaviour, skipped in _selected_reporters(
+            context=context,
+            config_lookup=config_lookup,
+            output_formats=output_formats,
+            python_based_plugins_only=python_based_plugins_only,
+            reporter_classes=reporter_classes,
+            check_dependencies=False,
+        )
+        # ``skipped is None`` is what makes disabling the documented way out
+        # actually work: a reporter the operator turned off must not refuse a run
+        # it is not part of.
+        if skipped is None and behaviour is ReporterWorkspaceBehaviour.UNSUPPORTED
+    )
+
+
+def emit_workspace_reports(
+    plan: WorkspacePlan,
+    output_dir: Path,
+    results_path: Path,
+    *,
+    output_formats: Sequence[str] = (),
+    python_based_plugins_only: bool = False,
+    ignore_suppressions: bool = False,
+    reporter_classes: Optional[Sequence[type]] = None,
+) -> WorkspaceReportOutcome:
+    """Run the workspace-level report step and write the manifest.
+
+    Args:
+        plan: The resolved workspace plan. Supplies the project list the manifest
+            enumerates, and the workspace root the reporters are rooted at.
+        output_dir: The workspace output directory -- the parent of both
+            ``reports/`` and ``projects/``.
+        results_path: The unified ``ash_aggregated_results.json`` the aggregator
+            wrote. Read back rather than passed as a model; see the module
+            docstring.
+        output_formats: Extensions the operator asked for. Empty means all.
+        python_based_plugins_only: Excludes reporters with non-Python
+            dependencies, matching ``--python-based-plugins-only``.
+        ignore_suppressions: Threaded onto the plugin context so a reporter that
+            reads it sees the same value the projects' scans did.
+        reporter_classes: Injected only by tests. Production callers take the
+            registry, which ``prewarm_plugin_registry`` has already resolved.
+
+    Returns:
+        What was written, what was withheld, and what refused. The caller folds
+        ``refused`` into the exit code; nothing here calls ``sys.exit``.
+    """
+    output_dir = Path(output_dir)
+    reports_dir = output_dir / REPORTS_DIR_NAME
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    context, config_lookup = _workspace_context(
+        plan.workspace_root, output_dir, ignore_suppressions
+    )
+
+    manifest_reporters: Dict[str, Dict[str, Any]] = {}
+    artifacts: Dict[str, Path] = {}
+    per_project: List[str] = []
+    unsupported: List[str] = []
+    failures: Dict[str, str] = {}
+
+    # Loaded lazily, so a workspace whose every reporter is per-project never
+    # pays the cost of materialising the whole model.
+    model = None
+
+    for instance, behaviour, skipped in _selected_reporters(
+        context=context,
+        config_lookup=config_lookup,
+        output_formats=output_formats,
+        python_based_plugins_only=python_based_plugins_only,
+        reporter_classes=reporter_classes,
+    ):
+        name = _reporter_name(instance)
+        filename = _report_filename(instance)
+        entry: Dict[str, Any] = {
+            "behaviour": behaviour.value,
+            "considered": skipped is None,
+            "covers_projects": behaviour is ReporterWorkspaceBehaviour.MERGED,
+            "workspace_artifact": None,
+            "per_project_artifacts": [],
+            "missing_per_project_artifacts": [],
+        }
+        manifest_reporters[name] = entry
+
+        if skipped is not None:
+            # Recorded rather than omitted. Six of the nineteen shipped reporters
+            # land here on a default run -- yaml and spdx ship disabled, and the
+            # four AWS ones report unsatisfied dependencies without credentials --
+            # and an operator asking where their yaml report went deserves an
+            # answer rather than silence. Silence is the defect this manifest
+            # exists to prevent; only the reason differs from a withheld artefact.
+            entry["skipped"] = skipped
+            entry["covers_projects"] = False
+            continue
+
+        if behaviour is ReporterWorkspaceBehaviour.UNSUPPORTED:
+            unsupported.append(name)
+            entry["error"] = (
+                "the reporter declares that it cannot produce a correct artefact "
+                "in workspace mode; disable it or scan the projects separately"
+            )
+            ASH_LOGGER.error(
+                f"Reporter {name} declares itself unsupported in workspace mode. "
+                f"No report was produced for it, and the workspace run will not "
+                f"report success. Disable it, or scan the projects separately."
+            )
+            continue
+
+        if behaviour is ReporterWorkspaceBehaviour.PER_PROJECT:
+            per_project.append(name)
+            entries, missing = _per_project_artifacts(plan, output_dir, filename)
+            entry["per_project_artifacts"] = entries
+            entry["missing_per_project_artifacts"] = missing
+            ASH_LOGGER.verbose(
+                f"Reporter {name} is per-project in workspace mode; "
+                f"{len(entries) - len(missing)} of {len(entries)} per-project "
+                f"artefact(s) present. No merged artefact is produced."
+            )
+            if missing:
+                ASH_LOGGER.warning(
+                    f"Reporter {name} has no artefact for project(s) "
+                    f"{', '.join(missing)}. Those projects were skipped, failed, "
+                    f"or had the reporter disabled."
+                )
+            continue
+
+        if behaviour not in _EMITTING_BEHAVIOURS:  # pragma: no cover - defensive
+            # Unreachable while the enum has four members and the three above are
+            # handled. Kept so that adding a fifth fails loudly here rather than
+            # silently producing nothing.
+            failures[name] = f"unhandled workspace behaviour {behaviour!r}"
+            entry["error"] = failures[name]
+            ASH_LOGGER.error(f"Reporter {name}: {failures[name]}")
+            continue
+
+        if model is None:
+            model = _load_workspace_model(Path(results_path))
+
+        try:
+            content = instance.report(model)
+        except Exception as exc:  # noqa: BLE001 -- one reporter must not sink the rest
+            failures[name] = f"{type(exc).__name__}: {exc}"
+            entry["error"] = failures[name]
+            ASH_LOGGER.error(f"Reporter {name} failed at workspace level: {exc}")
+            ASH_LOGGER.debug(f"Reporter traceback: {traceback.format_exc()}")
+            continue
+
+        if not content:
+            # Not an error: several reporters legitimately return nothing when
+            # they have nothing to say. Recorded so that "returned nothing" is
+            # distinguishable from "was never run".
+            entry["error"] = "the reporter returned no content"
+            ASH_LOGGER.verbose(f"Reporter {name} returned no content")
+            continue
+
+        target = reports_dir / filename
+        target.write_text(content, encoding="utf-8")
+        artifacts[name] = target
+        entry["workspace_artifact"] = target.relative_to(output_dir).as_posix()
+        ASH_LOGGER.info(f"Writing workspace {name} report to {target}")
+
+    manifest_path = reports_dir / MANIFEST_FILENAME
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "workspace_file": plan.workspace_file,
+                "workspace_root": plan.workspace_root,
+                "projects": [project.key for project in plan.projects],
+                "reporters": manifest_reporters,
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    return WorkspaceReportOutcome(
+        manifest_path=manifest_path,
+        workspace_artifacts=artifacts,
+        per_project_reporters=tuple(per_project),
+        unsupported_reporters=tuple(unsupported),
+        failed_reporters=failures,
+    )

--- a/automated_security_helper/workspace/resolver.py
+++ b/automated_security_helper/workspace/resolver.py
@@ -140,6 +140,10 @@ from automated_security_helper.core.exceptions import (
 from automated_security_helper.models.workspace import SkippedProjectReason
 from automated_security_helper.utils.path_containment import validate_contained_path
 from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.policy import (
+    policy_for_project,
+    resolve_workspace_policy,
+)
 from automated_security_helper.workspace.scanner_pins import PinVerdict, compare_pins
 from automated_security_helper.workspace.workspace_file import (
     WorkspaceDefinition,
@@ -599,10 +603,67 @@ def _assign_display_labels(projects: List[ProjectPlan]) -> None:
         )
 
 
+def _apply_workspace_policy(
+    definition: WorkspaceDefinition,
+    projects: List[ProjectPlan],
+    workspace_config: Optional[PathLike],
+) -> Optional[Path]:
+    """Resolve the workspace policy and fold it into every active project.
+
+    Runs AFTER the per-project configs are resolved, because the ceiling needs
+    each project's own threshold to combine with and the scanner classification
+    needs each project's scanner set. It runs after ``_validate_scanner_pins``
+    and ``_validate_plugin_modules`` too: a workspace that cannot be scanned at
+    all should say so rather than first complaining about a policy pattern.
+
+    Skipped projects are left alone. Applying a ceiling to a project that will
+    not be scanned would put a threshold in the plan for work that never
+    happens, and pushing a pattern into it could refuse the whole workspace over
+    a project nobody is looking at.
+
+    Returns:
+        The policy file that was applied, or ``None`` when there is no policy.
+
+    Raises:
+        WorkspaceDefinitionError: Exit code 4, for an unusable policy file or a
+            pattern with no sound rewrite for some project. The message names the
+            project as well as the pattern, because a workspace-level pattern is
+            legal in itself and only fails in combination with one project.
+    """
+    policy, source = resolve_workspace_policy(
+        definition.root,
+        explicit=workspace_config,
+        project_config_paths=[
+            Path(project.config_source)
+            for project in projects
+            if project.config_source
+        ],
+    )
+
+    for project in projects:
+        if project.skipped:
+            continue
+        resolved = policy_for_project(
+            policy.workspace if policy else None,
+            project_prefix=project.relative_path,
+            project_threshold=project.severity_threshold,
+            project_scanners=project.scanners,
+        )
+        project.effective_severity_threshold = resolved.effective_threshold
+        project.threshold_tightened_by_policy = resolved.threshold_tightened
+        project.policy_suppressions = list(resolved.suppressions)
+        project.policy_ignore_paths = list(resolved.ignore_paths)
+        project.policy_scanners = list(resolved.policy_scanners)
+        project.policy_scanners_gate = resolved.policy_scanners_gate
+
+    return source
+
+
 def resolve_workspace(
     workspace_file: PathLike,
     *,
     allow_missing_projects: bool = False,
+    workspace_config: Optional[PathLike] = None,
 ) -> WorkspacePlan:
     """Resolve and validate a workspace, returning an inspectable plan.
 
@@ -615,6 +676,11 @@ def resolve_workspace(
             absent or unreadable. Those projects are marked skipped and recorded
             in the plan's ``skipped_projects`` payload. Does not opt out of any
             other check -- see "Fail-closed" in the module docstring.
+        workspace_config: ``--workspace-config``: the workspace policy file to
+            apply. When omitted the workspace root is searched for one, and
+            having none is not an error. When given it must exist; ASH does not
+            fall back to searching, because that would apply different policy
+            than the one named. It may not be any project's own config.
 
     Returns:
         A :class:`~automated_security_helper.workspace.plan.WorkspacePlan` with
@@ -684,10 +750,14 @@ def resolve_workspace(
     _validate_scanner_pins(definition, active)
     _validate_plugin_modules(definition, active)
     _assign_display_labels(projects)
+    policy_source = _apply_workspace_policy(definition, projects, workspace_config)
 
     return WorkspacePlan(
         workspace_file=definition.path.as_posix(),
         workspace_root=definition.root.as_posix(),
+        workspace_config_source=(
+            policy_source.as_posix() if policy_source is not None else None
+        ),
         projects=projects,
         allow_missing_projects=allow_missing_projects,
     )

--- a/docs/content/docs/cli-reference.md
+++ b/docs/content/docs/cli-reference.md
@@ -116,6 +116,7 @@ ash [options]
 | `--phases`                    | Phases to run: `convert`, `scan`, `report`, `inspect`   | `convert,scan,report` |                         |
 | `--inspect`                   | Enable inspection of SARIF fields                       | `False`               |                         |
 | `--workspace`                 | Path to a `.code-workspace` file, or `auto` to find the one in the current directory. Mutually exclusive with `--source-dir` | None | `ASH_WORKSPACE` |
+| `--workspace-config`          | Path to the workspace policy file. Defaults to `ash-workspace.{yaml,yml,json}` in the workspace root or its `.ash` directory | None | `ASH_WORKSPACE_CONFIG` |
 | `--allow-missing-projects`    | Skip workspace projects that are absent or unreadable   | `False`               |                         |
 | `--dry-run`                   | Print the resolved workspace plan and exit without scanning | `False`           |                         |
 
@@ -138,6 +139,47 @@ Folder paths are relative to the directory holding the workspace file, which bec
 
 `--dry-run` resolves and validates the workspace, prints the resulting plan, and exits 0 without scanning anything. Without it, the same plan is what gets scanned — resolved once, so what you inspect is what runs.
 
+#### Workspace policy
+
+Each project is judged against its own configuration, so there is nowhere in a project's config to say something about the workspace as a whole. That goes in a workspace policy file, which ASH looks for at `ash-workspace.yaml` (or `.yml`/`.json`) in the workspace root or its `.ash` directory. Having none is not an error.
+
+```yaml
+workspace:
+  # The LOOSEST threshold any project may use. A stricter project keeps its own.
+  max_severity_threshold: MEDIUM
+  # Paths are workspace-relative and are rewritten per project.
+  suppressions:
+    - path: services/api/src/legacy.py
+      rule_id: B101
+      reason: tracked in TICKET-1
+  ignore_paths:
+    - path: '**/vendor'
+      reason: third-party code
+  # Additive: a project cannot be made to run fewer scanners than it enables.
+  additional_scanners:
+    - bandit
+  # Whether findings from scanners added above affect a project's exit code.
+  policy_scanners_gate: false
+```
+
+The policy file must be a **different file** from any project's ASH config. When the workspace root is itself a project, `.ash/ash.yaml` there is that project's config and keeps meaning exactly that; policy goes in `.ash/ash-workspace.yaml`, or in any file named with `--workspace-config`. Pointing `--workspace-config` at a project's config exits 4 and names the file, because workspace policy governs every project and reading one project's config as policy would apply its settings to its siblings.
+
+`max_severity_threshold` is a ceiling on permissiveness, not on severity. The strictness order is `ALL` (strictest) through `CRITICAL` (loosest), so *raising* this value loosens it. A project's effective threshold is whichever of its own setting and this ceiling is stricter: a project at `CRITICAL` under a `MEDIUM` ceiling is judged at `MEDIUM`, while a project already at `LOW` is left alone. `--dry-run` prints both values for any project the ceiling moved, so you can see what it changed before running a scan.
+
+One limitation is worth knowing before relying on the ceiling. It tightens findings that carry a severity. A finding that carries only a SARIF `error` level is treated as critical and stays actionable at every threshold, so no ceiling excludes it — this is not specific to workspace mode, and `severity_threshold` behaves the same way in a single-project scan. In practice it means the ceiling cannot quieten checkov, which reports no per-finding severity.
+
+Rather than leave that as a caveat to remember, ASH measures it. When the ceiling tightens a project and some of that project's findings were beyond the tightening's reach, the project's entry in `ash_aggregated_results.json` carries `ceiling_unreachable_findings` — a count per scanner:
+
+```json
+"ceiling_unreachable_findings": { "checkov": 7 }
+```
+
+Read it as a statement about those findings, not about the scanner: seven findings in this project carry no severity, so the ceiling did not change their verdict. It is recomputed on every scan from the findings actually present, so it disappears if a scanner starts reporting severity, and it is absent entirely when the ceiling either did not tighten the project or reached everything it needed to.
+
+Suppressions and ignore paths are written workspace-relative and pushed down into each project's own coordinates. A pattern that cannot match inside a project is not applied there, so `services/api/src/legacy.py` silences nothing in `shared-infra`. A pattern with no exact per-project equivalent is refused with exit 4 rather than approximated, because a suppression that matches more than intended hides findings and leaves nothing in the output to show what went missing. `**/vendor` works; `**/vendor/**` is refused, and the error names the pattern and the project.
+
+Scanners in `additional_scanners` that a project already enables run under that project's own configuration and their findings are the project's. Scanners only the policy adds run with default configuration, are reported separately as `origin: workspace-policy`, and do not affect the project's exit code unless `policy_scanners_gate: true`.
+
 #### What each project gets
 
 Each project is scanned in its own scope: its own directory as the scan root, its own configuration, its own suppressions, and its own severity threshold. A project's findings and its pass/fail verdict are the same as `ash --source-dir <that project>` would produce. A suppression written in one project's config does not apply to another, even for the same rule at the same relative path.
@@ -147,14 +189,38 @@ Output is laid out per project, with a workspace-level roll-up beside it:
 ```
 .ash/ash_output/
   ash_aggregated_results.json      # unified, with per-project attribution
+  reports/
+    workspace-reports.json         # what every reporter did, and where
+    ash.<ext>                       # workspace-level reports (see below)
   projects/<project-key>/
     ash_aggregated_results.json    # this project alone
+    reports/ash.<ext>              # this project's own reports
     scanners/<scanner>/<target>/   # raw scanner output
 ```
 
 The unified `ash_aggregated_results.json` carries a `workspace` block: one entry per project with its threshold, finding counts, verdict and `sarif_run_index`, plus the `skipped_projects` payload.
 
 Its SARIF holds one `run` per project. Each run declares its own project root under `originalUriBaseIds`, and result paths inside a run stay relative to that root — so a consumer that ingests SARIF against a single repository root, such as GitHub code scanning, still resolves every path correctly. Selecting one run gives you a valid single-root SARIF document for one project. Each result also carries `properties.workspace_project` and `properties.workspace_uri`, the workspace-relative path, for consumers that want one flat coordinate space.
+
+#### Which reports are written where
+
+Not every format can be merged across projects, so each reporter declares what it does with a multi-project scan. Three answers:
+
+| Behaviour | Reporters | What you get |
+| --- | --- | --- |
+| Merged | `sarif`, `html`, `markdown`, `text`, `csv`, `flat-json`, `yaml`, `junitxml`, `ocsf` | One workspace-level artefact under `reports/`, carrying the project on every finding |
+| Per project | `github-ghas`, `gitlab-sast`, `cyclonedx`, `gitlab-cyclonedx`, `spdx`, and the AWS reporters | No workspace-level artefact. The files under `projects/<key>/reports/` are the answer |
+| Workspace-scoped | `unused-suppressions` | A workspace-level artefact covering workspace-level state only, not a merge of the projects |
+
+Where the project appears depends on the format: a `workspace_project` column in `csv`, a field of the same name in `flat-json`, a per-project section in `html`, `markdown` and `text`, a `<project>/<scanner>` testsuite name in `junitxml`, and a `workspace_project:<key>` entry in `metadata.labels` for `ocsf`. Single-directory output is unchanged in every case.
+
+A reporter is per project when merging would be wrong rather than merely unimplemented. `github-ghas` and `gitlab-sast` produce documents their consumers resolve against a single repository root, so a merged one would mis-locate findings. The three SBOM formats describe one deliverable each, and a workspace of independently versioned projects is N SBOMs. The AWS reporters publish side effects, which a second invocation would duplicate.
+
+`reports/workspace-reports.json` accounts for all of them, including the ones that deliberately produced nothing: what each reporter's behaviour is, the path of its workspace-level artefact or `null`, the per-project paths that replace it, which of those are missing, and why a reporter was not considered at all — `disabled`, `not-in-requested-output-formats`, or unsatisfied dependencies. A missing report is never silent.
+
+Reporter enablement at the workspace level comes from ASH's default configuration plus `--output-format`, not from any single project's config, because there is no workspace-level configuration yet. So a project that disables `html` still contributes to the workspace-level `html` report; its own `projects/<key>/reports/` respects its config as usual.
+
+If a reporter declares that it cannot produce a correct workspace-level artefact at all, the scan is refused before anything is scanned, with exit code `4` naming the reporter. No reporter shipped with ASH is in that state. Disable it or narrow `--output-format` to proceed.
 
 #### Changed files and precommit
 

--- a/scripts/verify_workspace_policy.py
+++ b/scripts/verify_workspace_policy.py
@@ -1,0 +1,461 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove workspace policy on a real scan, not on mocks.
+
+Why this script exists
+----------------------
+The unit suite drives ``policy_for_project`` and ``resolve_workspace`` directly,
+and ``tests/unit/workspace/test_execution.py`` drives the executor against a fake
+orchestrator. None of that runs a scanner. So none of it can catch the failure
+this feature is most exposed to: policy that resolves correctly, appears in the
+plan, and then changes no verdict because the value never reaches the code that
+counts actionable findings. That defect passes every mock-based test.
+
+This runs ``ash --workspace`` for real, twice over the same fixture -- once with
+no policy and once with a ceiling -- and compares the two verdicts. Only a real
+scan can show the ceiling moved a real finding count.
+
+What it asserts, and why each one is here
+-----------------------------------------
+1. **A project looser than the ceiling is tightened.** The lax project passes on
+   its own and fails under the ceiling, over an identical finding set. This is
+   the assertion that fails if the ceiling is decorative.
+2. **A stricter project is untouched.** Its actionable count is the same in both
+   runs. Without this, "the ceiling replaced every threshold" would pass (1).
+3. **The ceiling's reach is disclosed where it fell short.** The iac project's
+   checkov findings carry no severity, so they are judged from the SARIF level
+   and stay actionable at every threshold; the ceiling cannot reach them and
+   ``ceiling_unreachable_findings`` says so per scanner. The baseline run must
+   disclose nothing, and so must the project the ceiling did reach -- a
+   disclosure that appears unconditionally is noise and gets ignored.
+4. **A workspace suppression is pushed into one project and not another.**
+   Checked on the resolved plan, because the suppression list is per project
+   there; see the limitation below for why it is not yet checked on findings.
+5. **An unrewritable pattern refuses with exit 4** and names the pattern, as
+   does a project config passed as the policy file.
+
+Two positive controls
+---------------------
+Assertion 1 is only meaningful if the lax project HAS findings that sit between
+the two thresholds. A fixture that produced no findings at all would satisfy
+"passes without the ceiling" trivially and then fail (1) for the wrong reason, or
+worse, satisfy both arms vacuously. So the script first asserts the baseline run
+found a non-zero number of findings in the lax project and that its actionable
+count is zero; if either is untrue it reports the fixture as broken rather than
+reporting a policy result.
+
+Assertion 3 has the same hazard from the other direction: with no checkov
+findings, "the ceiling could not reach them" and "there was nothing to reach"
+are indistinguishable. So the disclosure checks are skipped with a printed note
+when checkov reports nothing, rather than passing on an empty set.
+
+Known limitations
+-----------------
+* Assertion 4 stops at the plan. ``workspace.suppressions`` do not yet reach the
+  scanners -- see "Where policy enters" in ``workspace/execution.py`` for the
+  orchestrator constraint -- so a findings-level check would fail for a reason
+  that is not about the push-down.
+* ``additional_scanners`` is not exercised end to end for the same reason.
+* Two scanners are used, and which one is deliberate. bandit is the ASH-shipped
+  scanner that emits ``properties.issue_severity``, so it measures the ceiling
+  working; checkov emits none, so it measures the ceiling's limit. Building every
+  assertion on one of them would measure only half the behaviour.
+* Findings come from real bandit and checkov rules, so a release of either can
+  change the counts. The script asserts relationships between the two runs, and
+  the presence rather than the size of the disclosure, so a version bump changes
+  what is scanned but not whether the assertions hold.
+* checkov must be installed for assertion 3 to run. It is skipped with a note
+  rather than failed when checkov reports nothing, so an environment without it
+  does not produce a false failure -- but it also does not produce a false pass.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess  # nosec B404 - runs ash itself, argv-only, no shell
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# A finding bandit rates MEDIUM severity, so it is actionable at MEDIUM and below
+# but not at HIGH or CRITICAL. That gap is what the ceiling is measured against.
+# Kept free of anything credential-shaped: ASH self-scans this repository and
+# detect-secrets matches line by line.
+LAX_SOURCE = """\
+import subprocess
+
+
+def run(target):
+    # B602: shell=True with a non-literal argument. Bandit rates this MEDIUM.
+    return subprocess.call("echo " + target, shell=True)
+"""
+
+STRICT_SOURCE = """\
+import subprocess
+
+
+def run(target):
+    return subprocess.call("echo " + target, shell=True)
+"""
+
+# Terraform checkov flags, used to exercise the level-only case. checkov emits no
+# properties.issue_severity, so these findings are judged from the SARIF level,
+# where `error` is read as critical and stays actionable at every threshold. That
+# is what the ceiling cannot reach, and what the disclosure has to report.
+IAC_SOURCE = """\
+resource "aws_s3_bucket" "example" {
+  bucket = "policy-verification-fixture"
+}
+"""
+
+
+def _write(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+_ALL_SCANNERS = [
+    "bandit",
+    "cdk-nag",
+    "cfn-nag",
+    "checkov",
+    "detect-secrets",
+    "grype",
+    "npm-audit",
+    "opengrep",
+    "semgrep",
+    "syft",
+]
+
+
+def _project_config(threshold: str, keep: str = "bandit") -> str:
+    """A project config at *threshold* running only the *keep* scanner.
+
+    Everything else is disabled to keep the run short and the finding set
+    attributable to one tool -- which also makes the per-scanner disclosure
+    unambiguous.
+    """
+    lines = [
+        "global_settings:",
+        f"  severity_threshold: {threshold}",
+        "scanners:",
+    ]
+    for name in _ALL_SCANNERS:
+        lines.append(f"  {name}:")
+        lines.append(f"    enabled: {'true' if name == keep else 'false'}")
+    return "\n".join(lines) + "\n"
+
+
+def build_fixture(root: Path) -> Path:
+    """Create the three-project workspace the assertions are written against.
+
+    lax at CRITICAL with a severity-carrying bandit finding -- the ceiling reaches
+    it. strict at LOW -- the ceiling must not loosen it. iac at CRITICAL with
+    level-only checkov findings -- the ceiling cannot reach those, which is what
+    the disclosure has to report.
+    """
+    _write(root / "lax" / "src" / "runner.py", LAX_SOURCE)
+    _write(root / "lax" / ".ash" / "ash.yaml", _project_config("CRITICAL"))
+
+    _write(root / "strict" / "src" / "runner.py", STRICT_SOURCE)
+    _write(root / "strict" / ".ash" / "ash.yaml", _project_config("LOW"))
+
+    _write(root / "iac" / "main.tf", IAC_SOURCE)
+    _write(
+        root / "iac" / ".ash" / "ash.yaml",
+        _project_config("CRITICAL", keep="checkov"),
+    )
+
+    workspace = root / "fixture.code-workspace"
+    workspace.write_text(
+        json.dumps({"folders": [{"path": "lax"}, {"path": "strict"}, {"path": "iac"}]}),
+        encoding="utf-8",
+    )
+    return workspace
+
+
+def run_ash(
+    workspace: Path,
+    output_dir: Path,
+    policy: Path | None = None,
+) -> tuple[int, dict[str, Any], str]:
+    """Run a real workspace scan; return (exit code, workspace payload, output)."""
+    argv = [
+        sys.executable,
+        "-m",
+        # cli.main, not cli: the package has no __main__ and cannot be run.
+        "automated_security_helper.cli.main",
+        "scan",
+        "--workspace",
+        str(workspace),
+        "--output-dir",
+        str(output_dir),
+        "--phases",
+        "scan",
+        "--no-progress",
+        "--simple",
+    ]
+    if policy is not None:
+        argv += ["--workspace-config", str(policy)]
+
+    # cwd is the repository root and is passed to the child rather than set with
+    # os.chdir, matching verify_multi_project_attribution.py: this project
+    # deliberately removed process-wide cwd dependence.
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    env.setdefault("PYTHONUTF8", "1")
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parent.parent)
+
+    completed = subprocess.run(  # nosec B603 - argv list, no shell, argv[0] is sys.executable
+        argv,
+        capture_output=True,
+        text=True,
+        cwd=str(Path(__file__).resolve().parent.parent),
+        env=env,
+        # Explicitly not check=True. A non-zero exit is the expected result for
+        # most runs here: 2 when a project has actionable findings, 4 when the
+        # policy is deliberately malformed. Raising on it would turn the
+        # measurement into a crash.
+        check=False,
+    )
+    combined = completed.stdout + completed.stderr
+
+    results = output_dir / "ash_aggregated_results.json"
+    payload: dict[str, Any] = {}
+    if results.exists():
+        payload = json.loads(results.read_text(encoding="utf-8")).get("workspace", {})
+    return completed.returncode, payload, combined
+
+
+def _by_project(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {entry["project"]: entry for entry in payload.get("projects", [])}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="keep the scratch directory for inspection",
+    )
+    args = parser.parse_args()
+
+    scratch = Path(tempfile.mkdtemp(prefix="ash-policy-verify-"))
+    failures = []
+    checks = 0
+
+    def check(label: str, ok: bool, detail: str = "") -> None:
+        nonlocal checks
+        checks += 1
+        print(f"{'PASS' if ok else 'FAIL'}  {label}")
+        if detail:
+            print(f"        {detail}")
+        if not ok:
+            failures.append(label)
+
+    try:
+        workspace = build_fixture(scratch)
+
+        # ---- Run A: no policy -------------------------------------------------
+        code_a, payload_a, out_a = run_ash(workspace, scratch / "out-a")
+        projects_a = _by_project(payload_a)
+
+        if not projects_a:
+            print("FIXTURE BROKEN: run A produced no workspace payload")
+            print(out_a[-3000:])
+            return 3
+
+        lax_a = projects_a.get("lax", {})
+        strict_a = projects_a.get("strict", {})
+
+        # Positive control. Without findings in the gap between CRITICAL and
+        # MEDIUM, assertion 1 below would be vacuous.
+        check(
+            "fixture control: lax project reports findings",
+            lax_a.get("finding_count", 0) > 0,
+            f"finding_count={lax_a.get('finding_count')}",
+        )
+        check(
+            "fixture control: lax passes at its own CRITICAL threshold",
+            lax_a.get("actionable_finding_count") == 0,
+            f"actionable={lax_a.get('actionable_finding_count')}",
+        )
+        check(
+            "fixture control: strict fails at its own LOW threshold",
+            (strict_a.get("actionable_finding_count") or 0) > 0,
+            f"actionable={strict_a.get('actionable_finding_count')}",
+        )
+
+        # ---- Run B: MEDIUM ceiling -------------------------------------------
+        policy = _write(
+            scratch / ".ash" / "ash-workspace.yaml",
+            "workspace:\n"
+            "  max_severity_threshold: MEDIUM\n"
+            "  suppressions:\n"
+            "    - path: lax/src/runner.py\n"
+            "      reason: verification fixture\n",
+        )
+        code_b, payload_b, out_b = run_ash(workspace, scratch / "out-b", policy=policy)
+        projects_b = _by_project(payload_b)
+
+        if not projects_b:
+            print("FIXTURE BROKEN: run B produced no workspace payload")
+            print(out_b[-3000:])
+            return 3
+
+        lax_b = projects_b.get("lax", {})
+        strict_b = projects_b.get("strict", {})
+
+        # 1. The ceiling tightened the lax project.
+        check(
+            "ceiling tightens a lax project: actionable rises above zero",
+            (lax_b.get("actionable_finding_count") or 0) > 0,
+            f"without policy={lax_a.get('actionable_finding_count')}, "
+            f"with MEDIUM ceiling={lax_b.get('actionable_finding_count')}",
+        )
+        check(
+            "ceiling tightens a lax project: verdict flips to failing",
+            lax_a.get("exceeds_threshold") is False
+            and lax_b.get("exceeds_threshold") is True,
+            f"exceeds_threshold {lax_a.get('exceeds_threshold')} -> "
+            f"{lax_b.get('exceeds_threshold')}",
+        )
+        check(
+            "the enforced threshold is reported, not the declared one",
+            lax_b.get("severity_threshold") == "MEDIUM",
+            f"reported={lax_b.get('severity_threshold')} (declared CRITICAL)",
+        )
+
+        # 2. The stricter project is untouched.
+        check(
+            "stricter project untouched: same actionable count both runs",
+            strict_a.get("actionable_finding_count")
+            == strict_b.get("actionable_finding_count"),
+            f"{strict_a.get('actionable_finding_count')} -> "
+            f"{strict_b.get('actionable_finding_count')}",
+        )
+        check(
+            "stricter project untouched: still judged at its own LOW",
+            strict_b.get("severity_threshold") == "LOW",
+            f"reported={strict_b.get('severity_threshold')}",
+        )
+
+        # 2b. The ceiling's reach, disclosed from the findings actually present.
+        iac_a = projects_a.get("iac", {})
+        iac_b = projects_b.get("iac", {})
+        unreachable_b = iac_b.get("ceiling_unreachable_findings") or {}
+        unreachable_a = iac_a.get("ceiling_unreachable_findings") or {}
+
+        if not iac_a.get("finding_count"):
+            print(
+                "FIXTURE NOTE: checkov produced no findings for the iac project; "
+                "skipping the disclosure checks rather than asserting vacuously"
+            )
+            print(f"        iac finding_count={iac_a.get('finding_count')}")
+        else:
+            check(
+                "level-only findings stay actionable at CRITICAL (the limitation)",
+                (iac_a.get("actionable_finding_count") or 0) > 0,
+                f"at declared CRITICAL: actionable="
+                f"{iac_a.get('actionable_finding_count')} of "
+                f"{iac_a.get('finding_count')} findings",
+            )
+            check(
+                "the ceiling could not tighten them, and says so per scanner",
+                bool(unreachable_b) and "checkov" in unreachable_b,
+                f"ceiling_unreachable_findings={unreachable_b}",
+            )
+            check(
+                "no disclosure without a ceiling, so it stays load-bearing",
+                unreachable_a == {},
+                f"baseline run disclosure={unreachable_a}",
+            )
+            check(
+                "the project the ceiling DID reach discloses nothing",
+                (projects_b.get("lax", {}).get("ceiling_unreachable_findings") or {})
+                == {},
+                "lax carries severity, so there is nothing to qualify",
+            )
+
+        # 3. Suppression scoping, on the resolved plan.
+        sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+        from automated_security_helper.workspace.resolver import resolve_workspace
+
+        plan = resolve_workspace(workspace, workspace_config=policy)
+        by_key = {p.key: p for p in plan.projects}
+        check(
+            "workspace suppression is pushed into the project it names",
+            [s.path for s in by_key["lax"].policy_suppressions] == ["src/runner.py"],
+            f"lax={[s.path for s in by_key['lax'].policy_suppressions]}",
+        )
+        check(
+            "workspace suppression is NOT passed to the other project",
+            by_key["strict"].policy_suppressions == [],
+            f"strict={[s.path for s in by_key['strict'].policy_suppressions]}",
+        )
+        check(
+            "the plan records which policy file was applied",
+            plan.workspace_config_source == policy.resolve().as_posix(),
+            f"source={plan.workspace_config_source}",
+        )
+
+        # 4. An unrewritable pattern refuses with exit 4.
+        bad_policy = _write(
+            scratch / "bad-policy.yaml",
+            "workspace:\n"
+            "  suppressions:\n"
+            "    - path: '*/sub/*.py'\n"
+            "      reason: no sound rewrite\n",
+        )
+        code_c, _, out_c = run_ash(workspace, scratch / "out-c", policy=bad_policy)
+        check(
+            "an unrewritable policy pattern exits 4",
+            code_c == 4,
+            f"exit={code_c}",
+        )
+        check(
+            "the refusal names the offending pattern",
+            "*/sub/*.py" in out_c,
+            "pattern quoted in output" if "*/sub/*.py" in out_c else out_c[-400:],
+        )
+
+        # A project config may not double as the policy file.
+        code_d, _, _ = run_ash(
+            workspace,
+            scratch / "out-d",
+            policy=scratch / "lax" / ".ash" / "ash.yaml",
+        )
+        check(
+            "naming a project config as the policy file exits 4",
+            code_d == 4,
+            f"exit={code_d}",
+        )
+
+        print()
+        print(
+            f"Results: {checks - len(failures)} passed, {len(failures)} failed, "
+            f"{checks} total"
+        )
+        print(f"Baseline run exit={code_a}, ceiling run exit={code_b}")
+        if failures:
+            print("\nFailed checks:")
+            for label in failures:
+                print(f"  - {label}")
+            return 1
+        print("\nWorkspace policy verified end to end on a real scan.")
+        return 0
+    finally:
+        if args.keep:
+            print(f"\nScratch kept at {scratch}")
+        else:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify_workspace_reports.py
+++ b/scripts/verify_workspace_reports.py
@@ -1,0 +1,537 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prove a real workspace scan produces the reports the RFC's table promises.
+
+Run with: python scripts/verify_workspace_reports.py
+
+Why this exists
+---------------
+``tests/unit/workspace/test_workspace_reporting.py`` and
+``test_merged_reporter_content.py`` assert the same behaviours as this script, and
+they are not a substitute for it. Every one of them builds its model in Python.
+What none of them exercises is the path an operator actually takes: a real
+workspace file on disk, real scanners, the real report phase inside each project's
+own orchestrator, and then the workspace-level report step reading back the file
+the aggregator streamed.
+
+Three classes of failure live only on that path.
+
+* A reporter that works against a hand-built model and fails against the
+  aggregator's output. The unified file is assembled by hand rather than by
+  ``json.dump`` of one object, precisely so peak memory stays bounded -- so
+  "reporters can read what the aggregator writes" is a property of two pieces of
+  code agreeing, not of either one alone.
+* The plugin registry resolving a different reporter set than a test injects. A
+  default run resolves 15 reporters; the four under ``ash_aws_plugins`` are
+  registered only when an operator names that module. A test that injects all 19
+  cannot notice that the other four never appear in a real run's manifest.
+* A workspace-level artefact written to the wrong place, or a per-project one
+  clobbered. Both are properties of the output *tree*, and a test asserting on a
+  returned string cannot see either.
+
+What the fixture is shaped to catch
+-----------------------------------
+Two projects, generated at runtime outside the repository:
+
+* ``api`` -- threshold LOW, no ``project_name`` in its config, so its display label
+  falls back to its key. That is the common case and it is the one that used to
+  produce ``Project: ASH`` in every per-project report.
+* ``web`` -- threshold LOW, and its config *does* declare ``project_name: web-app``.
+  So its label differs from its key, which is what makes the label-versus-key
+  rendering testable at all: with both projects labelled after their keys, a
+  renderer that printed the key everywhere would pass.
+
+Each project holds a different vulnerable file, tripping a different bandit rule.
+That is deliberate and it is the same reasoning as
+``verify_multi_project_attribution.py``: with identical files, "the csv row for
+``api`` exists" would be satisfied by a reporter that credited every finding to
+whichever project it happened to read first. Different marker rules make the
+ground truth the source on disk rather than anything in the payload, so nothing in
+the pipeline can move both sides of a comparison together.
+
+Deliberate choices
+------------------
+* Only bandit runs. This gate is about reporters, not scanners, and every
+  additional scanner adds runtime and a new upstream release that can turn the
+  branch red without a source change.
+* Assertions are structural, never on finding counts. Bandit's per-rule severities
+  move between releases, and a count assertion turns an upstream release into a
+  failure. What cannot move is that a project's own row exists, carries its own
+  label, and agrees with the verdict recorded for it.
+* The scan runs as a subprocess with ``cwd`` set to the repository, not to the
+  workspace. Workspace mode's whole premise is that the working directory is not
+  the scan target, and running from inside the workspace would hide any path bug
+  that depends on that difference.
+* The workspace is built under a temporary directory obtained from ``tempfile``
+  rather than a hardcoded path. ASH self-scans this repository, and a literal
+  temp path in committed source is an actionable finding here.
+
+Failure modes and known limitations
+-----------------------------------
+* This does not exercise the four ``ash_aws_plugins`` reporters. They need
+  credentials and they publish side effects, so a gate cannot run them. Their
+  declared behaviour is asserted in
+  ``tests/unit/workspace/test_workspace_reporting.py::TestTheManifestIsExhaustive``
+  against the full nineteen, which is the strongest check available without a
+  live account.
+* An ``UNSUPPORTED`` reporter is not exercised either: none ships in that state.
+  The refusal path is proven in unit tests with a declared-unsupported double.
+* The scan needs bandit installed and takes tens of seconds. It is not part of the
+  unit suite for that reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Any, Dict, Iterable, List
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+RESULTS_FILENAME = "ash_aggregated_results.json"
+REPORTS_DIR_NAME = "reports"
+MANIFEST_FILENAME = "workspace-reports.json"
+WORKSPACE_FILENAME = "fixture.code-workspace"
+
+#: The scanner this gate runs. One, on purpose: see "Deliberate choices".
+SCANNER = "bandit"
+
+CONFIG_TEMPLATE = """project_name: {name}
+global_settings:
+  severity_threshold: {threshold}
+"""
+
+
+@dataclass(frozen=True)
+class FixtureProject:
+    key: str
+    #: What lands in the project's own ``project_name``. When it equals the key,
+    #: the label falls back to the key -- the common case.
+    declared_name: str
+    #: What the reports should call it.
+    expected_label: str
+    #: Python that trips exactly one bandit rule no other project trips.
+    source: str
+
+
+FIXTURE_PROJECTS = (
+    FixtureProject(
+        key="api",
+        declared_name="api",
+        expected_label="api",
+        # B602: subprocess with shell=True.
+        source='import subprocess\nsubprocess.call("ls -la", shell=True)\n',
+    ),
+    FixtureProject(
+        key="web",
+        declared_name="web-app",
+        # Label differs from key, so the report has to show both.
+        expected_label="web-app (web)",
+        # B403/B301: pickle import and load.
+        source='import pickle\npickle.loads(b"payload")\n',
+    ),
+)
+
+#: Reporters whose workspace-level artefact must exist after a default run, keyed
+#: by the filename the report phase gives them. Derived from the RFC's table
+#: rather than from the code, so a ruling silently flipped in code fails here.
+EXPECTED_MERGED_ARTIFACTS = {
+    "csv": "ash.csv",
+    "flat-json": "ash.flat.json",
+    "html": "ash.html",
+    "junitxml": "ash.junit.xml",
+    "markdown": "ash.summary.md",
+    "ocsf": "ash.ocsf.json",
+    "sarif": "ash.sarif",
+    "text": "ash.summary.txt",
+    "unused-suppressions": "ash.unused-suppressions.json",
+}
+
+#: Reporters that must produce NO workspace-level artefact, and whose per-project
+#: files must exist instead.
+EXPECTED_PER_PROJECT_ARTIFACTS = {
+    "cyclonedx": "ash.cdx.json",
+    "github-ghas": "ash.ghas.sarif",
+    "gitlab-cyclonedx": "ash.gl-dependency-scanning-report.cdx.json",
+    "gitlab-sast": "ash.gl-sast-report.json",
+}
+
+
+class GateFailure(AssertionError):
+    """One asserted property did not hold."""
+
+
+def build_workspace(root: Path) -> Path:
+    """Write the fixture projects and the workspace definition. Returns the file."""
+    for project in FIXTURE_PROJECTS:
+        source_dir = root / project.key / "src"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "marker.py").write_text(project.source, encoding="utf-8")
+
+        config_dir = root / project.key / ".ash"
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / "ash.yaml").write_text(
+            CONFIG_TEMPLATE.format(name=project.declared_name, threshold="LOW"),
+            encoding="utf-8",
+        )
+
+    definition = root / WORKSPACE_FILENAME
+    definition.write_text(
+        json.dumps(
+            {"folders": [{"path": project.key} for project in FIXTURE_PROJECTS]},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return definition
+
+
+def run_scan(definition: Path, output_dir: Path, timeout: float):
+    """Run one workspace scan with the default phases, from the repository root.
+
+    ``cwd=REPO_ROOT`` rather than the workspace, and passed to the child rather
+    than set with ``os.chdir``: this project deliberately removed process-wide cwd
+    dependence, and workspace mode's premise is that the working directory is not
+    the scan target.
+    """
+    command = [
+        sys.executable,
+        "-m",
+        "automated_security_helper.cli.main",
+        "scan",
+        "--workspace",
+        str(definition),
+        "--output-dir",
+        str(output_dir),
+        "--scanners",
+        SCANNER,
+        "--no-progress",
+        "--simple",
+    ]
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "utf-8"
+    env.setdefault("PYTHONUTF8", "1")
+    return subprocess.run(  # nosec B603 -- list args, no shell, argv[0] is sys.executable
+        command,
+        cwd=str(REPO_ROOT),
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _read_json(path: Path) -> Any:
+    if not path.is_file():
+        raise GateFailure(f"expected file does not exist: {path}")
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def check_manifest(output_dir: Path) -> List[str]:
+    """Every reporter accounted for, with the behaviour the RFC's table states."""
+    problems: List[str] = []
+    manifest = _read_json(output_dir / REPORTS_DIR_NAME / MANIFEST_FILENAME)
+    reporters: Dict[str, Any] = manifest["reporters"]
+
+    expected_projects = [project.key for project in FIXTURE_PROJECTS]
+    if manifest["projects"] != expected_projects:
+        problems.append(
+            f"manifest projects {manifest['projects']} do not match the fixture "
+            f"{expected_projects} -- order matters, because it is the operator's "
+            f"stated order and two runs of one workspace must be comparable"
+        )
+
+    for name, filename in EXPECTED_MERGED_ARTIFACTS.items():
+        entry = reporters.get(name)
+        if entry is None:
+            problems.append(f"{name}: absent from the manifest entirely")
+            continue
+        if entry["workspace_artifact"] != f"{REPORTS_DIR_NAME}/{filename}":
+            problems.append(
+                f"{name}: manifest says workspace_artifact="
+                f"{entry['workspace_artifact']!r}, expected {filename!r}"
+            )
+        if not (output_dir / REPORTS_DIR_NAME / filename).is_file():
+            problems.append(f"{name}: {filename} is named in the manifest but missing")
+
+    for name, filename in EXPECTED_PER_PROJECT_ARTIFACTS.items():
+        entry = reporters.get(name)
+        if entry is None:
+            problems.append(f"{name}: absent from the manifest entirely")
+            continue
+        if entry["behaviour"] != "per-project":
+            problems.append(
+                f"{name}: behaviour is {entry['behaviour']!r}, expected per-project"
+            )
+        if entry["workspace_artifact"] is not None:
+            problems.append(
+                f"{name}: produced a workspace artefact "
+                f"({entry['workspace_artifact']}) but is ruled per-project"
+            )
+        if (output_dir / REPORTS_DIR_NAME / filename).exists():
+            problems.append(
+                f"{name}: {filename} exists at workspace level but is ruled per-project"
+            )
+        if entry["missing_per_project_artifacts"]:
+            problems.append(
+                f"{name}: no artefact for project(s) "
+                f"{entry['missing_per_project_artifacts']}"
+            )
+        # The count is asserted before the paths, and that ordering is the point.
+        # An empty pointer list satisfies "every pointer exists" vacuously, and a
+        # mutation that routed per-project reporters down a different branch --
+        # leaving the list empty while every other assertion here still held --
+        # passed this gate until this check existed. A gate that cannot fail is
+        # worth less than no gate, because it is believed.
+        pointers = entry["per_project_artifacts"]
+        if len(pointers) != len(FIXTURE_PROJECTS):
+            problems.append(
+                f"{name}: manifest lists {len(pointers)} per-project artefact(s), "
+                f"expected one per project ({len(FIXTURE_PROJECTS)})"
+            )
+        if [pointer["project"] for pointer in pointers] != [
+            project.key for project in FIXTURE_PROJECTS
+        ]:
+            problems.append(
+                f"{name}: per-project pointers name "
+                f"{[pointer['project'] for pointer in pointers]}, expected "
+                f"{[project.key for project in FIXTURE_PROJECTS]}"
+            )
+        for pointer in pointers:
+            if not (output_dir / pointer["path"]).is_file():
+                problems.append(
+                    f"{name}: manifest points at {pointer['path']}, which does not exist"
+                )
+        if entry.get("error"):
+            problems.append(
+                f"{name}: recorded an error rather than a clean per-project "
+                f"ruling: {entry['error']}"
+            )
+
+    scoped = reporters.get("unused-suppressions")
+    if scoped is not None and scoped["covers_projects"]:
+        problems.append(
+            "unused-suppressions is marked as covering projects; it is "
+            "workspace-scoped and a consumer must not read it as a merge"
+        )
+    return problems
+
+
+def check_merged_content(output_dir: Path) -> List[str]:
+    """Each merged artefact names every project, in its own format's place."""
+    problems: List[str] = []
+    reports = output_dir / REPORTS_DIR_NAME
+    keys = {project.key for project in FIXTURE_PROJECTS}
+
+    rows = list(csv.reader(StringIO((reports / "ash.csv").read_text(encoding="utf-8"))))
+    if not rows or rows[0][0] != "workspace_project":
+        problems.append(
+            f"csv: first column is {rows[0][0]!r}, expected workspace_project"
+        )
+    else:
+        index = rows[0].index("workspace_project")
+        present = {row[index] for row in rows[1:] if row}
+        if present != keys:
+            problems.append(
+                f"csv: projects in rows are {sorted(present)}, expected {sorted(keys)}"
+            )
+
+    flat = _read_json(reports / "ash.flat.json")
+    attributed = {finding.get("workspace_project") for finding in flat["findings"]}
+    if attributed != keys:
+        problems.append(f"flat-json: finding projects are {sorted(attributed)}")
+    if [p["project"] for p in flat.get("workspace", {}).get("projects", [])] != [
+        project.key for project in FIXTURE_PROJECTS
+    ]:
+        problems.append(
+            "flat-json: workspace block does not list the projects in order"
+        )
+
+    sarif = _read_json(reports / "ash.sarif")
+    if len(sarif["runs"]) != len(FIXTURE_PROJECTS):
+        problems.append(
+            f"sarif: {len(sarif['runs'])} run(s), expected {len(FIXTURE_PROJECTS)}"
+        )
+    roots = set()
+    for run in sarif["runs"]:
+        bases = run.get("originalUriBaseIds") or {}
+        if len(bases) != 1:
+            problems.append(
+                f"sarif: a run declares {len(bases)} base id(s), expected 1"
+            )
+        roots.update(entry["uri"] for entry in bases.values())
+    if len(roots) != len(FIXTURE_PROJECTS):
+        problems.append(f"sarif: runs share a root; roots were {sorted(roots)}")
+
+    from defusedxml import ElementTree
+
+    suites = {
+        suite.get("name")
+        for suite in ElementTree.fromstring(
+            (reports / "ash.junit.xml").read_text(encoding="utf-8")
+        ).iter("testsuite")
+    }
+    for key in keys:
+        if not any(name and name.startswith(f"{key}/") for name in suites):
+            problems.append(
+                f"junitxml: no testsuite named {key}/<scanner>; got {sorted(suites)}"
+            )
+
+    ocsf = _read_json(reports / "ash.ocsf.json")
+    labelled = {
+        label.split(":", 1)[1]
+        for finding in ocsf
+        for label in (finding["metadata"].get("labels") or [])
+        if label.startswith("workspace_project:")
+    }
+    if labelled != keys:
+        problems.append(f"ocsf: labelled projects are {sorted(labelled)}")
+
+    scoped = _read_json(reports / "ash.unused-suppressions.json")
+    if scoped.get("scope") != "workspace":
+        problems.append(f"unused-suppressions: scope is {scoped.get('scope')!r}")
+
+    return problems
+
+
+def check_labels(output_dir: Path) -> List[str]:
+    """A project whose declared name differs from its key shows both.
+
+    The reason this is a separate check: ``metadata.project_name`` was the literal
+    string "ASH" for every project before Phase 2b, so a renderer that printed a
+    constant satisfied every "the project appears" assertion.
+    """
+    problems: List[str] = []
+    reports = output_dir / REPORTS_DIR_NAME
+    markdown = (reports / "ash.summary.md").read_text(encoding="utf-8")
+    text = (reports / "ash.summary.txt").read_text(encoding="utf-8")
+    html = (reports / "ash.html").read_text(encoding="utf-8")
+
+    if "## Projects" not in markdown:
+        problems.append("markdown: no '## Projects' section")
+    if "PROJECTS" not in text:
+        problems.append("text: no PROJECTS section")
+    if 'id="workspace-projects"' not in html:
+        problems.append("html: no workspace-projects section")
+
+    for project in FIXTURE_PROJECTS:
+        if f"| {project.expected_label} |" not in markdown:
+            problems.append(f"markdown: no row labelled {project.expected_label!r}")
+        if project.expected_label not in text:
+            problems.append(f"text: no row labelled {project.expected_label!r}")
+        if f"<td>{project.expected_label}</td>" not in html:
+            problems.append(f"html: no cell labelled {project.expected_label!r}")
+
+    return problems
+
+
+def check_per_project_identity(output_dir: Path) -> List[str]:
+    """Each project's own results name that project, not a shared constant."""
+    problems: List[str] = []
+    seen = {}
+    for project in FIXTURE_PROJECTS:
+        results = _read_json(output_dir / "projects" / project.key / RESULTS_FILENAME)
+        metadata = results.get("metadata") or {}
+        seen[project.key] = metadata.get("project_name")
+        if metadata.get("project_name") != project.declared_name:
+            problems.append(
+                f"{project.key}: per-project metadata.project_name is "
+                f"{metadata.get('project_name')!r}, expected {project.declared_name!r}"
+            )
+        if metadata.get("workspace_project") != project.key:
+            problems.append(
+                f"{project.key}: per-project metadata.workspace_project is "
+                f"{metadata.get('workspace_project')!r}"
+            )
+    if len(set(seen.values())) != len(seen):
+        problems.append(
+            f"two projects share a project_name: {seen} -- per-project artefacts "
+            f"published to a shared destination would be indistinguishable"
+        )
+    return problems
+
+
+def _parse_args(argv: Iterable[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=900.0,
+        help="Seconds to allow the scan (default: 900)",
+    )
+    parser.add_argument(
+        "--keep",
+        action="store_true",
+        help="Leave the generated workspace and output on disk for inspection",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv)
+    scratch = Path(tempfile.mkdtemp(prefix="ash-workspace-reports-gate-"))
+    try:
+        workspace_root = scratch / "workspace"
+        workspace_root.mkdir(parents=True, exist_ok=True)
+        output_dir = scratch / "output"
+
+        definition = build_workspace(workspace_root)
+        print(f"workspace: {definition}")
+        print(f"output:    {output_dir}")
+
+        completed = run_scan(definition, output_dir, args.timeout)
+        print(f"exit code: {completed.returncode}")
+
+        problems: List[str] = []
+        # Exit 2 is the expected outcome: both fixture projects carry findings
+        # above their own LOW threshold. Anything else means the scan itself did
+        # not do what this gate assumes, so the report assertions below would be
+        # measuring the wrong run.
+        if completed.returncode != 2:
+            problems.append(
+                f"expected exit code 2 (actionable findings), got "
+                f"{completed.returncode}\nstdout:\n{completed.stdout[-4000:]}"
+                f"\nstderr:\n{completed.stderr[-4000:]}"
+            )
+        else:
+            for check in (
+                check_manifest,
+                check_merged_content,
+                check_labels,
+                check_per_project_identity,
+            ):
+                problems.extend(check(output_dir))
+
+        if problems:
+            print("\nFAILED:")
+            for problem in problems:
+                print(f"  - {problem}")
+            return 1
+
+        print(
+            f"\nPASSED: {len(EXPECTED_MERGED_ARTIFACTS)} merged artefact(s), "
+            f"{len(EXPECTED_PER_PROJECT_ARTIFACTS)} per-project ruling(s), "
+            f"and {len(FIXTURE_PROJECTS)} project identities verified on disk."
+        )
+        return 0
+    finally:
+        if args.keep:
+            print(f"\nkept: {scratch}")
+        else:
+            shutil.rmtree(scratch, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/integration/cli/conftest.py
+++ b/tests/integration/cli/conftest.py
@@ -44,7 +44,9 @@ def mock_mcp_environment():
     modules_to_mock = {
         "mcp": mock_mcp,
         "mcp.server": MagicMock(),
-        "mcp.server.mcpserver": MagicMock(MCPServer=mock_mcpserver, Context=mock_context),
+        "mcp.server.mcpserver": MagicMock(
+            MCPServer=mock_mcpserver, Context=mock_context
+        ),
     }
 
     with patch.dict("sys.modules", modules_to_mock):
@@ -211,11 +213,56 @@ def pytest_configure(config):
 
 # Test collection configuration
 def pytest_collection_modifyitems(config, items):
-    """Modify test collection to add markers automatically."""
+    """Modify test collection to add markers automatically.
+
+    Every rule here is scoped to this directory, and that scoping is the point.
+
+    ``pytest_collection_modifyitems`` receives *every* item in the session, not
+    only the ones under the conftest that defines the hook. The name-based rules
+    below were unscoped, so any test anywhere in the repository whose name
+    contained "workflow", "lifecycle" or "end_to_end" was marked slow -- and
+    ``tests/conftest.py`` then skips slow tests unless ``--run-slow`` is passed.
+    Six unit tests were silently not running in a full-suite run as a result,
+    including two CI gates whose whole job is to fail when a workflow drifts from
+    its documented budget. All six pass when actually executed, so nothing was
+    hiding a real failure; they were simply providing no coverage while appearing
+    to.
+
+    The failure mode is worth naming because it is invisible from either end. The
+    test file gives no hint it will be skipped, and the conftest that skips it
+    lives in an unrelated directory the author had no reason to read. A green
+    suite plus a skip count nobody diffs is all the signal there was.
+
+    The same defect survived that fix in the ``integration`` marker, which kept
+    testing ``"integration" in str(item.fspath)`` while only the slow rules were
+    scoped -- with a comment saying the substring form would reach the whole repo
+    again. It did: a unit test at
+    ``tests/unit/workspace/test_workspace_policy_resolution.py``, originally
+    named ``..._integration.py``, had all fourteen of its tests skipped in a full
+    run while passing when the file was run on its own. Fixing one instance of a
+    pattern and documenting it is not the same as removing the pattern, so the
+    ``integration`` marker now hangs off the same path scoping as everything
+    else. Detected by diffing the skipped-test IDs against a baseline, which is
+    the only signal this failure emits.
+    """
+    integration_root = Path(__file__).resolve().parent.parent
+
     for item in items:
-        # Add integration marker to all tests in this directory
-        if "integration" in str(item.fspath):
-            item.add_marker(pytest.mark.integration)
+        # Scoped to the integration tree, which is what every heuristic below is
+        # about. Compared against a resolved path rather than by substring: a
+        # substring test is how the unscoped version reached the whole repo.
+        if not Path(item.fspath).resolve().is_relative_to(integration_root):
+            continue
+
+        # What makes a test an integration test is living in this tree, not
+        # having "integration" in its path. The previous version tested the
+        # substring and so marked -- and therefore skipped -- any test anywhere
+        # in the repository whose path happened to contain the word. That is the
+        # same defect this hook's docstring describes for the slow marker, left
+        # in place when that one was fixed; a unit test named
+        # test_workspace_policy_integration.py hit it and its fourteen tests
+        # were silently skipped in the full suite while passing in isolation.
+        item.add_marker(pytest.mark.integration)
 
         # Add slow marker to tests that might take longer
         if any(

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_csv_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_csv_reporter.py
@@ -49,15 +49,25 @@ class TestCsvReporter:
     def test_report_empty_model_returns_header_only(
         self, csv_reporter, sample_ash_model
     ):
-        """When there are no vulnerabilities, only the header row is produced."""
+        """When there are no vulnerabilities, only the header row is produced.
+
+        The column names asserted here changed from title case ("ID", "Severity")
+        to the field names the populated form has always emitted ("id",
+        "severity"). This test previously pinned a real inconsistency: the two
+        code paths in ``CsvReporter.report`` produced different headers for the
+        same data, so a consumer parsing by header name worked against one and
+        not the other depending on whether the scan happened to find anything.
+        Both headers are now derived from ``FlatVulnerability``'s own field
+        order, so they cannot disagree.
+        """
         result = csv_reporter.report(sample_ash_model)
 
         lines = result.strip().split("\n")
         assert len(lines) == 1  # header only
         # Verify some expected header columns
-        assert "ID" in lines[0]
-        assert "Severity" in lines[0]
-        assert "Scanner" in lines[0]
+        assert "id" in lines[0]
+        assert "severity" in lines[0]
+        assert "scanner" in lines[0]
 
     def test_report_with_vulnerabilities(self, csv_reporter):
         """When there are vulnerabilities, data rows follow the header."""

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_spdx_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_spdx_reporter.py
@@ -58,11 +58,23 @@ class TestSpdxReporter:
             mock_logger.warning.assert_called_once()
             assert "stub" in mock_logger.warning.call_args[0][0]
 
-    def test_report_uses_by_alias(self, spdx_reporter):
-        """report() calls model_dump with by_alias=True."""
+    def test_report_uses_by_alias_and_json_mode(self, spdx_reporter):
+        """report() calls model_dump with by_alias=True and mode="json".
+
+        ``mode="json"`` was added because without it ``model_dump`` leaves enum
+        objects in the tree and ``yaml.dump`` serialises those as
+        ``!!python/object/apply:`` tags -- output ``yaml.safe_load`` refuses
+        outright, and which any other loader parses by constructing arbitrary
+        Python objects. Every real scan has at least one such enum, in
+        ``scanner_results``.
+
+        Pinned as an exact call rather than by inspecting the output because that
+        is what this test has always done, and because the two kwargs are the only
+        thing that makes the document loadable at all.
+        """
         model = MagicMock()
         model.model_dump.return_value = {"key": "value"}
 
         spdx_reporter.report(model)
 
-        model.model_dump.assert_called_once_with(by_alias=True)
+        model.model_dump.assert_called_once_with(by_alias=True, mode="json")

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_yaml_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_yaml_reporter.py
@@ -1,0 +1,152 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ash.yaml`` has to be loadable by a parser that will not execute the file.
+
+Why a behavioural test and not a call assertion
+-----------------------------------------------
+The fix is one kwarg -- ``model_dump(by_alias=True, mode="json")`` -- and the
+obvious guard is to assert that kwarg was passed. ``test_spdx_reporter.py`` has
+such an assertion and it is worth keeping there for other reasons, but on its own
+it is the wrong shape of guard for *this* defect: it passes whenever the kwargs
+are present, including if the output becomes unloadable again by some other route.
+Which is how the defect arrived in the first place -- nobody was checking the
+output, only the code.
+
+So these tests load the output. ``yaml.safe_load`` succeeding is the property an
+operator actually depends on.
+
+What the defect was
+-------------------
+``yaml.dump(model.model_dump(by_alias=True))`` -- Python mode, not JSON mode --
+leaves rich objects in the tree, and ``yaml.dump`` serialises those as
+``!!python/object`` tags. ``yaml.safe_load`` refuses them outright with
+``ConstructorError``; the only loaders that accept them are the ones that will
+construct arbitrary Python objects out of the file. Requiring that of anyone
+consuming a *security tool's* output is the part that makes this more than a
+formatting bug.
+
+It is not limited to scans that found something. A **default**
+``AshAggregatedResults`` with no findings at all emits four such tags, from the
+``AnyUrl`` values in the SARIF tool metadata's ``informationUri`` and
+``downloadUri``. So it was every document ASH has ever written, empty ones
+included. Enum fields such as ``ScannerStatus`` add more tags on any real scan,
+but they are the second source, not the first.
+
+Both sources are asserted below, and separately, because they come from different
+pydantic types and a partial fix would leave one of them behind.
+"""
+
+import re
+
+import pytest
+import yaml
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.models.asharp_model import (
+    AshAggregatedResults,
+    ScannerStatusInfo,
+)
+from automated_security_helper.plugin_modules.ash_builtin.reporters.yaml_reporter import (
+    YamlReporter,
+)
+
+#: Any tag that makes a document constructible only by an unsafe loader. Matched
+#: as a prefix because pydantic emits at least two spellings --
+#: ``!!python/object:pydantic.networks.AnyUrl`` and
+#: ``!!python/object/new:pydantic_core._pydantic_core.Url`` -- and a fix that
+#: eliminated one but not the other must still fail.
+UNSAFE_TAG = re.compile(r"!!python/object\S*")
+
+
+@pytest.fixture
+def context(tmp_path) -> PluginContext:
+    return PluginContext(
+        source_dir=tmp_path,
+        output_dir=tmp_path / "out",
+        config=AshConfig(),
+    )
+
+
+def _report(model: AshAggregatedResults, context: PluginContext) -> str:
+    return YamlReporter(context=context).report(model)
+
+
+class TestTheOutputIsSafeLoadable:
+    def test_an_empty_scan_produces_a_safe_loadable_document(self, context):
+        """The broadest case, and the one that makes this every document.
+
+        A default model has no findings and no scanner results, and still emitted
+        four ``!!python/object`` tags before the fix -- from the ``AnyUrl`` values
+        in the SARIF tool metadata. So "every real scan" understated it: an empty
+        scan was affected too.
+        """
+        result = _report(AshAggregatedResults(), context)
+
+        loaded = yaml.safe_load(result)
+        assert isinstance(loaded, dict)
+        assert not UNSAFE_TAG.search(result), UNSAFE_TAG.findall(result)
+
+    def test_a_scan_with_a_scanner_status_enum_is_safe_loadable(self, context):
+        """The second source of tags, asserted separately.
+
+        ``ScannerStatus`` is an enum, and it reaches the dump through
+        ``scanner_results`` on every scan that ran a scanner. It comes from a
+        different pydantic type than the ``AnyUrl`` case above, so a partial fix
+        could close one and leave the other; asserting them separately is what
+        makes that visible.
+        """
+        model = AshAggregatedResults()
+        model.scanner_results = {
+            "bandit": ScannerStatusInfo(status=ScannerStatus.FAILED)
+        }
+        result = _report(model, context)
+
+        loaded = yaml.safe_load(result)
+        assert not UNSAFE_TAG.search(result), UNSAFE_TAG.findall(result)
+        # The load is not vacuous: the enum survived as a plain string, and the
+        # value is the one that was set. Without this, a fix that dropped
+        # scanner_results entirely would satisfy safe_load and this test.
+        assert loaded["scanner_results"]["bandit"]["status"] == "FAILED"
+
+    def test_the_document_still_carries_the_model_it_was_given(self, context):
+        """Guards against making the output loadable by making it empty.
+
+        ``yaml.safe_load("{}")`` succeeds, so "safe_load did not raise" is
+        satisfiable by a reporter that emits nothing useful. This pins that the
+        loaded document is the model.
+        """
+        model = AshAggregatedResults()
+        model.name = "fixture-scan"
+        loaded = yaml.safe_load(_report(model, context))
+
+        assert loaded["name"] == "fixture-scan"
+        assert "metadata" in loaded
+        assert "sarif" in loaded
+
+
+class TestTheUnsafeTagMatcherWorks:
+    """A negative control for the matcher itself.
+
+    Every assertion above is of the form "no unsafe tag was found". If the regex
+    were wrong, all of them would pass against output full of tags. So the matcher
+    is checked against a document known to contain them, produced the way the
+    pre-fix reporter produced it.
+    """
+
+    def test_the_matcher_finds_tags_in_a_python_mode_dump(self):
+        model = AshAggregatedResults()
+        model.scanner_results = {
+            "bandit": ScannerStatusInfo(status=ScannerStatus.FAILED)
+        }
+        # Exactly what yaml_reporter did before the fix: no mode="json".
+        pre_fix = yaml.dump(model.model_dump(by_alias=True), indent=2)
+
+        assert UNSAFE_TAG.search(pre_fix), (
+            "the pre-fix dump contains no !!python/object tag, so the matcher "
+            "above proves nothing"
+        )
+        with pytest.raises(yaml.constructor.ConstructorError):
+            yaml.safe_load(pre_fix)

--- a/tests/unit/test_collection_marker_scoping.py
+++ b/tests/unit/test_collection_marker_scoping.py
@@ -1,0 +1,117 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A conftest hook must not mark tests outside its own tree.
+
+The failure this prevents
+-------------------------
+``pytest_collection_modifyitems`` receives *every* item in the session, not only
+the ones beneath the conftest that defines the hook.
+``tests/integration/cli/conftest.py`` used that hook to add ``pytest.mark.slow``
+to any test whose name contained "workflow", "lifecycle" or "end_to_end" -- with
+no path scoping. ``tests/conftest.py`` then skips slow tests unless ``--run-slow``
+is passed.
+
+The result was six unit tests that silently did not run in a full-suite run,
+including two CI gates whose entire job is to fail when a GitHub workflow drifts
+from its documented timeout budget. All six passed when executed, so nothing was
+hiding a real failure -- they were simply providing no coverage while appearing to.
+
+It is worth guarding rather than just fixing, because the failure is invisible
+from both ends. A test file gives no hint that a conftest three directories away
+will skip it, and the author of that conftest had no reason to think about tests
+they did not write. The only signal was a skip count in a summary line, against a
+suite that stays green either way.
+
+Asserted against the hook rather than against a real collection
+--------------------------------------------------------------
+The hook is called directly with stand-in items. Driving a real nested pytest
+session would be slower, would need the marker state inspected across process
+boundaries, and would test pytest's collection machinery rather than the one
+decision this file cares about: does the rule look at the path.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Names that trigger the heuristic in ``tests/integration/cli/conftest.py``.
+#: Taken from that file; if it grows a keyword and this list does not, the
+#: parametrised cases below simply cover less rather than failing wrongly.
+TRIGGERING_NAMES = (
+    "test_complete_scan_workflow",
+    "test_server_lifecycle",
+    "test_report_end_to_end",
+)
+
+
+class _FakeItem:
+    """The minimum surface ``pytest_collection_modifyitems`` touches."""
+
+    def __init__(self, path: Path, name: str) -> None:
+        self.fspath = path
+        self.name = name
+        self.applied: list[str] = []
+
+    def add_marker(self, marker) -> None:
+        self.applied.append(getattr(marker, "name", str(marker)))
+
+
+@pytest.fixture
+def modify_items():
+    """The hook under test, imported from the integration conftest by path."""
+    import importlib.util
+
+    conftest = REPO_ROOT / "tests" / "integration" / "cli" / "conftest.py"
+    spec = importlib.util.spec_from_file_location(
+        "_integration_cli_conftest_under_test", conftest
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.pytest_collection_modifyitems
+
+
+@pytest.fixture
+def config():
+    class _Config:
+        rootpath = REPO_ROOT
+
+        def addinivalue_line(self, *args, **kwargs):  # pragma: no cover
+            pass
+
+    return _Config()
+
+
+@pytest.mark.parametrize("name", TRIGGERING_NAMES)
+def test_a_unit_test_is_never_marked_slow_by_the_integration_conftest(
+    modify_items, config, name
+):
+    item = _FakeItem(REPO_ROOT / "tests" / "unit" / "workspace" / "test_x.py", name)
+    modify_items(config, [item])
+    assert "slow" not in item.applied
+    assert "mcp" not in item.applied
+    assert "integration" not in item.applied
+
+
+@pytest.mark.parametrize("name", TRIGGERING_NAMES)
+def test_an_integration_test_is_still_marked_slow(modify_items, config, name):
+    """The companion assertion, and the reason the fix is a scope and not a delete.
+
+    Without this, removing the heuristic entirely would satisfy the test above --
+    and the integration suite would lose the ``--run-slow`` gate that keeps a
+    default run fast.
+    """
+    item = _FakeItem(REPO_ROOT / "tests" / "integration" / "cli" / "test_x.py", name)
+    modify_items(config, [item])
+    assert "slow" in item.applied
+    assert "integration" in item.applied
+
+
+def test_a_unit_test_named_after_mcp_is_not_marked_mcp(modify_items, config):
+    item = _FakeItem(
+        REPO_ROOT / "tests" / "unit" / "cli" / "test_x.py", "test_mcp_something"
+    )
+    modify_items(config, [item])
+    assert "mcp" not in item.applied

--- a/tests/unit/workspace/test_execution.py
+++ b/tests/unit/workspace/test_execution.py
@@ -280,6 +280,202 @@ class TestPerProjectThresholds:
         verdicts = {p.project: p.exceeds_threshold for p in outcome.payload.projects}
         assert verdicts == {"strict": True, "lax": False}
 
+    def test_a_workspace_ceiling_makes_a_lax_project_fail(self, tmp_path):
+        """The ceiling has to change the VERDICT, not just the plan.
+
+        api declares CRITICAL, so on its own a warning-level finding is not
+        actionable -- test_a_project_below_its_own_threshold_passes above is that
+        exact case. Under a MEDIUM ceiling the same finding must fail. If
+        execution read severity_threshold instead of the effective value, this
+        test would see exit 0 and the ceiling would be decorative.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.exceeds_threshold is True
+        assert outcome.exit_code == WorkspaceExitCode.ACTIONABLE_FINDINGS
+        # The reported threshold is the one actually enforced, or a reader
+        # comparing the finding against it would conclude ASH had miscounted.
+        assert entry.severity_threshold == "MEDIUM"
+
+    def test_a_ceiling_does_not_loosen_a_stricter_project(self, tmp_path):
+        """The other direction, since a ceiling that replaced would pass here.
+
+        strict declares LOW and the ceiling is CRITICAL. stricter_of keeps LOW,
+        so the warning stays actionable. An implementation that let the ceiling
+        win would report exit 0 for a project the operator set to LOW.
+        """
+        _, plan = _make_workspace(tmp_path, ("strict", "LOW"))
+        project = plan.projects[0]
+        # What resolution produces for a project already stricter than the
+        # ceiling: unchanged, and not flagged as tightened.
+        project.effective_severity_threshold = "LOW"
+        project.threshold_tightened_by_policy = False
+        FakeOrchestrator.behaviour["strict"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.exceeds_threshold is True
+        assert entry.severity_threshold == "LOW"
+
+    def test_a_plan_with_no_effective_threshold_falls_back_to_the_projects_own(
+        self, tmp_path
+    ):
+        """Plans built outside resolve_workspace never set the effective value.
+
+        plan.py's docstring says a hand-built plan can hold states resolution
+        would not produce, and the executor is given plans by tests and by
+        callers that predate this field. Falling back keeps those judged by their
+        own threshold rather than by None, which would turn the gate off.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "LOW"))
+        assert plan.projects[0].effective_severity_threshold is None
+
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        assert entry.actionable_finding_count == 1
+        assert entry.severity_threshold == "LOW"
+
+    def test_the_per_scanner_rollup_agrees_with_the_project_total_under_a_ceiling(
+        self, tmp_path
+    ):
+        """Two derivations of one number must not disagree once policy applies.
+
+        The project's actionable count is computed from the effective threshold,
+        while the workspace rollup splits it per scanner. If the split is derived
+        from the DECLARED threshold instead, the two disagree the moment a ceiling
+        tightens anything -- the per-scanner numbers sum to 0 while the project
+        says 1, and a reader has no rule for which to trust.
+
+        This is the failure the ceiling wiring introduces if the split is missed,
+        so it is asserted as an equality between the two payloads rather than
+        against a literal.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="warning")}
+
+        outcome = _run(tmp_path, plan)
+        entry = outcome.payload.projects[0]
+
+        # Control: the ceiling really did make this actionable, or the equality
+        # below would hold trivially at 0 == 0 and prove nothing.
+        assert entry.actionable_finding_count == 1
+
+        # Read the written file: scanner_results is a top-level key of the
+        # aggregated report, not a field of WorkspaceResults, and the file is what
+        # a consumer actually reads.
+        written = json.loads(
+            (tmp_path / "out" / "ash_aggregated_results.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        rollup = {
+            name: (value or {}).get("actionable_finding_count", 0)
+            for name, value in (written.get("scanner_results") or {}).items()
+        }
+        assert sum(rollup.values()) == entry.actionable_finding_count, rollup
+
+    def test_a_tightened_project_discloses_findings_the_ceiling_could_not_reach(
+        self, tmp_path
+    ):
+        """The mechanised form of the documented limitation, on the outcome.
+
+        A level-only `error` is read as critical by both threshold gates, so
+        tightening CRITICAL to MEDIUM changes nothing for it. The project still
+        fails -- correctly -- but the operator needs to know the ceiling is not
+        what made it fail, or they will conclude the ceiling works on findings it
+        never touched.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        assert entry.ceiling_unreachable_findings == {"bandit": 1}
+
+    def test_an_untightened_project_discloses_nothing(self, tmp_path):
+        """Load-bearing only. The same finding, no ceiling, no disclosure.
+
+        Without this the disclosure would appear on every scan carrying a
+        level-only finding, and a message that always appears is one nobody
+        reads.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        # Control: the finding IS present and actionable, so the empty disclosure
+        # is a decision rather than an absence of input.
+        assert entry.actionable_finding_count == 1
+        assert entry.ceiling_unreachable_findings == {}
+
+    def test_the_disclosure_follows_the_tightened_flag_not_just_the_thresholds(
+        self, tmp_path
+    ):
+        """Pins the execution-level guard, which is otherwise indistinguishable.
+
+        ceiling_unreachable_counts short-circuits on equal thresholds, so for any
+        plan resolve_workspace builds -- where the flag and the two thresholds are
+        set together and cannot disagree -- either guard alone suffices, and
+        removing the one in execution.py leaves every other test green. That was
+        measured, not assumed.
+
+        This constructs the one state where they disagree: differing thresholds
+        with the flag false, which plan.py's docstring says a hand-built plan may
+        hold. The flag is the record of whether policy moved this project, so it
+        is what the disclosure follows.
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = False
+        FakeOrchestrator.behaviour["api"] = {"sarif": _sarif(level="error")}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+
+        # Control: the finding is present and the thresholds DO differ, so the
+        # empty disclosure is the flag's doing and not a missing input.
+        assert entry.actionable_finding_count == 1
+        assert project.severity_threshold != project.effective_severity_threshold
+        assert entry.ceiling_unreachable_findings == {}
+
+    def test_a_tightened_project_whose_findings_the_ceiling_reached_discloses_nothing(
+        self, tmp_path
+    ):
+        """The other load-bearing arm: tightening happened AND it worked.
+
+        A severity-carrying MEDIUM finding is exactly what the ceiling is for, so
+        there is nothing to qualify. Distinguishes "we disclose whenever tightened"
+        from "we disclose when tightening fell short".
+        """
+        _, plan = _make_workspace(tmp_path, ("api", "CRITICAL"))
+        project = plan.projects[0]
+        project.effective_severity_threshold = "MEDIUM"
+        project.threshold_tightened_by_policy = True
+        sarif = _sarif(level="warning")
+        sarif["runs"][0]["results"][0]["properties"]["issue_severity"] = "MEDIUM"
+        FakeOrchestrator.behaviour["api"] = {"sarif": sarif}
+
+        entry = _run(tmp_path, plan).payload.projects[0]
+        assert entry.actionable_finding_count == 1
+        assert entry.ceiling_unreachable_findings == {}
+
     def test_the_aggregate_exit_code_reflects_the_strictest_failing_project(
         self, tmp_path
     ):
@@ -803,9 +999,50 @@ class TestWorkspaceOutput:
         assert outcome.payload.project_timeout == pytest.approx(42.0)
 
     def test_the_payload_records_wall_clock(self, tmp_path):
+        """The field is populated with a real, non-negative measurement.
+
+        Deliberately ``>= 0`` and not ``> 0``. ``wall_clock`` is
+        ``time.monotonic() - started``, so a strict comparison asserts that the
+        run outlasted the host's clock granularity rather than asserting
+        anything about this code. On Windows that granularity is coarse enough
+        that a fully-faked run can finish inside one tick, making the delta
+        exactly ``0.0``; the strict form failed one CI row out of four while
+        passing on every other platform and version. The exact value is pinned
+        by the test below, against a clock this test controls.
+        """
         _, plan = _make_workspace(tmp_path, ("api", "MEDIUM"))
         outcome = _run(tmp_path, plan)
-        assert outcome.payload.wall_clock_seconds > 0
+        assert outcome.payload.wall_clock_seconds is not None
+        assert outcome.payload.wall_clock_seconds >= 0
+
+    def test_the_wall_clock_is_the_elapsed_time_not_a_constant(
+        self, tmp_path, monkeypatch
+    ):
+        """Pin the arithmetic by driving the clock instead of racing it.
+
+        The first ``monotonic()`` call in ``execute_workspace`` is the start
+        stamp; every later call here returns a fixed later instant, so the
+        recorded wall clock must be exactly the difference. ``calls`` is the
+        control: if the start stamp were ever *not* the first call, or the clock
+        were consulted only once, the subtraction below would be meaningless, so
+        the count is asserted rather than assumed.
+        """
+        calls: List[float] = []
+
+        def fake_monotonic() -> float:
+            value = 100.0 if not calls else 142.5
+            calls.append(value)
+            return value
+
+        monkeypatch.setattr(
+            "automated_security_helper.workspace.execution.time.monotonic",
+            fake_monotonic,
+        )
+        _, plan = _make_workspace(tmp_path, ("api", "MEDIUM"))
+        outcome = _run(tmp_path, plan)
+        assert len(calls) >= 2, "the clock was consulted too few times to subtract"
+        assert calls[0] == 100.0
+        assert outcome.payload.wall_clock_seconds == pytest.approx(42.5)
 
     def test_the_payload_status_is_completed(self, tmp_path):
         _, plan = _make_workspace(tmp_path, ("api", "MEDIUM"))

--- a/tests/unit/workspace/test_merged_reporter_content.py
+++ b/tests/unit/workspace/test_merged_reporter_content.py
@@ -1,0 +1,625 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""What each merged reporter actually carries about the project.
+
+Why existence is not enough
+---------------------------
+``test_workspace_reporting.py`` proves the driver writes a file for a MERGED
+reporter. This file proves the file is *worth having*: that the project appears
+in it, in the place the RFC's table promised, and that a reader can tell one
+project's findings from another's.
+
+A merged artefact that contained every finding but named no project would pass
+every test in the other file and still be useless -- an operator staring at 40
+findings across a monorepo with no way to route any of them. That is the failure
+mode this file exists against, and it is why each assertion below names a
+specific project's own data rather than merely counting.
+
+The single-directory companion assertion
+----------------------------------------
+Every reporter here is also asserted to leave single-directory output alone. Not
+defensiveness: a project column added unconditionally to CSV would shift every
+subsequent column, and a consumer indexing by position rather than by header
+would silently read the wrong field from then on. So each "adds the project"
+assertion is paired with a "changes nothing without a workspace" assertion.
+"""
+
+import json
+
+import pytest
+
+# defusedxml rather than xml.etree: ASH self-scans this repository, and the
+# stdlib parsers accept external entities by default. Already a dependency --
+# junitxml_reporter calls defuse_stdlib() for the same reason.
+from defusedxml import ElementTree
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.ash_config import AshConfig
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.models.workspace import (
+    ProjectRunStatus,
+    WorkspaceProjectResult,
+    WorkspaceResults,
+)
+from automated_security_helper.schemas.sarif_schema_model import SarifReport
+
+PROJECTS = ("api", "web")
+
+
+def _result(project: str | None, *, rule: str, uri: str) -> dict:
+    entry = {
+        "ruleId": rule,
+        "level": "error",
+        "message": {"text": f"finding for {project or 'single'}"},
+        "locations": [{"physicalLocation": {"artifactLocation": {"uri": uri}}}],
+        "properties": {"scanner_name": "bandit"},
+    }
+    if project is not None:
+        entry["properties"]["workspace_project"] = project
+    return entry
+
+
+def _project_result(
+    key: str, *, findings: int, actionable: int
+) -> WorkspaceProjectResult:
+    return WorkspaceProjectResult(
+        project=key,
+        relative_path=key,
+        display_label=key,
+        status=ProjectRunStatus.COMPLETED,
+        severity_threshold="MEDIUM",
+        finding_count=findings,
+        actionable_finding_count=actionable,
+        exceeds_threshold=bool(actionable),
+        output_path=f"projects/{key}",
+        scanners={"bandit": "FAILED" if actionable else "PASSED"},
+    )
+
+
+@pytest.fixture
+def workspace_model(tmp_path) -> AshAggregatedResults:
+    """A two-project workspace model, with one run per project.
+
+    Rule ids and file paths differ per project so that a reporter which dropped
+    or duplicated a project is caught by asserting on that project's own data
+    rather than by a count -- which a duplicated first project would satisfy.
+    """
+    model = AshAggregatedResults()
+    model.sarif = SarifReport.model_validate(
+        {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "ASH"}},
+                    "results": [
+                        _result(key, rule=f"RULE-{key.upper()}", uri=f"src/{key}.py")
+                    ],
+                    "originalUriBaseIds": {
+                        "PROJECTROOT": {"uri": f"file:///ws/{key}/"}
+                    },
+                    "invocations": [],
+                }
+                for key in PROJECTS
+            ],
+        }
+    )
+    model.workspace = WorkspaceResults(
+        workspace_file=(tmp_path / "fixture.code-workspace").as_posix(),
+        workspace_root=tmp_path.as_posix(),
+        exit_code=2,
+        projects=[
+            _project_result("api", findings=1, actionable=1),
+            _project_result("web", findings=1, actionable=0),
+        ],
+        wall_clock_seconds=3.25,
+    )
+    return model
+
+
+@pytest.fixture
+def single_model() -> AshAggregatedResults:
+    """The single-directory shape: one run, no ``workspace`` block."""
+    model = AshAggregatedResults()
+    model.sarif = SarifReport.model_validate(
+        {
+            "version": "2.1.0",
+            "runs": [
+                {
+                    "tool": {"driver": {"name": "ASH"}},
+                    "results": [_result(None, rule="RULE-ONE", uri="src/app.py")],
+                    "invocations": [],
+                }
+            ],
+        }
+    )
+    return model
+
+
+@pytest.fixture
+def context(tmp_path) -> PluginContext:
+    return PluginContext(
+        source_dir=tmp_path,
+        output_dir=tmp_path / "out",
+        config=AshConfig(),
+    )
+
+
+def _report(reporter_class, model, context) -> str:
+    return reporter_class(context=context).report(model)
+
+
+# --------------------------------------------------------------------------- #
+# Column-and-field reporters: csv, flat-json, yaml
+# --------------------------------------------------------------------------- #
+
+
+class TestCsvCarriesAProjectColumn:
+    @staticmethod
+    def _rows(text: str):
+        import csv
+        from io import StringIO
+
+        return list(csv.reader(StringIO(text)))
+
+    def test_the_project_column_is_present_and_leads_the_header(
+        self, workspace_model, context
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.csv_reporter import (
+            PROJECT_COLUMN,
+            CsvReporter,
+        )
+
+        rows = self._rows(_report(CsvReporter, workspace_model, context))
+        assert rows[0][0] == PROJECT_COLUMN
+
+    def test_every_project_has_its_own_row(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.csv_reporter import (
+            CsvReporter,
+        )
+
+        rows = self._rows(_report(CsvReporter, workspace_model, context))
+        header, *data = rows
+        project_index = header.index("workspace_project")
+        rule_index = header.index("rule_id")
+        by_project = {row[project_index]: row[rule_index] for row in data if row}
+        assert by_project == {"api": "RULE-API", "web": "RULE-WEB"}
+
+    def test_a_single_directory_scan_gains_no_column(self, single_model, context):
+        """The paired assertion: adding it unconditionally shifts every column.
+
+        A consumer that reads by position rather than by header would then read
+        the wrong field with no error, for every single-directory scan.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.csv_reporter import (
+            PROJECT_COLUMN,
+            CsvReporter,
+        )
+
+        rows = self._rows(_report(CsvReporter, single_model, context))
+        assert PROJECT_COLUMN not in rows[0]
+
+    def test_the_header_only_form_matches_the_populated_header(
+        self, workspace_model, context
+    ):
+        """A workspace with no findings must still declare the project column.
+
+        The empty case has its own hardcoded header list in this reporter, which
+        is exactly the kind of duplicate that drifts. Asserted by comparing the
+        two headers to each other rather than to a literal, so they cannot drift
+        apart in either direction.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.csv_reporter import (
+            CsvReporter,
+        )
+
+        populated = self._rows(_report(CsvReporter, workspace_model, context))[0]
+
+        empty = AshAggregatedResults()
+        empty.sarif = SarifReport.model_validate({"version": "2.1.0", "runs": []})
+        empty.workspace = workspace_model.workspace
+        assert self._rows(_report(CsvReporter, empty, context))[0] == populated
+
+
+class TestFlatJsonCarriesAProjectField:
+    def test_every_finding_names_its_project(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.flatjson_reporter import (
+            FlatJSONReporter,
+        )
+
+        payload = json.loads(_report(FlatJSONReporter, workspace_model, context))
+        assert {finding["workspace_project"] for finding in payload["findings"]} == set(
+            PROJECTS
+        )
+
+    def test_the_workspace_block_carries_the_per_project_verdicts(
+        self, workspace_model, context
+    ):
+        """Grouping must not require re-deriving a verdict from the findings.
+
+        A consumer that recomputed "did api fail" from the finding list would be
+        applying its own threshold, not the one api's own config set -- and would
+        get a different answer than the exit code for the same run.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.flatjson_reporter import (
+            FlatJSONReporter,
+        )
+
+        payload = json.loads(_report(FlatJSONReporter, workspace_model, context))
+        verdicts = {
+            entry["project"]: entry["exceeds_threshold"]
+            for entry in payload["workspace"]["projects"]
+        }
+        assert verdicts == {"api": True, "web": False}
+
+    def test_a_single_directory_scan_has_no_project_field_and_no_block(
+        self, single_model, context
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.flatjson_reporter import (
+            FlatJSONReporter,
+        )
+
+        payload = json.loads(_report(FlatJSONReporter, single_model, context))
+        assert "workspace" not in payload
+        for finding in payload["findings"]:
+            assert "workspace_project" not in finding
+
+
+class TestYamlCarriesTheWholeWorkspaceShape:
+    """No code change was needed here, so the test is the whole guarantee.
+
+    ``yaml`` dumps the entire model, which already carries the ``workspace``
+    block, all N runs, and per-finding attribution. Asserting it is what turns a
+    coincidence into a contract: a future change that narrowed the dump would
+    otherwise silently drop workspace attribution from this format alone.
+    """
+
+    @staticmethod
+    def _load(text: str):
+        import yaml
+
+        return yaml.safe_load(text)
+
+    def test_the_workspace_block_survives_the_dump(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.yaml_reporter import (
+            YamlReporter,
+        )
+
+        payload = self._load(_report(YamlReporter, workspace_model, context))
+        assert [entry["project"] for entry in payload["workspace"]["projects"]] == list(
+            PROJECTS
+        )
+
+    def test_every_run_survives_the_dump(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.yaml_reporter import (
+            YamlReporter,
+        )
+
+        payload = self._load(_report(YamlReporter, workspace_model, context))
+        assert len(payload["sarif"]["runs"]) == len(PROJECTS)
+
+    def test_each_finding_keeps_its_project_attribution(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.yaml_reporter import (
+            YamlReporter,
+        )
+
+        payload = self._load(_report(YamlReporter, workspace_model, context))
+        attributed = {
+            result["properties"]["workspace_project"]
+            for run in payload["sarif"]["runs"]
+            for result in run["results"]
+        }
+        assert attributed == set(PROJECTS)
+
+
+# --------------------------------------------------------------------------- #
+# Human-readable reporters: html, markdown, text
+# --------------------------------------------------------------------------- #
+
+
+class TestMarkdownHasAPerProjectSection:
+    @staticmethod
+    def _row(report: str, key: str) -> list[str]:
+        """The cells of one project's markdown table row."""
+        for line in report.splitlines():
+            if line.startswith(f"| {key} |"):
+                return [cell.strip() for cell in line.strip("|").split("|")]
+        raise AssertionError(f"no table row for project {key!r} in:\n{report}")
+
+    def test_every_project_appears_with_its_verdict(self, workspace_model, context):
+        """The verdict, not just the name.
+
+        The fixture is deliberately asymmetric: ``web`` has a finding but zero
+        *actionable* findings, so it passes. A renderer that decided PASSED/FAILED
+        from ``finding_count`` instead of from the project's recorded
+        ``exceeds_threshold`` would call it FAILED -- and would be applying one
+        threshold to projects that are independently configured, disagreeing with
+        the exit code for the same run. Asserting only that "web" appears somewhere
+        misses that entirely, which a mutation run showed it did.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+        )
+
+        report = _report(MarkdownReporter, workspace_model, context)
+        assert "## Projects" in report
+        assert self._row(report, "api")[-1] == "FAILED"
+        assert self._row(report, "web")[-1] == "PASSED"
+
+    def test_the_row_carries_the_counts_and_the_threshold(
+        self, workspace_model, context
+    ):
+        """So a reader can see *why* a project failed, not only that it did."""
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+        )
+
+        report = _report(MarkdownReporter, workspace_model, context)
+        api = self._row(report, "api")
+        assert api[2] == "1"  # findings
+        assert api[3] == "1"  # actionable
+        assert api[4] == "MEDIUM"  # threshold
+
+    def test_the_section_survives_compact_mode(self, workspace_model, context):
+        """Compact exists for PR comments, which is where this matters most.
+
+        In a monorepo PR the single most useful line is which project the
+        findings are in, so this is the one section compact must not drop.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+            MarkdownReporterConfig,
+            MarkdownReporterConfigOptions,
+        )
+
+        reporter = MarkdownReporter(
+            context=context,
+            config=MarkdownReporterConfig(
+                options=MarkdownReporterConfigOptions(compact=True)
+            ),
+        )
+        report = reporter.report(workspace_model)
+        assert "## Projects" in report
+        for key in PROJECTS:
+            assert f"| {key} |" in report
+
+    def test_a_single_directory_scan_has_no_such_section(self, single_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+        )
+
+        assert "## Projects" not in _report(MarkdownReporter, single_model, context)
+
+
+class TestTextHasAPerProjectSection:
+    def test_every_project_appears(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.text_reporter import (
+            TextReporter,
+        )
+
+        report = _report(TextReporter, workspace_model, context)
+        assert "PROJECTS" in report
+        for key in PROJECTS:
+            assert key in report
+
+    def test_the_project_table_columns_line_up_with_its_header(
+        self, workspace_model, context
+    ):
+        """This lands in a CI log, where a misaligned table is unreadable.
+
+        The same defect was fixed once already for the scanner table -- see
+        ``TestTextReporterColumnAlignment`` in
+        ``tests/unit/plugin_modules/test_reporter_regression.py`` -- so it is
+        asserted here rather than assumed for the new table.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.text_reporter import (
+            TextReporter,
+        )
+
+        lines = _report(TextReporter, workspace_model, context).splitlines()
+        start = next(index for index, line in enumerate(lines) if "PROJECTS" in line)
+        header = next(
+            line for line in lines[start:] if line.strip().startswith("Project")
+        )
+        rows = [line for line in lines[start:] if line.strip().startswith(PROJECTS)]
+        assert rows, "no project rows found under the PROJECTS heading"
+        for row in rows:
+            assert len(row.rstrip()) <= len(header.rstrip()) + 2
+
+    def test_a_single_directory_scan_has_no_such_section(self, single_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.text_reporter import (
+            TextReporter,
+        )
+
+        assert "PROJECTS" not in _report(TextReporter, single_model, context)
+
+
+class TestHtmlHasAPerProjectSection:
+    def test_every_project_appears_in_a_table(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.html_reporter import (
+            HtmlReporter,
+        )
+
+        report = _report(HtmlReporter, workspace_model, context)
+        assert "Projects" in report
+        for key in PROJECTS:
+            assert f"<td>{key}</td>" in report
+
+    def test_a_project_label_is_escaped(self, context, workspace_model):
+        """A project label reaches HTML from a config file, so it is untrusted.
+
+        ASH self-scans this repository at MEDIUM and an unescaped interpolation
+        into HTML is a finding, but the substantive reason is the same one it
+        always is: a label containing markup would otherwise rewrite the report.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.html_reporter import (
+            HtmlReporter,
+        )
+
+        workspace_model.workspace.projects[0].display_label = "<script>x</script>"
+        report = _report(HtmlReporter, workspace_model, context)
+        assert "<script>x</script>" not in report
+        assert "&lt;script&gt;" in report
+
+    def test_a_single_directory_scan_has_no_such_section(self, single_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.html_reporter import (
+            HtmlReporter,
+        )
+
+        report = _report(HtmlReporter, single_model, context)
+        assert "workspace-projects" not in report
+
+
+# --------------------------------------------------------------------------- #
+# Structured reporters: junitxml, ocsf
+# --------------------------------------------------------------------------- #
+
+
+class TestJunitXmlNamesTheProjectInTheSuite:
+    def test_the_suite_name_carries_both_project_and_scanner(
+        self, workspace_model, context
+    ):
+        """The deviation from the RFC, asserted rather than described.
+
+        The RFC said the project *becomes* the suite name. Taken literally that
+        discards the scanner grouping every JUnit front end renders. The compound
+        keeps both, with the project leading so one project's suites sort
+        together.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.junitxml_reporter import (
+            JunitXmlReporter,
+        )
+
+        tree = ElementTree.fromstring(
+            _report(JunitXmlReporter, workspace_model, context)
+        )
+        names = {suite.get("name") for suite in tree.iter("testsuite")}
+        assert {"api/bandit", "web/bandit"} <= names
+
+    def test_a_single_directory_scan_keeps_the_bare_scanner_name(
+        self, single_model, context
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.junitxml_reporter import (
+            JunitXmlReporter,
+        )
+
+        tree = ElementTree.fromstring(_report(JunitXmlReporter, single_model, context))
+        names = {suite.get("name") for suite in tree.iter("testsuite")}
+        assert "bandit" in names
+        assert not any(name and "/" in name for name in names)
+
+
+class TestOcsfCarriesTheProjectInMetadata:
+    """Carried in ``metadata.labels``, not as a ``metadata`` field.
+
+    The RFC asked for "the project in metadata", and OCSF's ``Metadata`` sets
+    ``extra="forbid"``. The trap is that pydantic's ``model_copy(update=...)``
+    *silently drops* an undeclared key rather than raising, so the obvious
+    implementation would have shipped findings with no attribution and nothing to
+    show it had failed. ``labels`` is the schema's own slot for free-form
+    annotation and is indexed by SIEMs, so the intent is met without extending
+    the schema.
+    """
+
+    def test_every_finding_names_its_project(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.ocsf_reporter import (
+            WORKSPACE_PROJECT_LABEL_PREFIX,
+            OcsfReporter,
+        )
+
+        findings = json.loads(_report(OcsfReporter, workspace_model, context))
+        attributed = {
+            label[len(WORKSPACE_PROJECT_LABEL_PREFIX) :]
+            for finding in findings
+            for label in finding["metadata"].get("labels", [])
+            if label.startswith(WORKSPACE_PROJECT_LABEL_PREFIX)
+        }
+        assert attributed == set(PROJECTS)
+
+    def test_no_finding_carries_more_than_one_project_label(
+        self, workspace_model, context
+    ):
+        """One ``Metadata`` instance is shared across every finding in the report.
+
+        Appending to its ``labels`` in place would give every finding every
+        project's label -- each one individually plausible, and the whole report
+        useless for routing. This is the assertion that catches a mutation where a
+        copy should have been made.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.ocsf_reporter import (
+            WORKSPACE_PROJECT_LABEL_PREFIX,
+            OcsfReporter,
+        )
+
+        findings = json.loads(_report(OcsfReporter, workspace_model, context))
+        assert findings
+        for finding in findings:
+            labels = [
+                label
+                for label in finding["metadata"].get("labels", [])
+                if label.startswith(WORKSPACE_PROJECT_LABEL_PREFIX)
+            ]
+            assert len(labels) == 1
+
+    def test_a_single_directory_scan_carries_no_project_label(
+        self, single_model, context
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.ocsf_reporter import (
+            WORKSPACE_PROJECT_LABEL_PREFIX,
+            OcsfReporter,
+        )
+
+        findings = json.loads(_report(OcsfReporter, single_model, context))
+        assert findings
+        for finding in findings:
+            for label in finding["metadata"].get("labels") or []:
+                assert not label.startswith(WORKSPACE_PROJECT_LABEL_PREFIX)
+
+
+# --------------------------------------------------------------------------- #
+# Workspace-scoped: unused-suppressions
+# --------------------------------------------------------------------------- #
+
+
+class TestUnusedSuppressionsStatesItsScope:
+    def test_the_workspace_report_says_it_covers_workspace_scope_only(
+        self, workspace_model, context
+    ):
+        """The whole point of the WORKSPACE_SCOPED ruling, made explicit in output.
+
+        Read as a merge, this reporter's zero counts mean "no unused suppressions
+        anywhere in the workspace". What they actually mean is "no workspace-level
+        suppressions". An operator who conflated the two would conclude their
+        per-project suppressions were all in use without any evidence for it.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.unused_suppressions_reporter import (
+            UnusedSuppressionsReporter,
+        )
+
+        payload = json.loads(
+            _report(UnusedSuppressionsReporter, workspace_model, context)
+        )
+        assert payload["scope"] == "workspace"
+        assert payload["summary"]["total_suppressions"] == 0
+
+    def test_it_points_at_the_per_project_reports(self, workspace_model, context):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.unused_suppressions_reporter import (
+            UnusedSuppressionsReporter,
+        )
+
+        payload = json.loads(
+            _report(UnusedSuppressionsReporter, workspace_model, context)
+        )
+        assert [entry["project"] for entry in payload["per_project_reports"]] == list(
+            PROJECTS
+        )
+
+    def test_a_single_directory_scan_declares_no_scope_key(self, single_model, context):
+        """The existing shape is unchanged, so existing consumers keep working."""
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.unused_suppressions_reporter import (
+            UnusedSuppressionsReporter,
+        )
+
+        payload = json.loads(_report(UnusedSuppressionsReporter, single_model, context))
+        assert "scope" not in payload
+        assert "per_project_reports" not in payload

--- a/tests/unit/workspace/test_project_attribution.py
+++ b/tests/unit/workspace/test_project_attribution.py
@@ -1,0 +1,326 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A per-project artefact has to say which project it is.
+
+Why this is part of the reporter contract and not a nice-to-have
+---------------------------------------------------------------
+Ten of the nineteen reporters are ruled PER_PROJECT: no workspace-level artefact,
+the per-project files are the answer. For that ruling to be true, the N artefacts
+have to be *distinguishable*. For the fifteen file-based reporters they are, by
+path -- ``projects/api/reports/ash.ghas.sarif`` versus
+``projects/web/reports/...``. For the four that publish to a shared destination
+they were not:
+
+* ``s3`` derives its object key from ``metadata.summary_stats.start`` with one
+  shared ``key_prefix`` -- and that field is ``None`` at report time, because the
+  engine assigns it in a ``finally`` block that runs after ``ReportPhase``. So the
+  key was the constant ``ash-report-None.json`` and *every* project overwrote
+  every other. Not a race that concurrency makes likely: a certainty.
+* ``cloudwatch_logs`` published N events to one log stream with nothing in the
+  payload naming the project.
+* ``security_hub`` and ``bedrock_summary`` had the same gap in their payloads.
+
+And ``metadata.project_name`` -- which ``html``, ``markdown`` and ``text`` print
+as "Project:" -- was the literal string ``"ASH"`` for every project, because it is
+hardcoded in ``AshAggregatedResults``'s default and is never derived from
+``AshConfig.project_name``. So every per-project human-readable report named the
+same project.
+
+The seam these tests span
+-------------------------
+Attribution is set by ``execute_workspace`` and honoured by the orchestrator, and
+those are two different pieces of code. Testing only the first would pass against
+an orchestrator that ignored what it was handed -- which is exactly what the
+orchestrator did before this, since its ``metadata`` parameter was declared and
+never read. So both ends are asserted: that the workspace passes the right thing,
+and that the orchestrator puts it where reporters look.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.schemas.sarif_schema_model import SarifReport
+from automated_security_helper.workspace.execution import (
+    ProjectScanSettings,
+    execute_workspace,
+)
+from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+
+WORKSPACE_PROJECT_KEY = "workspace_project"
+
+
+def _plan(root: Path, *projects) -> WorkspacePlan:
+    """*projects* are ``(key, display_label)`` pairs."""
+    (root).mkdir(parents=True, exist_ok=True)
+    (root / "fixture.code-workspace").write_text(
+        json.dumps({"folders": [{"path": key} for key, _ in projects]}),
+        encoding="utf-8",
+    )
+    entries = []
+    for key, label in projects:
+        (root / key / "src").mkdir(parents=True, exist_ok=True)
+        entries.append(
+            ProjectPlan(
+                key=key,
+                relative_path=key,
+                path=(root / key).as_posix(),
+                label=label,
+                display_label=label,
+                severity_threshold="MEDIUM",
+            )
+        )
+    return WorkspacePlan(
+        workspace_file=(root / "fixture.code-workspace").as_posix(),
+        workspace_root=root.as_posix(),
+        projects=entries,
+    )
+
+
+class _RecordingOrchestrator:
+    """Records the ``metadata`` it was constructed with, per project."""
+
+    seen: dict = {}
+
+    def __init__(self, **kwargs):
+        self.key = Path(kwargs["source_dir"]).name
+        _RecordingOrchestrator.seen[self.key] = kwargs.get("metadata")
+
+    @classmethod
+    def create(cls, **kwargs):
+        return cls(**kwargs)
+
+    def execute_scan(self, phases=None):
+        model = AshAggregatedResults()
+        model.sarif = SarifReport.model_validate({"version": "2.1.0", "runs": []})
+        return model
+
+
+@pytest.fixture(autouse=True)
+def _reset_recorder():
+    _RecordingOrchestrator.seen = {}
+    yield
+    _RecordingOrchestrator.seen = {}
+
+
+class TestTheWorkspaceHandsEachProjectItsOwnIdentity:
+    def test_each_project_is_given_its_label_and_key(self, tmp_path):
+        plan = _plan(tmp_path / "ws", ("api", "Payments API"), ("web", "web"))
+        execute_workspace(
+            plan,
+            ProjectScanSettings(output_dir=tmp_path / "out", phases=("scan",)),
+            orchestrator_factory=_RecordingOrchestrator.create,
+        )
+
+        assert _RecordingOrchestrator.seen["api"] == {
+            "project_name": "Payments API",
+            WORKSPACE_PROJECT_KEY: "api",
+        }
+        assert _RecordingOrchestrator.seen["web"] == {
+            "project_name": "web",
+            WORKSPACE_PROJECT_KEY: "web",
+        }
+
+    def test_two_projects_never_receive_the_same_identity(self, tmp_path):
+        """The property that makes the PER_PROJECT ruling honest.
+
+        Asserted as distinctness rather than against literals, because the defect
+        was not a wrong name -- it was the *same* name for every project, which any
+        per-project literal assertion would still have passed against.
+        """
+        plan = _plan(tmp_path / "ws", ("api", "api"), ("web", "web"), ("cli", "cli"))
+        execute_workspace(
+            plan,
+            ProjectScanSettings(output_dir=tmp_path / "out", phases=("scan",)),
+            orchestrator_factory=_RecordingOrchestrator.create,
+        )
+
+        identities = [
+            (value["project_name"], value[WORKSPACE_PROJECT_KEY])
+            for value in _RecordingOrchestrator.seen.values()
+        ]
+        assert len(identities) == 3
+        assert len(set(identities)) == 3
+
+
+class TestTheOrchestratorHonoursWhatItIsHanded:
+    """The other half of the seam.
+
+    ``ASHScanOrchestrator.metadata`` was declared and read nowhere -- a dead
+    parameter. So "the workspace passes the right thing" proved nothing on its
+    own, and this is the assertion that closes the gap.
+    """
+
+    @staticmethod
+    def _orchestrator(tmp_path, metadata):
+        from automated_security_helper.core.orchestrator import ASHScanOrchestrator
+
+        source = tmp_path / "src"
+        source.mkdir(parents=True, exist_ok=True)
+        return ASHScanOrchestrator.create(
+            source_dir=source,
+            output_dir=tmp_path / "out",
+            metadata=metadata,
+        )
+
+    def test_the_metadata_reaches_the_results_model(self, tmp_path):
+        orchestrator = self._orchestrator(
+            tmp_path, {"project_name": "Payments API", WORKSPACE_PROJECT_KEY: "api"}
+        )
+        metadata = orchestrator.execution_engine._asharp_model.metadata
+
+        assert metadata.project_name == "Payments API"
+        assert getattr(metadata, WORKSPACE_PROJECT_KEY) == "api"
+
+    def test_no_metadata_leaves_the_defaults_alone(self, tmp_path):
+        """A single-directory scan is unchanged, so no existing output moves."""
+        orchestrator = self._orchestrator(tmp_path, None)
+        metadata = orchestrator.execution_engine._asharp_model.metadata
+
+        assert metadata.project_name == "ASH"
+        assert getattr(metadata, WORKSPACE_PROJECT_KEY, None) is None
+
+    def test_an_empty_name_is_refused_rather_than_written(self, tmp_path):
+        """``project_name`` has a min_length validator, so it must not be bypassed.
+
+        Assigning past a pydantic validator is easy to do by accident and the
+        result is a model that cannot be serialised later, a long way from the
+        assignment. Better to ignore an unusable value here and keep the default.
+        """
+        orchestrator = self._orchestrator(tmp_path, {"project_name": "   "})
+        assert (
+            orchestrator.execution_engine._asharp_model.metadata.project_name == "ASH"
+        )
+
+
+class TestS3KeysCannotCollideAcrossProjects:
+    """``PutObject`` overwrites, so a colliding key loses a project's report.
+
+    The reporter is PER_PROJECT, so in a workspace it runs N times against N
+    single-project models -- each with ``workspace=None``, because a project does
+    not know it is in a workspace. ``metadata.workspace_project`` is how it finds
+    out, which is the whole reason that field exists.
+    """
+
+    @staticmethod
+    def _key(tmp_path, project, start):
+        from unittest.mock import MagicMock, patch
+
+        from automated_security_helper.base.plugin_context import PluginContext
+        from automated_security_helper.config.ash_config import AshConfig
+        from automated_security_helper.plugin_modules.ash_aws_plugins.s3_reporter import (
+            S3Reporter,
+            S3ReporterConfig,
+            S3ReporterConfigOptions,
+        )
+
+        model = AshAggregatedResults()
+        model.metadata.summary_stats.start = start
+        if project is not None:
+            setattr(model.metadata, WORKSPACE_PROJECT_KEY, project)
+
+        reporter = S3Reporter(
+            context=PluginContext(
+                source_dir=tmp_path,
+                output_dir=tmp_path / "out",
+                config=AshConfig(),
+            ),
+            config=S3ReporterConfig(
+                options=S3ReporterConfigOptions(
+                    bucket_name="fixture-bucket",
+                    aws_region="us-east-1",
+                )
+            ),
+        )
+
+        captured = {}
+
+        # *args because patch.object replaces the bound method with a plain
+        # function, so it receives self and the client positionally.
+        def _capture(*args, **kwargs):
+            captured.update(kwargs)
+
+        with patch("boto3.Session", MagicMock()):
+            with patch.object(S3Reporter, "_put_object_with_retry", _capture):
+                reporter.report(model)
+        return captured["Key"]
+
+    def test_the_start_timestamp_is_unset_when_a_reporter_runs(self, tmp_path):
+        """The premise the collision rests on, pinned rather than assumed.
+
+        ``ScanExecutionEngine.execute_phases`` assigns
+        ``metadata.summary_stats.start`` in a ``finally`` block that runs *after*
+        ``ReportPhase``, so every reporter observes ``None`` and the key is the
+        constant ``ash-report-None.json``. Verified against a real scan by probing
+        ``ReportPhase._execute_phase``; asserted here on the default so that a
+        future change which sets it earlier shows up as a failure of this
+        assumption rather than as a silently different key.
+        """
+        from automated_security_helper.plugin_modules.ash_aws_plugins.s3_reporter import (
+            S3ReporterConfigOptions,
+        )
+
+        prefix = S3ReporterConfigOptions.model_fields["key_prefix"].default
+        model = AshAggregatedResults()
+        assert model.metadata.summary_stats.start is None
+        assert (
+            self._key(tmp_path, None, model.metadata.summary_stats.start)
+            == f"{prefix}ash-report-None.json"
+        )
+
+    def test_every_project_gets_a_different_key(self, tmp_path):
+        """The collision, reproduced and then closed.
+
+        The timestamp is ``None`` for both, which is what a real scan produces --
+        so this is not a same-instant race but the certainty that every project
+        computed one identical key. ``PutObject`` overwrites, so before the project
+        segment N-1 projects' reports vanished with no message.
+        """
+        shared = None
+        api = self._key(tmp_path, "api", shared)
+        web = self._key(tmp_path, "web", shared)
+
+        assert api != web
+        assert "api" in api
+        assert "web" in web
+
+    def test_a_single_directory_scan_keeps_its_existing_key_shape(self, tmp_path):
+        """No workspace attribution means the key is what it has always been.
+
+        Composed from the reporter's own default ``key_prefix`` rather than
+        written out, so this asserts "nothing was inserted" rather than pinning
+        the prefix's current value -- which is ``ash-reports/`` and is not this
+        test's business.
+
+        A non-``None`` timestamp is used here and in the test below because these
+        two are about *where the project segment goes*, and a placeholder value
+        makes that readable. A real scan yields ``None``; that is pinned by
+        ``test_the_start_timestamp_is_unset_when_a_reporter_runs``.
+        """
+        from automated_security_helper.plugin_modules.ash_aws_plugins.s3_reporter import (
+            S3ReporterConfigOptions,
+        )
+
+        start = "2026-08-25T00:00:00+00:00"
+        prefix = S3ReporterConfigOptions.model_fields["key_prefix"].default
+        assert self._key(tmp_path, None, start) == f"{prefix}ash-report-{start}.json"
+
+    def test_the_project_segment_is_the_only_difference(self, tmp_path):
+        """Pins where the project goes, so the workspace key stays predictable.
+
+        Without this, the collision test above would pass against a key that had
+        become unrecognisable to anyone with a lifecycle rule or a bucket prefix
+        filter written against the old shape.
+        """
+        from automated_security_helper.plugin_modules.ash_aws_plugins.s3_reporter import (
+            S3ReporterConfigOptions,
+        )
+
+        start = "2026-08-25T00:00:00+00:00"
+        prefix = S3ReporterConfigOptions.model_fields["key_prefix"].default
+        assert (
+            self._key(tmp_path, "api", start) == f"{prefix}api/ash-report-{start}.json"
+        )

--- a/tests/unit/workspace/test_reporter_workspace_behaviour.py
+++ b/tests/unit/workspace/test_reporter_workspace_behaviour.py
@@ -1,0 +1,220 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Every reporter states what it does with an N-project model, and is held to it.
+
+Why this file exists
+--------------------
+Before Phase 2b a workspace scan emitted no workspace-level report at all, and
+the reason was one line: ``github_ghas_reporter`` did ``run = sarif.runs[0]``.
+Against the N-run SARIF the aggregator writes, that emits the first project's
+findings and drops the rest -- no error, no warning, a smaller file that looks
+fine. A security reporter that under-reports silently is the worst failure this
+feature can have, so the fix is not "make every reporter merge" but "make every
+reporter *state* what it does, and make the driver hold it to that".
+
+These tests are the enforcement. They assert three things:
+
+1. Every shipped reporter declares a behaviour. A new reporter added without one
+   inherits the fail-closed default rather than being handed a shape it has never
+   seen -- and the exhaustiveness test below fails, so the omission is visible.
+2. The declared set is exactly the RFC's table. A ruling changed in code without
+   changing the table, or vice versa, fails here.
+3. The default is ``PER_PROJECT``, and that is a deliberate fail-closed choice.
+   See ``test_the_default_is_per_project_and_that_is_fail_closed``.
+"""
+
+import inspect
+import pkgutil
+from importlib import import_module
+from typing import get_args
+
+import pytest
+
+from automated_security_helper.base.reporter_plugin import (
+    ReporterPluginBase,
+    ReporterWorkspaceBehaviour,
+)
+
+#: The RFC's reporter table, transcribed. Keyed on the reporter's configured
+#: ``name`` rather than its class name, because that is the identifier an
+#: operator writes in ``--output-format`` and in config.
+#:
+#: Every entry is asserted twice over: that the class declares this value, and
+#: that the driver does what the value means (see
+#: ``test_workspace_reporting.py``). A table that agreed with the code but not
+#: with the behaviour would be the same defect this file exists to prevent.
+EXPECTED_BEHAVIOURS = {
+    # --- Merged: one workspace artefact, project carried inside it. -----------
+    "sarif": ReporterWorkspaceBehaviour.MERGED,
+    "html": ReporterWorkspaceBehaviour.MERGED,
+    "markdown": ReporterWorkspaceBehaviour.MERGED,
+    "text": ReporterWorkspaceBehaviour.MERGED,
+    "csv": ReporterWorkspaceBehaviour.MERGED,
+    "flat-json": ReporterWorkspaceBehaviour.MERGED,
+    "yaml": ReporterWorkspaceBehaviour.MERGED,
+    "junitxml": ReporterWorkspaceBehaviour.MERGED,
+    "ocsf": ReporterWorkspaceBehaviour.MERGED,
+    # --- Per project: the per-project artefacts are the answer. ---------------
+    # Merging these is wrong for one of three reasons, each recorded in the
+    # reporter's own module docstring: the consumer ingests against a single
+    # repository root (github-ghas, gitlab-sast), the artefact is an
+    # independently versioned deliverable (the three SBOMs), or the reporter
+    # publishes a side effect that merging would duplicate (the four AWS ones).
+    "github-ghas": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "gitlab-sast": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "cyclonedx": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "gitlab-cyclonedx": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "spdx": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "aws-security-hub": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "bedrock-summary-reporter": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "cloudwatch-logs": ReporterWorkspaceBehaviour.PER_PROJECT,
+    "s3": ReporterWorkspaceBehaviour.PER_PROJECT,
+    # --- Workspace-scoped: a workspace artefact that is not a merge. ----------
+    "unused-suppressions": ReporterWorkspaceBehaviour.WORKSPACE_SCOPED,
+}
+
+#: How many reporters ship. Pinned as a literal so that adding a reporter
+#: without ruling on its workspace behaviour fails this file rather than
+#: silently inheriting a default nobody chose.
+SHIPPED_REPORTER_COUNT = 19
+
+
+def _iter_reporter_classes():
+    """Every concrete ``ReporterPluginBase`` subclass the package ships.
+
+    Discovered by walking the plugin packages rather than by importing a
+    hand-written list, because a hand-written list is exactly the thing that
+    goes stale when a reporter is added.
+    """
+    import automated_security_helper.plugin_modules as plugin_modules
+
+    found = {}
+    for module_info in pkgutil.walk_packages(
+        plugin_modules.__path__, prefix=f"{plugin_modules.__name__}."
+    ):
+        if "reporter" not in module_info.name:
+            continue
+        module = import_module(module_info.name)
+        for _, obj in inspect.getmembers(module, inspect.isclass):
+            if not issubclass(obj, ReporterPluginBase) or obj is ReporterPluginBase:
+                continue
+            if inspect.isabstract(obj):
+                continue
+            if obj.__module__ != module_info.name:
+                # Re-exported from somewhere else; count it once, at its home.
+                continue
+            found[obj.__name__] = obj
+    return found
+
+
+def _configured_name(reporter_class) -> str:
+    """The reporter's configured ``name``, read off its config class default.
+
+    Read from the config rather than from the class name because ``name`` is what
+    an operator types in ``--output-format`` and in config, and the two do not
+    always match -- ``FlatJSONReporter`` is ``flat-json`` and
+    ``SecurityHubReporter`` is ``aws-security-hub``.
+
+    Resolved from the ``config`` field's resolved annotation, which pydantic
+    renders as ``Union[XConfig, ReporterPluginConfigBase, None]``. Deliberately
+    not from ``__orig_bases__``: pydantic's metaclass does not leave the
+    ``ReporterPluginBase[XConfig]`` parameterisation on the subclass, so
+    ``__orig_bases__`` resolves up to ``ReporterPluginBase``'s own bases and
+    yields the unbound ``TypeVar`` for every reporter alike.
+    """
+    for candidate in get_args(reporter_class.model_fields["config"].annotation):
+        fields = getattr(candidate, "model_fields", None)
+        if not fields:
+            continue
+        name_field = fields.get("name")
+        # ReporterPluginConfigBase is also in the Union and has no name default.
+        if name_field is not None and isinstance(name_field.default, str):
+            return name_field.default
+    raise AssertionError(f"{reporter_class.__name__} declares no config name")
+
+
+class TestEveryReporterDeclaresABehaviour:
+    def test_the_shipped_reporter_count_is_what_the_table_covers(self):
+        """A reporter added without a ruling fails here, not silently at runtime."""
+        discovered = _iter_reporter_classes()
+        assert len(discovered) == SHIPPED_REPORTER_COUNT, (
+            f"found {len(discovered)} reporters, expected {SHIPPED_REPORTER_COUNT}: "
+            f"{sorted(discovered)}"
+        )
+        assert len(EXPECTED_BEHAVIOURS) == SHIPPED_REPORTER_COUNT
+
+    def test_every_reporter_declares_the_behaviour_the_table_states(self):
+        discovered = _iter_reporter_classes()
+        actual = {
+            _configured_name(cls): cls.workspace_behaviour
+            for cls in discovered.values()
+        }
+        assert actual == EXPECTED_BEHAVIOURS
+
+    @pytest.mark.parametrize("name", sorted(EXPECTED_BEHAVIOURS))
+    def test_each_declared_behaviour_is_a_member_of_the_enum(self, name):
+        """Guards against a string literal drifting from the enum.
+
+        ``PluginBase`` sets ``use_enum_values=True``, so a *field* holding an
+        enum would serialise to its value and compare equal to a typo'd string.
+        ``workspace_behaviour`` is a ClassVar precisely so that does not apply,
+        and this asserts the distinction still holds.
+        """
+        assert EXPECTED_BEHAVIOURS[name] in set(ReporterWorkspaceBehaviour)
+
+
+class TestTheDefaultIsFailClosed:
+    def test_the_default_is_per_project_and_that_is_fail_closed(self):
+        """The default must not be MERGED, and the reason is the ghas bug.
+
+        A third-party reporter written against single-directory ASH has never
+        seen an N-run SARIF. Defaulting to MERGED would hand it one and trust it
+        to cope; ``github_ghas_reporter``'s ``runs[0]`` is the proof that a
+        reporter in that position under-reports without saying anything.
+
+        PER_PROJECT is the safe default because it is not a refusal: the
+        reporter's per-project artefacts under ``projects/<key>/reports/`` still
+        exist and are still correct, and the driver records where they are. So
+        the fail-closed choice costs an undeclared reporter nothing except a
+        workspace-level file it was never able to produce correctly.
+
+        UNSUPPORTED was rejected as the default for the opposite reason -- it
+        would fail the whole workspace run for any external plugin.
+        """
+        assert (
+            ReporterPluginBase.workspace_behaviour
+            is ReporterWorkspaceBehaviour.PER_PROJECT
+        )
+
+    def test_a_reporter_that_declares_nothing_inherits_the_default(self):
+        """Constructed by subclassing, so this cannot pass by reading the base."""
+
+        class UndeclaredReporter(ReporterPluginBase):
+            def report(self, model):  # pragma: no cover - never invoked
+                return ""
+
+        assert (
+            UndeclaredReporter.workspace_behaviour
+            is ReporterWorkspaceBehaviour.PER_PROJECT
+        )
+
+    def test_a_subclass_can_override_the_inherited_default(self):
+        """The companion assertion: inheritance is not the only path.
+
+        Without this, ``test_a_reporter_that_declares_nothing_inherits_the_default``
+        would still pass if the attribute were impossible to override at all,
+        which would make every declaration in EXPECTED_BEHAVIOURS a no-op.
+        """
+
+        class DeclaredReporter(ReporterPluginBase):
+            workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+            def report(self, model):  # pragma: no cover - never invoked
+                return ""
+
+        assert DeclaredReporter.workspace_behaviour is ReporterWorkspaceBehaviour.MERGED
+        assert (
+            ReporterPluginBase.workspace_behaviour
+            is ReporterWorkspaceBehaviour.PER_PROJECT
+        )

--- a/tests/unit/workspace/test_workspace_policy.py
+++ b/tests/unit/workspace/test_workspace_policy.py
@@ -1,0 +1,743 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the workspace-level policy file.
+
+These are the acceptance criteria for Phase 3 (criteria 7, 19, 20, 21).
+
+Two biases run through the whole file, and they point in opposite directions on
+purpose:
+
+* **The ceiling may only tighten.** ``max_severity_threshold`` names the loosest
+  a project may be, so a project that is already stricter is left exactly as it
+  was. A test that cannot tell "tightened" from "replaced" is worthless here,
+  so every threshold case asserts the untouched direction as well.
+* **A pushed-down pattern may only narrow.** A workspace suppression that ASH
+  cannot rewrite soundly for a project is refused, and one that cannot match
+  inside a project is not passed to it. Over-suppression is the dangerous
+  direction because a suppressed finding leaves no trace -- see
+  ``utils/workspace_paths.py``.
+"""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from automated_security_helper.config.ash_workspace_config import (
+    AshWorkspaceConfig,
+    WorkspacePolicyConfig,
+)
+from automated_security_helper.core.exceptions import (
+    WorkspaceDefinitionError,
+    WorkspacePatternError,
+)
+from automated_security_helper.models.core import (
+    AshSuppression,
+    IgnorePathWithReason,
+)
+from automated_security_helper.workspace.policy import (
+    WORKSPACE_POLICY_FILE_NAMES,
+    ceiling_unreachable_counts,
+    policy_for_project,
+    resolve_workspace_policy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _policy(**fields):
+    """A WorkspacePolicyConfig with *fields* set and everything else default."""
+    return WorkspacePolicyConfig(**fields)
+
+
+def _write(path, text):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def _suppression(path, **extra):
+    return AshSuppression(path=path, reason="test", **extra)
+
+
+# ---------------------------------------------------------------------------
+# 1. The schema itself
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_policy_file_is_valid_and_carries_no_policy():
+    """A policy file that sets nothing must not invent a threshold.
+
+    Defaulting max_severity_threshold to MEDIUM here would silently tighten
+    every project in a workspace whose operator wrote an empty file.
+    """
+    config = AshWorkspaceConfig()
+    assert config.workspace.max_severity_threshold is None
+    assert config.workspace.suppressions == []
+    assert config.workspace.ignore_paths == []
+    assert config.workspace.additional_scanners == []
+    assert config.workspace.policy_scanners_gate is False
+
+
+def test_an_unknown_policy_key_is_refused():
+    """extra=forbid, so a typo is an error rather than a silently ignored key."""
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate(
+            {"workspace": {"max_severity_threshhold": "HIGH"}}
+        )
+
+
+def test_an_unknown_top_level_key_is_refused():
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate({"global_settings": {}})
+
+
+@pytest.mark.parametrize("value", ["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"])
+def test_every_ladder_value_is_accepted_as_a_ceiling(value):
+    config = AshWorkspaceConfig.model_validate(
+        {"workspace": {"max_severity_threshold": value}}
+    )
+    assert config.workspace.max_severity_threshold == value
+
+
+@pytest.mark.parametrize("value", ["medium", "SEVERE", "", "NONE"])
+def test_an_off_ladder_ceiling_is_refused(value):
+    """The ladder is case-sensitive, so 'medium' must not be accepted.
+
+    severity_ladder gates an unrecognised threshold like CRITICAL -- the
+    loosest setting -- so accepting 'medium' here would quietly turn a ceiling
+    the operator meant as MEDIUM into no ceiling at all.
+    """
+    with pytest.raises(ValidationError):
+        AshWorkspaceConfig.model_validate(
+            {"workspace": {"max_severity_threshold": value}}
+        )
+
+
+def test_the_generated_schema_includes_the_workspace_config():
+    """The lint job regenerates schemas and fails on a diff, so it must be listed."""
+    from automated_security_helper.schemas.generate_schemas import generate_schemas
+
+    schemas = generate_schemas("dict")
+    assert "AshWorkspaceConfig" in schemas
+    properties = schemas["AshWorkspaceConfig"]["properties"]
+    assert "workspace" in properties
+
+
+# ---------------------------------------------------------------------------
+# 2. The ceiling tightens a lax project and leaves a strict one alone
+# ---------------------------------------------------------------------------
+
+
+def test_a_project_looser_than_the_ceiling_is_tightened():
+    """CRITICAL is the loosest setting, so a MEDIUM ceiling must pull it in."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="MEDIUM"),
+        project_prefix="api",
+        project_threshold="CRITICAL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "MEDIUM"
+    assert resolved.threshold_tightened is True
+
+
+def test_a_project_stricter_than_the_ceiling_is_untouched():
+    """LOW is stricter than MEDIUM, so the ceiling must not loosen it to MEDIUM."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="MEDIUM"),
+        project_prefix="api",
+        project_threshold="LOW",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "LOW"
+    assert resolved.threshold_tightened is False
+
+
+def test_the_strictest_project_setting_survives_the_loosest_ceiling():
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="CRITICAL"),
+        project_prefix="api",
+        project_threshold="ALL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "ALL"
+    assert resolved.threshold_tightened is False
+
+
+def test_no_ceiling_leaves_the_project_threshold_exactly_as_it_was():
+    resolved = policy_for_project(
+        _policy(),
+        project_prefix="api",
+        project_threshold="CRITICAL",
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "CRITICAL"
+    assert resolved.threshold_tightened is False
+
+
+def test_a_project_with_the_gate_turned_off_is_still_tightened_by_the_ceiling():
+    """A falsy project threshold means "nothing fails", which is looser than any
+    ceiling. The ceiling has to reach it, or an operator could opt out of
+    workspace policy by deleting their own threshold."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold="HIGH"),
+        project_prefix="api",
+        project_threshold=None,
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == "HIGH"
+    assert resolved.threshold_tightened is True
+
+
+@pytest.mark.parametrize(
+    "project,ceiling,expected",
+    [
+        ("CRITICAL", "HIGH", "HIGH"),
+        ("CRITICAL", "MEDIUM", "MEDIUM"),
+        ("HIGH", "MEDIUM", "MEDIUM"),
+        ("HIGH", "CRITICAL", "HIGH"),
+        ("MEDIUM", "MEDIUM", "MEDIUM"),
+        ("LOW", "HIGH", "LOW"),
+        ("ALL", "LOW", "ALL"),
+    ],
+)
+def test_the_effective_threshold_is_the_stricter_of_the_two(project, ceiling, expected):
+    """The RFC's worked table, plus the untouched direction for each row."""
+    resolved = policy_for_project(
+        _policy(max_severity_threshold=ceiling),
+        project_prefix="api",
+        project_threshold=project,
+        project_scanners=(),
+    )
+    assert resolved.effective_threshold == expected
+
+
+def test_the_effective_threshold_is_never_looser_than_the_project_asked_for():
+    """Property: over every pair, the ceiling can only tighten or do nothing.
+
+    The strictness order is spelled out here rather than imported from
+    severity_ladder ON PURPOSE. Asserting against ``stricter_of`` would compare
+    the implementation to itself -- both sides would derive from the same
+    function, so an inverted ladder would satisfy the test. This table is an
+    independent statement of the order the RFC specifies, so if the two ever
+    disagree the test fails rather than agreeing with the bug.
+    """
+    # Strictest first. Raising a threshold LOOSENS the gate.
+    order = ["ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+    checked = 0
+    for project in order:
+        for ceiling in order:
+            resolved = policy_for_project(
+                _policy(max_severity_threshold=ceiling),
+                project_prefix="api",
+                project_threshold=project,
+                project_scanners=(),
+            )
+            effective = resolved.effective_threshold
+
+            # The result is one of the two inputs, and it is the stricter one --
+            # i.e. the earlier one in the order above.
+            assert effective in (project, ceiling)
+            assert order.index(effective) == min(
+                order.index(project), order.index(ceiling)
+            ), f"project={project} ceiling={ceiling} gave {effective}"
+            # And never looser than the project already was.
+            assert order.index(effective) <= order.index(project)
+            checked += 1
+
+    assert checked == len(order) ** 2
+
+
+# ---------------------------------------------------------------------------
+# 3. Suppressions and ignore_paths are pushed DOWN into each project
+# ---------------------------------------------------------------------------
+
+
+def test_a_suppression_anchored_at_one_project_reaches_only_that_project():
+    """The whole point of the push-down: api's suppression must not silence web."""
+    policy = _policy(suppressions=[_suppression("api/src/legacy.py")])
+
+    for_api = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    for_web = policy_for_project(
+        policy,
+        project_prefix="web",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+
+    assert [s.path for s in for_api.suppressions] == ["src/legacy.py"]
+    assert for_web.suppressions == ()
+
+
+def test_a_double_star_suppression_reaches_every_project():
+    policy = _policy(suppressions=[_suppression("**/generated.py")])
+
+    for prefix in ("api", "web", "services/worker"):
+        resolved = policy_for_project(
+            policy,
+            project_prefix=prefix,
+            project_threshold="MEDIUM",
+            project_scanners=(),
+        )
+        assert [s.path for s in resolved.suppressions] == ["**/generated.py"], prefix
+
+
+def test_a_suppression_naming_only_the_project_directory_is_not_passed_down():
+    """ "api" matches the path "api", not "api/src/x.py", so it covers no file.
+
+    Passing "**" here would suppress an entire project the operator never asked
+    to silence -- the failure the workspace_paths contract sweep caught.
+    """
+    policy = _policy(suppressions=[_suppression("api")])
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.suppressions == ()
+
+
+def test_an_unrewritable_suppression_is_refused_and_names_the_pattern():
+    """A pattern with no sound single-pattern rewrite must not be dropped quietly.
+
+    Dropping it would leave the operator's stated policy unapplied with nothing
+    in the output to say so; ``*/sub/*.py`` is the two-glob-semantics case from
+    workspace_paths.
+    """
+    policy = _policy(suppressions=[_suppression("*/sub/*.py")])
+    with pytest.raises((WorkspaceDefinitionError, WorkspacePatternError)) as excinfo:
+        policy_for_project(
+            policy,
+            project_prefix="api",
+            project_threshold="MEDIUM",
+            project_scanners=(),
+        )
+    assert "*/sub/*.py" in str(excinfo.value)
+
+
+def test_ignore_paths_are_pushed_down_the_same_way_as_suppressions():
+    policy = _policy(
+        ignore_paths=[
+            IgnorePathWithReason(path="api/vendor/**", reason="third party"),
+            IgnorePathWithReason(path="web/dist/**", reason="build output"),
+        ]
+    )
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert [p.path for p in resolved.ignore_paths] == ["vendor/**"]
+
+
+def test_everything_except_the_path_survives_the_push_down_unchanged():
+    """Rewriting the path must not drop the rule_id, reason, lines or expiry.
+
+    A suppression that loses its rule_id widens from "this rule here" to
+    "every rule here".
+    """
+    policy = _policy(
+        suppressions=[
+            AshSuppression(
+                path="api/src/x.py",
+                reason="tracked in TICKET-1",
+                rule_id="B101",
+                line_start=10,
+                line_end=20,
+                expiration="2099-01-01",
+            )
+        ]
+    )
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+
+    (pushed,) = resolved.suppressions
+    assert pushed.path == "src/x.py"
+    assert pushed.reason == "tracked in TICKET-1"
+    assert pushed.rule_id == "B101"
+    assert pushed.line_start == 10
+    assert pushed.line_end == 20
+    assert pushed.expiration == "2099-01-01"
+
+
+def test_the_pushed_down_suppression_is_a_copy_not_the_policy_object():
+    """Each project gets its own object, or rewriting one would rewrite all.
+
+    The policy is shared across projects, so mutating in place would leave the
+    second project's push-down operating on the first project's coordinates.
+    """
+    original = _suppression("api/src/x.py")
+    policy = _policy(suppressions=[original])
+    resolved = policy_for_project(
+        policy,
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.suppressions[0] is not original
+    assert original.path == "api/src/x.py"
+
+
+# ---------------------------------------------------------------------------
+# 4. additional_scanners are additive, and policy-origin ones do not gate
+# ---------------------------------------------------------------------------
+
+
+def test_a_scanner_the_project_already_declares_is_not_policy_origin():
+    """It runs under the project's own config, so it is the project's finding."""
+    resolved = policy_for_project(
+        _policy(additional_scanners=["bandit"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("bandit", "checkov"),
+    )
+    assert resolved.policy_scanners == ()
+
+
+def test_a_scanner_only_the_policy_names_is_policy_origin():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("bandit",),
+    )
+    assert resolved.policy_scanners == ("semgrep",)
+
+
+def test_policy_origin_scanners_do_not_gate_by_default():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.policy_scanners == ("semgrep",)
+    assert resolved.policy_scanners_gate is False
+
+
+def test_policy_origin_scanners_gate_when_the_operator_opts_in():
+    resolved = policy_for_project(
+        _policy(additional_scanners=["semgrep"], policy_scanners_gate=True),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=(),
+    )
+    assert resolved.policy_scanners_gate is True
+
+
+def test_the_scanner_comparison_ignores_case_and_separator_style():
+    """--scanners accepts the alias form, so cdk-nag and cdk_nag are one scanner.
+
+    Treating them as different would run a second copy under default config and
+    report its findings as policy-origin duplicates of the project's own.
+    """
+    resolved = policy_for_project(
+        _policy(additional_scanners=["cdk-nag"]),
+        project_prefix="api",
+        project_threshold="MEDIUM",
+        project_scanners=("cdk_nag",),
+    )
+    assert resolved.policy_scanners == ()
+
+
+# ---------------------------------------------------------------------------
+# 5. Finding the policy file, and refusing to read a project's config as one
+# ---------------------------------------------------------------------------
+
+
+def test_the_policy_file_names_are_disjoint_from_the_project_config_names():
+    """Structural guarantee that discovery can never pick up a project config."""
+    from automated_security_helper.core.constants import ASH_CONFIG_FILE_NAMES
+
+    assert not set(WORKSPACE_POLICY_FILE_NAMES) & set(ASH_CONFIG_FILE_NAMES)
+
+
+def test_a_policy_file_beside_the_workspace_file_is_discovered(tmp_path):
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: HIGH\n",
+    )
+    config, source = resolve_workspace_policy(tmp_path)
+    assert config.workspace.max_severity_threshold == "HIGH"
+    assert source == (tmp_path / ".ash" / "ash-workspace.yaml").resolve()
+
+
+def test_no_policy_file_at_all_is_not_an_error(tmp_path):
+    """Workspace policy is opt-in; Phase 2b behaviour must survive its absence."""
+    config, source = resolve_workspace_policy(tmp_path)
+    assert config is None
+    assert source is None
+
+
+def test_an_explicit_policy_file_is_used(tmp_path):
+    explicit = _write(
+        tmp_path / "custom-policy.yaml",
+        "workspace:\n  max_severity_threshold: LOW\n",
+    )
+    config, source = resolve_workspace_policy(tmp_path, explicit=explicit)
+    assert config.workspace.max_severity_threshold == "LOW"
+    assert source == explicit.resolve()
+
+
+def test_a_workspace_root_that_is_also_a_project_keeps_both_files_separate(tmp_path):
+    """The collision case from the RFC, stated as behaviour.
+
+    .ash/ash.yaml at the workspace root belongs to the root project. Reading it
+    as workspace policy would apply one project's threshold to its siblings.
+    """
+    _write(
+        tmp_path / ".ash" / "ash.yaml",
+        "global_settings:\n  severity_threshold: CRITICAL\n",
+    )
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: MEDIUM\n",
+    )
+
+    config, source = resolve_workspace_policy(tmp_path)
+    assert source.name == "ash-workspace.yaml"
+    assert config.workspace.max_severity_threshold == "MEDIUM"
+
+
+def test_pointing_the_policy_at_a_project_config_is_refused_naming_the_file(tmp_path):
+    project_config = _write(
+        tmp_path / ".ash" / "ash.yaml",
+        "global_settings:\n  severity_threshold: HIGH\n",
+    )
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path, explicit=project_config)
+
+    message = str(excinfo.value)
+    assert "ash.yaml" in message
+    assert "ash-workspace" in message
+
+
+def test_pointing_the_policy_at_a_named_project_config_is_refused(tmp_path):
+    """Caught by identity against the project's own config path, not by name.
+
+    An operator may name their policy file anything; what makes this a
+    collision is that the file IS a project's config, so a symlink alias to one
+    has to be caught too.
+    """
+    project = tmp_path / "api"
+    project_config = _write(project / ".ash" / "ash.yaml", "global_settings: {}\n")
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(
+            tmp_path,
+            explicit=project_config,
+            project_config_paths=(project_config,),
+        )
+    assert "api" in str(excinfo.value)
+
+
+def test_two_candidate_policy_files_are_refused_rather_than_ranked(tmp_path):
+    """Sort order or mtime would silently pick a different file over time."""
+    _write(tmp_path / ".ash" / "ash-workspace.yaml", "workspace: {}\n")
+    _write(tmp_path / ".ash" / "ash-workspace.yml", "workspace: {}\n")
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+
+    message = str(excinfo.value)
+    assert "ash-workspace.yaml" in message
+    assert "ash-workspace.yml" in message
+
+
+def test_a_malformed_policy_file_is_refused(tmp_path):
+    _write(tmp_path / ".ash" / "ash-workspace.yaml", "workspace: [this is not a map\n")
+    with pytest.raises(WorkspaceDefinitionError):
+        resolve_workspace_policy(tmp_path)
+
+
+def test_an_explicit_policy_file_that_does_not_exist_is_refused(tmp_path):
+    """Silently ignoring it would run with no policy while the operator believes
+    a ceiling is in force."""
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path, explicit=tmp_path / "absent.yaml")
+    assert "absent.yaml" in str(excinfo.value)
+
+
+def test_a_policy_file_with_an_unknown_key_is_refused_naming_the_file(tmp_path):
+    path = _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshhold: HIGH\n",
+    )
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+    assert path.name in str(excinfo.value)
+
+
+def test_an_unsubstituted_env_placeholder_refuses_rather_than_disabling_the_gate(
+    tmp_path,
+):
+    """The policy loader does no ${VAR} substitution, and that must fail CLOSED.
+
+    AshConfig.from_file resolves ${VAR} in its YAML; this loader deliberately
+    does not, because a ceiling an environment variable can loosen is not a
+    ceiling. The danger is the failure MODE, not the missing feature: if
+    '${THRESH}' were accepted and then read as an unrecognised threshold, the
+    ladder would gate it like CRITICAL -- the loosest setting -- and the operator
+    would have no ceiling while believing they had one. It must refuse instead.
+    """
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: ${ASH_THRESHOLD}\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace_policy(tmp_path)
+
+    message = str(excinfo.value)
+    assert "ash-workspace.yaml" in message
+    # The message has to show the value that was rejected, or an operator with a
+    # templated CI config cannot tell substitution never happened.
+    assert "ASH_THRESHOLD" in message
+
+
+def test_an_env_placeholder_is_not_silently_substituted_from_the_environment(
+    tmp_path, monkeypatch
+):
+    """Companion to the above: even with the variable SET, it must not expand.
+
+    Without this, the previous test would pass for the wrong reason on a machine
+    where the variable happens to be unset, and the loader could quietly gain
+    substitution later without any test noticing.
+    """
+    monkeypatch.setenv("ASH_THRESHOLD", "CRITICAL")
+    _write(
+        tmp_path / ".ash" / "ash-workspace.yaml",
+        "workspace:\n  max_severity_threshold: ${ASH_THRESHOLD}\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError):
+        resolve_workspace_policy(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 6. The ceiling's reach, disclosed from the findings actually present
+# ---------------------------------------------------------------------------
+
+
+def _finding(level="error", issue_severity=None, scanner="checkov"):
+    result = {"ruleId": "R1", "level": level, "properties": {}}
+    if scanner is not None:
+        result["properties"]["scanner_name"] = scanner
+    if issue_severity is not None:
+        result["properties"]["issue_severity"] = issue_severity
+    return result
+
+
+def test_a_level_only_error_finding_is_reported_as_beyond_the_ceilings_reach():
+    """The measured limitation, disclosed per scanner from the findings.
+
+    An `error` with no issue_severity is treated as CRITICAL by both threshold
+    gates, so it is actionable at every threshold and tightening CRITICAL to
+    MEDIUM changes nothing for it.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", scanner="checkov")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {"checkov": 1}
+
+
+def test_a_severity_carrying_finding_is_not_reported():
+    """The ceiling reaches it, so there is nothing to disclose.
+
+    bandit's MEDIUM finding is not actionable at CRITICAL and is actionable at
+    MEDIUM, so the tightening did exactly what it says.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="warning", issue_severity="MEDIUM", scanner="bandit")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_a_genuinely_critical_finding_is_not_reported_as_unreachable():
+    """It is actionable at both thresholds, but that is correct, not a limitation.
+
+    Reporting it would tell the operator the ceiling failed on a finding the
+    ceiling was never meant to change. The discriminator is the ABSENCE of
+    issue_severity, not sameness of verdict alone.
+    """
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", issue_severity="CRITICAL", scanner="bandit")],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_nothing_is_reported_when_the_ceiling_did_not_tighten():
+    """Load-bearing only: no tightening means there is no claim to qualify."""
+    counts = ceiling_unreachable_counts(
+        [_finding(level="error", scanner="checkov")],
+        declared_threshold="MEDIUM",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_a_suppressed_finding_is_not_reported():
+    """It is not actionable at any threshold, so the ceiling is irrelevant to it."""
+    suppressed = _finding(level="error", scanner="checkov")
+    suppressed["suppressions"] = [{"kind": "external"}]
+    counts = ceiling_unreachable_counts(
+        [suppressed],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {}
+
+
+def test_counts_are_split_per_scanner_and_unattributed_findings_are_named():
+    counts = ceiling_unreachable_counts(
+        [
+            _finding(scanner="checkov"),
+            _finding(scanner="checkov"),
+            _finding(scanner="cfn-nag"),
+            _finding(scanner=None),
+        ],
+        declared_threshold="CRITICAL",
+        effective_threshold="MEDIUM",
+    )
+    assert counts == {"checkov": 2, "cfn-nag": 1, "unattributed": 1}
+
+
+def test_a_note_level_finding_the_ceiling_does_reach_is_not_reported():
+    """Not every level-only finding is beyond reach; only those whose verdict is
+    unchanged. A `note` is not actionable at CRITICAL and is actionable at LOW,
+    so tightening CRITICAL to LOW does affect it."""
+    counts = ceiling_unreachable_counts(
+        [_finding(level="note", scanner="checkov")],
+        declared_threshold="CRITICAL",
+        effective_threshold="LOW",
+    )
+    assert counts == {}
+
+
+def test_a_json_policy_file_is_read(tmp_path):
+    _write(
+        tmp_path / ".ash" / "ash-workspace.json",
+        json.dumps({"workspace": {"max_severity_threshold": "HIGH"}}),
+    )
+    config, _ = resolve_workspace_policy(tmp_path)
+    assert config.workspace.max_severity_threshold == "HIGH"

--- a/tests/unit/workspace/test_workspace_policy_resolution.py
+++ b/tests/unit/workspace/test_workspace_policy_resolution.py
@@ -1,0 +1,382 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Workspace policy as resolution applies it -- Phase 3, criteria 19-21.
+
+``test_workspace_policy.py`` covers the policy file and the push-down in
+isolation. This file covers the part an operator actually experiences: policy
+found next to the workspace file, applied to every project, and visible in
+``--dry-run`` BEFORE anything is scanned.
+
+That visibility is the point of the render assertions below rather than an
+aesthetic preference. A severity ceiling silently tightens projects whose own
+config says something else, so an operator has to be able to see which projects
+it moved without running a scan and diffing finding counts.
+"""
+
+import json
+
+import pytest
+
+from automated_security_helper.core.exceptions import WorkspaceDefinitionError
+from automated_security_helper.workspace.resolver import resolve_workspace
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _workspace(root, folders, name="dev.code-workspace"):
+    path = root / name
+    path.write_text(
+        json.dumps({"folders": [{"path": p} for p in folders]}), encoding="utf-8"
+    )
+    return path
+
+
+def _project(root, relative, threshold=None, disabled_scanners=None):
+    """A project directory, with a config when a threshold or scanners are given.
+
+    ``disabled_scanners`` rather than ``enabled``: ASH enables all ten builtin
+    scanners by default, so listing a scanner as enabled says nothing. A project
+    that does NOT have a given scanner is one that explicitly turned it off, and
+    that is the only shape in which ``additional_scanners`` has anything to add.
+    """
+    project = root / relative
+    project.mkdir(parents=True, exist_ok=True)
+    if threshold is None and disabled_scanners is None:
+        return project
+
+    lines = ["global_settings:", f"  severity_threshold: {threshold or 'MEDIUM'}"]
+    if disabled_scanners:
+        lines.append("scanners:")
+        for scanner in disabled_scanners:
+            lines.append(f"  {scanner}:")
+            lines.append("    enabled: false")
+    ash_dir = project / ".ash"
+    ash_dir.mkdir(exist_ok=True)
+    (ash_dir / "ash.yaml").write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return project
+
+
+def _policy_file(root, body, name="ash-workspace.yaml"):
+    ash_dir = root / ".ash"
+    ash_dir.mkdir(parents=True, exist_ok=True)
+    path = ash_dir / name
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _by_key(plan):
+    return {project.key: project for project in plan.projects}
+
+
+# ---------------------------------------------------------------------------
+# 1. The ceiling reaches every project, and only tightens
+# ---------------------------------------------------------------------------
+
+
+def test_the_ceiling_tightens_a_lax_project_and_leaves_a_strict_one(tmp_path):
+    _project(tmp_path, "lax", threshold="CRITICAL")
+    _project(tmp_path, "strict", threshold="LOW")
+    workspace = _workspace(tmp_path, ["lax", "strict"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # The project's own setting is preserved as declared, so an operator can see
+    # what the ceiling changed rather than only its result.
+    assert projects["lax"].severity_threshold == "CRITICAL"
+    assert projects["lax"].effective_severity_threshold == "MEDIUM"
+    assert projects["lax"].threshold_tightened_by_policy is True
+
+    assert projects["strict"].severity_threshold == "LOW"
+    assert projects["strict"].effective_severity_threshold == "LOW"
+    assert projects["strict"].threshold_tightened_by_policy is False
+
+
+def test_without_a_policy_file_the_effective_threshold_is_the_projects_own(tmp_path):
+    """Phase 2b behaviour has to survive: no policy means nothing changes."""
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api"])
+
+    plan = resolve_workspace(workspace)
+    project = _by_key(plan)["api"]
+
+    assert plan.workspace_config_source is None
+    assert project.effective_severity_threshold == "CRITICAL"
+    assert project.threshold_tightened_by_policy is False
+
+
+def test_a_skipped_project_gets_no_policy_at_all(tmp_path):
+    """Policy must not be applied to a project that will not be scanned.
+
+    Two reasons, and the second is the one with teeth. A threshold recorded for
+    work that never happens is misleading in the plan; and pushing patterns into
+    a skipped project can refuse the ENTIRE workspace over a pattern that is only
+    unrewritable for a project nobody is scanning -- fail-closed aimed at the
+    wrong target.
+    """
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api", "absent"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  max_severity_threshold: MEDIUM\n"
+        "  suppressions:\n"
+        "    - path: '**/legacy.py'\n"
+        "      reason: everywhere\n",
+    )
+
+    plan = resolve_workspace(workspace, allow_missing_projects=True)
+    projects = _by_key(plan)
+
+    # Companion assertion: the skip really happened, so the checks below are not
+    # passing because the project was scanned after all.
+    assert projects["absent"].skipped is True
+    assert projects["api"].skipped is False
+
+    assert projects["absent"].effective_severity_threshold is None
+    assert projects["absent"].threshold_tightened_by_policy is False
+    assert projects["absent"].policy_suppressions == []
+    assert projects["absent"].policy_scanners == []
+
+    # The project that does run still gets the full policy.
+    assert projects["api"].effective_severity_threshold == "MEDIUM"
+    assert [s.path for s in projects["api"].policy_suppressions] == ["**/legacy.py"]
+
+
+def test_the_plan_records_which_policy_file_was_used(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    policy = _policy_file(tmp_path, "workspace:\n  max_severity_threshold: HIGH\n")
+
+    plan = resolve_workspace(workspace)
+    assert plan.workspace_config_source == policy.resolve().as_posix()
+
+
+def test_an_explicit_policy_file_overrides_discovery(tmp_path):
+    _project(tmp_path, "api", threshold="CRITICAL")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: HIGH\n")
+    chosen = tmp_path / "other-policy.yaml"
+    chosen.write_text("workspace:\n  max_severity_threshold: LOW\n", encoding="utf-8")
+
+    plan = resolve_workspace(workspace, workspace_config=chosen)
+    assert plan.workspace_config_source == chosen.resolve().as_posix()
+    assert _by_key(plan)["api"].effective_severity_threshold == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# 2. The collision the RFC names, at the resolution layer
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_root_that_is_also_a_project_keeps_its_config_separate(tmp_path):
+    """The root's .ash/ash.yaml is the root project's config, not workspace policy.
+
+    Reading it as policy would apply one project's threshold to its siblings.
+    Here the root project declares CRITICAL and the policy declares a MEDIUM
+    ceiling, so mixing them up is visible in the sibling's effective threshold.
+    """
+    root_project = _project(tmp_path, "root-app", threshold="CRITICAL")
+    assert (root_project / ".ash" / "ash.yaml").exists()
+    _project(tmp_path, "sibling", threshold="CRITICAL")
+    # The workspace root's own config, distinct from the policy beside it.
+    (tmp_path / ".ash").mkdir(exist_ok=True)
+    (tmp_path / ".ash" / "ash.yaml").write_text(
+        "global_settings:\n  severity_threshold: ALL\n", encoding="utf-8"
+    )
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+    workspace = _workspace(tmp_path, ["root-app", "sibling"])
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # ALL from the root's own config must not have become the ceiling.
+    assert plan.workspace_config_source.endswith("ash-workspace.yaml")
+    assert projects["sibling"].effective_severity_threshold == "MEDIUM"
+    assert projects["root-app"].effective_severity_threshold == "MEDIUM"
+
+
+def test_naming_a_project_config_as_the_policy_file_is_refused(tmp_path):
+    project = _project(tmp_path, "api", threshold="HIGH")
+    workspace = _workspace(tmp_path, ["api"])
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace, workspace_config=project / ".ash" / "ash.yaml")
+    assert "ash.yaml" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 3. Patterns land on the right project, or refuse
+# ---------------------------------------------------------------------------
+
+
+def test_a_workspace_suppression_reaches_only_the_project_it_names(tmp_path):
+    _project(tmp_path, "api")
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  suppressions:\n"
+        "    - path: api/src/legacy.py\n"
+        "      reason: tracked in TICKET-1\n",
+    )
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    assert [s.path for s in projects["api"].policy_suppressions] == ["src/legacy.py"]
+    assert projects["web"].policy_suppressions == []
+
+
+def test_an_unrewritable_policy_pattern_refuses_naming_project_and_pattern(tmp_path):
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  suppressions:\n"
+        "    - path: '*/sub/*.py'\n"
+        "      reason: ambiguous on purpose\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+
+    message = str(excinfo.value)
+    assert "*/sub/*.py" in message
+    assert "api" in message
+
+
+def test_workspace_ignore_paths_are_pushed_into_each_project(tmp_path):
+    _project(tmp_path, "api")
+    _project(tmp_path, "web")
+    workspace = _workspace(tmp_path, ["api", "web"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  ignore_paths:\n"
+        "    - path: '**/vendor'\n"
+        "      reason: third party\n",
+    )
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    for key in ("api", "web"):
+        assert [p.path for p in projects[key].policy_ignore_paths] == ["**/vendor"]
+
+
+def test_a_trailing_double_star_after_a_double_star_is_refused(tmp_path):
+    """``**/vendor/**`` has no sound rewrite, and an operator will write it.
+
+    It is the most natural way to say "any vendor directory, at any depth, in any
+    project", so its refusal is the limitation of the push-down most likely to be
+    hit. Pinned as a test rather than left to be discovered, with the working
+    alternatives named in the message the operator sees.
+
+    The cause is workspace_paths' family 1: the remainder ``vendor/**`` is
+    multi-component and contains a glob, so prefixing it with ``**`` moves the
+    whole pattern from fnmatch to component-anchored matching and silently
+    re-interprets the trailing ``**``.
+    """
+    _project(tmp_path, "api")
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  ignore_paths:\n"
+        "    - path: '**/vendor/**'\n"
+        "      reason: third party\n",
+    )
+
+    with pytest.raises(WorkspaceDefinitionError) as excinfo:
+        resolve_workspace(workspace)
+    assert "**/vendor/**" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# 4. Policy-added scanners, per project
+# ---------------------------------------------------------------------------
+
+
+def test_a_policy_scanner_the_project_already_enables_is_not_policy_origin(tmp_path):
+    """Only the project that turned bandit off gets it back as policy-origin.
+
+    The project that still has it runs bandit under its own config, so those
+    findings are the project's and gate normally.
+    """
+    _project(tmp_path, "has-it", threshold="MEDIUM")
+    _project(tmp_path, "lacks-it", threshold="MEDIUM", disabled_scanners=["bandit"])
+    workspace = _workspace(tmp_path, ["has-it", "lacks-it"])
+    _policy_file(tmp_path, "workspace:\n  additional_scanners:\n    - bandit\n")
+
+    plan = resolve_workspace(workspace)
+    projects = _by_key(plan)
+
+    # Companion assertion: confirm the passing path is the one intended, i.e.
+    # has-it really does enable bandit rather than the comparison silently
+    # matching nothing.
+    assert "bandit" in projects["has-it"].scanners
+    assert "bandit" not in projects["lacks-it"].scanners
+
+    assert projects["has-it"].policy_scanners == []
+    assert projects["lacks-it"].policy_scanners == ["bandit"]
+
+
+def test_policy_scanners_do_not_gate_unless_the_operator_opts_in(tmp_path):
+    _project(tmp_path, "api", threshold="MEDIUM", disabled_scanners=["bandit"])
+    workspace = _workspace(tmp_path, ["api"])
+    _policy_file(tmp_path, "workspace:\n  additional_scanners:\n    - bandit\n")
+
+    plan = resolve_workspace(workspace)
+    # Companion assertion: the gate flag is only meaningful if bandit really is
+    # policy-origin here, so confirm that before asserting on the flag.
+    assert _by_key(plan)["api"].policy_scanners == ["bandit"]
+    assert _by_key(plan)["api"].policy_scanners_gate is False
+
+    _policy_file(
+        tmp_path,
+        "workspace:\n"
+        "  additional_scanners:\n"
+        "    - bandit\n"
+        "  policy_scanners_gate: true\n",
+    )
+    plan = resolve_workspace(workspace)
+    assert _by_key(plan)["api"].policy_scanners_gate is True
+
+
+# ---------------------------------------------------------------------------
+# 5. --dry-run shows the policy, so a ceiling is visible before it applies
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_names_the_policy_file_and_marks_the_projects_it_tightened(tmp_path):
+    _project(tmp_path, "lax", threshold="CRITICAL")
+    _project(tmp_path, "strict", threshold="LOW")
+    workspace = _workspace(tmp_path, ["lax", "strict"])
+    _policy_file(tmp_path, "workspace:\n  max_severity_threshold: MEDIUM\n")
+
+    rendered = resolve_workspace(workspace).render()
+
+    assert "ash-workspace.yaml" in rendered
+    # The tightened project shows both values and says policy moved it; the
+    # untouched one must not claim a change it did not undergo.
+    assert "CRITICAL" in rendered and "MEDIUM" in rendered
+    lax_block = rendered.split("1. lax")[1].split("2. strict")[0]
+    strict_block = rendered.split("2. strict")[1]
+    assert "workspace policy" in lax_block
+    assert "workspace policy" not in strict_block
+
+
+def test_dry_run_without_policy_does_not_mention_it(tmp_path):
+    _project(tmp_path, "api", threshold="MEDIUM")
+    workspace = _workspace(tmp_path, ["api"])
+
+    rendered = resolve_workspace(workspace).render()
+    assert "workspace policy" not in rendered
+    assert "policy:" not in rendered

--- a/tests/unit/workspace/test_workspace_reporting.py
+++ b/tests/unit/workspace/test_workspace_reporting.py
@@ -1,0 +1,1113 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The workspace-level report step, and the four behaviours it enforces.
+
+What these tests are for
+------------------------
+``test_reporter_workspace_behaviour.py`` asserts that every reporter *declares*
+something. This file asserts that the declaration *does* something -- that the
+driver emits a merged artefact for MERGED, withholds one for PER_PROJECT while
+recording where the per-project files are, emits a workspace-scoped artefact for
+WORKSPACE_SCOPED, and refuses with a non-zero exit for UNSUPPORTED.
+
+A declaration the driver ignored would be worse than no declaration at all: it
+would read as a guarantee in every reporter docstring while the shipped behaviour
+was whatever the code happened to do. So the two files are deliberately split,
+and neither is sufficient alone.
+
+Driven through the real ``WorkspaceAggregator``
+----------------------------------------------
+The unified results file these tests read is produced by the real aggregator, not
+hand-written. Writing the N-run SARIF by hand would let a test pass against a
+shape the aggregator does not actually produce -- and the shape is the entire
+subject here, since it is the shape that broke ``runs[0]``.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.base.reporter_plugin import (
+    ReporterPluginBase,
+    ReporterPluginConfigBase,
+    ReporterWorkspaceBehaviour,
+)
+from automated_security_helper.models.workspace import (
+    ProjectRunStatus,
+    WorkspaceProjectResult,
+)
+from automated_security_helper.workspace.aggregation import (
+    PROJECT_ROOT_URI_BASE_ID,
+    WorkspaceAggregator,
+)
+from automated_security_helper.workspace.plan import ProjectPlan, WorkspacePlan
+from automated_security_helper.workspace.reporting import (
+    MANIFEST_FILENAME,
+    REPORTS_DIR_NAME,
+    emit_workspace_reports,
+)
+
+# --------------------------------------------------------------------------- #
+# Fixtures: a real two-project workspace, aggregated the way production does.
+# --------------------------------------------------------------------------- #
+
+
+def _plan(root: Path, *keys: str) -> WorkspacePlan:
+    return WorkspacePlan(
+        workspace_file=(root / "fixture.code-workspace").as_posix(),
+        workspace_root=root.as_posix(),
+        projects=[
+            ProjectPlan(
+                key=key,
+                relative_path=key,
+                path=(root / key).as_posix(),
+                label=key,
+                display_label=key,
+                severity_threshold="MEDIUM",
+            )
+            for key in keys
+        ],
+    )
+
+
+def _run(project_key: str, *, rule: str, uri: str) -> dict:
+    """One project's SARIF run, shaped the way a real project scan emits it.
+
+    Rule ids differ per project so a merged artefact that dropped a project can
+    be caught by a positive assertion -- "RULE-WEB is present" -- rather than
+    only by a count, which a duplicated first project would also satisfy.
+    """
+    return {
+        "tool": {"driver": {"name": "ASH", "rules": [{"id": rule}]}},
+        "results": [
+            {
+                "ruleId": rule,
+                "level": "error",
+                "message": {"text": f"finding in {project_key}"},
+                "locations": [
+                    {"physicalLocation": {"artifactLocation": {"uri": uri}}},
+                ],
+                "properties": {"scanner_name": "bandit"},
+            }
+        ],
+        "invocations": [],
+    }
+
+
+def _outcome(project: ProjectPlan) -> WorkspaceProjectResult:
+    return WorkspaceProjectResult(
+        project=project.key,
+        relative_path=project.relative_path,
+        display_label=project.display_label,
+        status=ProjectRunStatus.COMPLETED,
+        severity_threshold="MEDIUM",
+        finding_count=1,
+        actionable_finding_count=1,
+        exceeds_threshold=True,
+        output_path=f"projects/{project.key}",
+        scanners={"bandit": "FAILED"},
+    )
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A written two-project workspace: output tree, unified results, and plan.
+
+    Each project also gets a populated ``projects/<key>/reports/`` directory,
+    because that is what a real per-project scan leaves behind and it is what the
+    PER_PROJECT manifest entries have to find.
+    """
+    root = tmp_path / "ws"
+    output_dir = tmp_path / "out"
+    plan = _plan(root, "api", "web")
+
+    aggregator = WorkspaceAggregator(plan=plan, output_dir=output_dir)
+    for project, rule in zip(plan.projects, ("RULE-API", "RULE-WEB")):
+        aggregator.add(
+            _outcome(project),
+            _run(project.key, rule=rule, uri=f"src/{project.key}.py"),
+            project,
+        )
+    results_path = aggregator.write(exit_code=2, wall_clock_seconds=1.5)
+
+    for project in plan.projects:
+        reports = output_dir / "projects" / project.key / REPORTS_DIR_NAME
+        reports.mkdir(parents=True, exist_ok=True)
+        (reports / "ash.ghas.sarif").write_text("{}", encoding="utf-8")
+        (reports / "ash.cdx.json").write_text("{}", encoding="utf-8")
+
+    return plan, output_dir, results_path
+
+
+# --------------------------------------------------------------------------- #
+# Test doubles: one reporter per behaviour, so the driver is what is under test.
+# --------------------------------------------------------------------------- #
+
+
+class _MergedConfig(ReporterPluginConfigBase):
+    name: str = "fake-merged"
+    extension: str = "merged.txt"
+    enabled: bool = True
+
+
+class FakeMergedReporter(ReporterPluginBase[_MergedConfig]):
+    """Reports the rule id of every run it was given, one per line."""
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _MergedConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:
+        rules = [
+            result.ruleId
+            for run in (model.sarif.runs or [])
+            for result in (run.results or [])
+        ]
+        return "\n".join(rules)
+
+
+class _PerProjectConfig(ReporterPluginConfigBase):
+    name: str = "fake-per-project"
+    extension: str = "ghas.sarif"
+    enabled: bool = True
+
+
+class FakePerProjectReporter(ReporterPluginBase[_PerProjectConfig]):
+    """Stands in for ``github_ghas``: reads ``runs[0]`` and would drop the rest."""
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.PER_PROJECT
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _PerProjectConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:  # pragma: no cover - must never be reached
+        raise AssertionError(
+            "a PER_PROJECT reporter was invoked at workspace level; that is the "
+            "silent-under-report bug this contract exists to prevent"
+        )
+
+
+class _ScopedConfig(ReporterPluginConfigBase):
+    name: str = "fake-workspace-scoped"
+    extension: str = "scoped.json"
+    enabled: bool = True
+
+
+class FakeWorkspaceScopedReporter(ReporterPluginBase[_ScopedConfig]):
+    workspace_behaviour = ReporterWorkspaceBehaviour.WORKSPACE_SCOPED
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _ScopedConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:
+        return json.dumps({"scope": "workspace"})
+
+
+class _UnsupportedConfig(ReporterPluginConfigBase):
+    name: str = "fake-unsupported"
+    extension: str = "unsupported.txt"
+    enabled: bool = True
+
+
+class FakeUnsupportedReporter(ReporterPluginBase[_UnsupportedConfig]):
+    workspace_behaviour = ReporterWorkspaceBehaviour.UNSUPPORTED
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _UnsupportedConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:  # pragma: no cover - must never be reached
+        raise AssertionError("an UNSUPPORTED reporter must not be invoked")
+
+
+class _RaisingConfig(ReporterPluginConfigBase):
+    name: str = "fake-raising"
+    extension: str = "raising.txt"
+    enabled: bool = True
+
+
+class FakeRaisingReporter(ReporterPluginBase[_RaisingConfig]):
+    """A MERGED reporter that blows up, to pin that one failure is not fatal."""
+
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _RaisingConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:
+        raise RuntimeError("fixture explosion")
+
+
+class _DisabledConfig(ReporterPluginConfigBase):
+    name: str = "fake-disabled"
+    extension: str = "disabled.txt"
+    enabled: bool = False
+
+
+class FakeDisabledReporter(ReporterPluginBase[_DisabledConfig]):
+    workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+    def model_post_init(self, context):
+        if self.config is None:
+            self.config = _DisabledConfig()
+        return super().model_post_init(context)
+
+    def report(self, model) -> str:  # pragma: no cover - must never be reached
+        raise AssertionError("a disabled reporter must not be invoked")
+
+
+def _emit(workspace, *reporter_classes, **kwargs):
+    plan, output_dir, results_path = workspace
+    return emit_workspace_reports(
+        plan=plan,
+        output_dir=output_dir,
+        results_path=results_path,
+        reporter_classes=list(reporter_classes),
+        **kwargs,
+    )
+
+
+def _manifest(output_dir: Path) -> dict:
+    return json.loads(
+        (output_dir / REPORTS_DIR_NAME / MANIFEST_FILENAME).read_text(encoding="utf-8")
+    )
+
+
+# --------------------------------------------------------------------------- #
+
+
+class TestMergedReporters:
+    def test_a_merged_reporter_writes_one_workspace_artefact(self, workspace):
+        _, output_dir, _ = workspace
+        outcome = _emit(workspace, FakeMergedReporter)
+
+        artefact = output_dir / REPORTS_DIR_NAME / "ash.merged.txt"
+        assert artefact.is_file()
+        assert outcome.workspace_artifacts == {"fake-merged": artefact}
+
+    def test_the_merged_artefact_covers_every_project(self, workspace):
+        """The positive control for the whole feature.
+
+        ``RULE-WEB`` comes only from the second run. A reporter that read
+        ``runs[0]`` -- the shipped ``github_ghas`` behaviour -- produces a file
+        containing ``RULE-API`` alone, and this is the assertion that catches it.
+        Asserted by presence of both ids rather than by a line count, because a
+        reporter that emitted the first project twice would satisfy a count.
+        """
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeMergedReporter)
+
+        content = (output_dir / REPORTS_DIR_NAME / "ash.merged.txt").read_text(
+            encoding="utf-8"
+        )
+        assert "RULE-API" in content
+        assert "RULE-WEB" in content
+
+    def test_a_reporter_that_raises_does_not_sink_the_others(self, workspace):
+        """One broken reporter must not cost the operator every other report."""
+        _, output_dir, _ = workspace
+        outcome = _emit(workspace, FakeRaisingReporter, FakeMergedReporter)
+
+        assert (output_dir / REPORTS_DIR_NAME / "ash.merged.txt").is_file()
+        assert not (output_dir / REPORTS_DIR_NAME / "ash.raising.txt").exists()
+        assert "fake-raising" in outcome.failed_reporters
+        assert "fixture explosion" in outcome.failed_reporters["fake-raising"]
+
+    def test_a_reporter_failure_is_recorded_in_the_manifest(self, workspace):
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeRaisingReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-raising"]
+        assert entry["workspace_artifact"] is None
+        assert "fixture explosion" in entry["error"]
+
+    def test_a_disabled_reporter_is_not_invoked(self, workspace):
+        outcome = _emit(workspace, FakeDisabledReporter)
+        assert outcome.workspace_artifacts == {}
+
+    def test_a_disabled_reporter_is_still_recorded_with_its_reason(self, workspace):
+        """Found by running a real workspace scan and reading the manifest.
+
+        ``yaml`` and ``spdx`` ship disabled, and the four AWS reporters report
+        unsatisfied dependencies without credentials -- so six of the nineteen were
+        absent from the manifest with nothing to say why. An operator asking "where
+        is my yaml report" got silence, which is the failure mode this manifest
+        exists to prevent; only the reason differs from a withheld one.
+
+        Recorded with ``considered: false``, so a consumer can still tell "the
+        operator turned this off" from "this format cannot be merged".
+        """
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeDisabledReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-disabled"]
+        assert entry["considered"] is False
+        assert entry["skipped"] == "disabled"
+        assert entry["workspace_artifact"] is None
+
+    def test_a_reporter_outside_the_requested_formats_says_so(self, workspace):
+        """A distinct reason from "disabled", because the fix is different.
+
+        Disabled means edit the config; not-requested means widen
+        ``--output-format``. Collapsing the two would send an operator to the
+        wrong knob.
+        """
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeMergedReporter, output_formats=("something.else",))
+
+        entry = _manifest(output_dir)["reporters"]["fake-merged"]
+        assert entry["considered"] is False
+        assert entry["skipped"] == "not-in-requested-output-formats"
+
+    def test_a_reporter_that_ran_is_marked_considered(self, workspace):
+        """The companion assertion, so ``considered`` is not always False."""
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeMergedReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-merged"]
+        assert entry["considered"] is True
+        assert "skipped" not in entry
+
+
+class TestPerProjectReporters:
+    def test_a_per_project_reporter_gets_no_workspace_artefact(self, workspace):
+        """Withheld, not attempted.
+
+        ``FakePerProjectReporter.report`` raises if called, so this asserts the
+        driver never reaches it -- rather than asserting only that no file
+        appeared, which a reporter returning an empty string would also satisfy.
+        """
+        _, output_dir, _ = workspace
+        outcome = _emit(workspace, FakePerProjectReporter)
+
+        assert outcome.workspace_artifacts == {}
+        assert outcome.per_project_reporters == ("fake-per-project",)
+        assert not (output_dir / REPORTS_DIR_NAME / "ash.ghas.sarif").exists()
+
+    def test_the_manifest_names_every_per_project_artefact(self, workspace):
+        """The absence of a merged file has to be stated, not merely true.
+
+        Silence is the defect the whole contract is against, so a withheld
+        workspace artefact must come with a machine-readable pointer to the N
+        files that replace it.
+        """
+        _, output_dir, _ = workspace
+        _emit(workspace, FakePerProjectReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-per-project"]
+        assert entry["behaviour"] == "per-project"
+        assert entry["workspace_artifact"] is None
+        assert entry["per_project_artifacts"] == [
+            {"project": "api", "path": "projects/api/reports/ash.ghas.sarif"},
+            {"project": "web", "path": "projects/web/reports/ash.ghas.sarif"},
+        ]
+
+    def test_a_per_project_artefact_that_was_not_written_is_reported_missing(
+        self, workspace, tmp_path
+    ):
+        """A path in the manifest that names nothing is worse than no path.
+
+        The per-project report is written by that project's own report phase,
+        which can be skipped, disabled, or have failed. The manifest says which
+        of the N actually exist so an operator is never sent to a file that is
+        not there.
+        """
+        _, output_dir, _ = workspace
+        (output_dir / "projects" / "web" / REPORTS_DIR_NAME / "ash.ghas.sarif").unlink()
+
+        _emit(workspace, FakePerProjectReporter)
+        entry = _manifest(output_dir)["reporters"]["fake-per-project"]
+        assert entry["missing_per_project_artifacts"] == ["web"]
+
+
+class TestWorkspaceScopedReporters:
+    def test_a_workspace_scoped_reporter_writes_a_workspace_artefact(self, workspace):
+        _, output_dir, _ = workspace
+        outcome = _emit(workspace, FakeWorkspaceScopedReporter)
+
+        assert (output_dir / REPORTS_DIR_NAME / "ash.scoped.json").is_file()
+        assert "fake-workspace-scoped" in outcome.workspace_artifacts
+
+    def test_the_manifest_marks_it_as_not_a_merge(self, workspace):
+        """A consumer must not read a workspace-scoped file as covering projects.
+
+        ``unused_suppressions`` is the real case: read as a merge, its zero
+        counts would mean "no unused suppressions anywhere", when what they mean
+        is "no workspace-level suppressions". The behaviour string in the
+        manifest is what keeps those apart.
+        """
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeWorkspaceScopedReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-workspace-scoped"]
+        assert entry["behaviour"] == "workspace-scoped"
+        assert entry["covers_projects"] is False
+
+    def test_a_merged_reporter_is_marked_as_covering_projects(self, workspace):
+        """The companion assertion, so ``covers_projects`` is not always False."""
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeMergedReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-merged"]
+        assert entry["covers_projects"] is True
+
+
+class TestUnsupportedReportersAreRefusedBeforeAnythingIsScanned:
+    """The production gate for acceptance criterion 23's non-zero exit.
+
+    ``emit_workspace_reports`` records an ``UNSUPPORTED`` reporter in the
+    manifest, but it is not what fails the run -- by the time it runs, the
+    aggregator has already written the exit code *into* the results file, and a
+    refusal discovered then could only be surfaced by exiting with a status the
+    file does not contain. So the same declaration is checked before any project
+    is scanned, where refusing costs nothing and nothing has been written that a
+    process exit could contradict.
+    """
+
+    def test_the_detection_needs_no_scan_and_no_results_file(self, workspace, tmp_path):
+        from automated_security_helper.workspace.reporting import (
+            unsupported_reporter_names,
+        )
+
+        plan, _, _ = workspace
+        # A directory with nothing in it: no results file, no projects subtree.
+        assert unsupported_reporter_names(
+            plan,
+            tmp_path / "never-written",
+            reporter_classes=[FakeUnsupportedReporter, FakeMergedReporter],
+        ) == ("fake-unsupported",)
+
+    def test_nothing_is_reported_when_every_reporter_can_participate(
+        self, workspace, tmp_path
+    ):
+        """The companion assertion: the detector is not stuck returning a name."""
+        from automated_security_helper.workspace.reporting import (
+            unsupported_reporter_names,
+        )
+
+        plan, _, _ = workspace
+        assert (
+            unsupported_reporter_names(
+                plan,
+                tmp_path / "never-written",
+                reporter_classes=[
+                    FakeMergedReporter,
+                    FakePerProjectReporter,
+                    FakeWorkspaceScopedReporter,
+                ],
+            )
+            == ()
+        )
+
+    def test_a_disabled_unsupported_reporter_does_not_refuse_the_run(
+        self, workspace, tmp_path
+    ):
+        """Disabling it is the documented way out, so it has to actually work."""
+        from automated_security_helper.workspace.reporting import (
+            unsupported_reporter_names,
+        )
+
+        class _DisabledUnsupportedConfig(ReporterPluginConfigBase):
+            name: str = "fake-unsupported-disabled"
+            extension: str = "unsupported.txt"
+            enabled: bool = False
+
+        class FakeDisabledUnsupportedReporter(
+            ReporterPluginBase[_DisabledUnsupportedConfig]
+        ):
+            workspace_behaviour = ReporterWorkspaceBehaviour.UNSUPPORTED
+
+            def model_post_init(self, context):
+                if self.config is None:
+                    self.config = _DisabledUnsupportedConfig()
+                return super().model_post_init(context)
+
+            def report(self, model) -> str:  # pragma: no cover - never invoked
+                raise AssertionError("must not be invoked")
+
+        plan, _, _ = workspace
+        assert (
+            unsupported_reporter_names(
+                plan,
+                tmp_path / "never-written",
+                reporter_classes=[FakeDisabledUnsupportedReporter],
+            )
+            == ()
+        )
+
+    def test_the_pre_flight_runs_after_the_plugin_registry_is_prewarmed(self, tmp_path):
+        """Ordering is load-bearing, and violating it is silent.
+
+        ``unsupported_reporter_names`` reads the reporter set from the plugin
+        registry. Called before ``prewarm_plugin_registry``, it resolves a cold
+        registry -- and ``AshPluginManager.plugin_modules`` memoises into
+        ``_resolved_plugins``, so whatever happened to be resolvable at that
+        instant becomes the set prewarm then hands to every project. That is
+        exactly the defect prewarm exists to fix (PR #462), re-entered from the
+        other end, and its symptom is a project losing a scanner rather than an
+        error.
+
+        Asserted by observing call order rather than by reading the source, in the
+        same shape as
+        ``test_plugin_registry_scoping.py::test_execute_workspace_prewarms_before_starting_the_pool``,
+        so a refactor that reopens the hole fails here instead of quietly.
+
+        The registry-scoping tests cannot cover this: they all use
+        ``phases=("scan",)``, so the report phase -- and therefore the pre-flight
+        -- is outside their reach entirely. ``phases`` here includes ``report``
+        for that reason.
+        """
+        import automated_security_helper.workspace.execution as execution
+        from automated_security_helper.models.asharp_model import AshAggregatedResults
+
+        order: list[str] = []
+        real_prewarm = execution.prewarm_plugin_registry
+        real_unsupported = execution.unsupported_reporter_names
+
+        def recording_prewarm(plan, settings):
+            order.append("prewarm")
+            return real_prewarm(plan, settings)
+
+        def recording_unsupported(*args, **kwargs):
+            order.append("preflight")
+            return real_unsupported(*args, **kwargs)
+
+        class _Orchestrator:
+            def __init__(self, **kwargs):
+                order.append(f"engine:{Path(kwargs['source_dir']).name}")
+
+            @classmethod
+            def create(cls, **kwargs):
+                return cls(**kwargs)
+
+            def execute_scan(self, phases=None):
+                return AshAggregatedResults()
+
+        root = tmp_path / "ws"
+        for key in ("api", "web"):
+            (root / key).mkdir(parents=True, exist_ok=True)
+        plan = _plan(root, "api", "web")
+        settings = execution.ProjectScanSettings(
+            output_dir=tmp_path / "out",
+            phases=("scan", "report"),
+            max_parallel_projects=2,
+        )
+
+        execution.prewarm_plugin_registry = recording_prewarm
+        execution.unsupported_reporter_names = recording_unsupported
+        try:
+            execution.execute_workspace(
+                plan, settings, orchestrator_factory=_Orchestrator.create
+            )
+        finally:
+            execution.prewarm_plugin_registry = real_prewarm
+            execution.unsupported_reporter_names = real_unsupported
+
+        assert order[0] == "prewarm", order
+        assert order[1] == "preflight", order
+        # And both before any project's engine is built, so neither can be
+        # influenced by a project having already touched the registry.
+        assert sorted(order[2:]) == ["engine:api", "engine:web"], order
+
+    def test_the_pre_flight_does_not_validate_reporter_dependencies(
+        self, workspace, tmp_path
+    ):
+        """It runs before every workspace scan, so it must not perform IO.
+
+        ``SecurityHubReporter`` and ``BedrockSummaryReporter`` call AWS inside
+        ``validate_plugin_dependencies``. Validating here would put live API calls
+        on the path before every workspace scan -- and it did, in the first version
+        of this, which is how it was noticed: two unit tests that only read
+        declarations were reaching a real account and logging "Security Hub is not
+        enabled in this region".
+
+        Asserted by counting calls rather than by timing or by patching the network,
+        because zero is the only number that cannot regress quietly.
+        """
+        from automated_security_helper.workspace.reporting import (
+            unsupported_reporter_names,
+        )
+
+        calls: list[str] = []
+
+        class _ValidatingConfig(ReporterPluginConfigBase):
+            name: str = "fake-validating"
+            extension: str = "validating.txt"
+            enabled: bool = True
+
+        class FakeValidatingReporter(ReporterPluginBase[_ValidatingConfig]):
+            workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+            def model_post_init(self, context):
+                if self.config is None:
+                    self.config = _ValidatingConfig()
+                return super().model_post_init(context)
+
+            def validate_plugin_dependencies(self) -> bool:
+                calls.append("validated")
+                return True
+
+            def report(self, model) -> str:
+                return "content"
+
+        plan, _, _ = workspace
+        unsupported_reporter_names(
+            plan, tmp_path / "never-written", reporter_classes=[FakeValidatingReporter]
+        )
+        assert calls == []
+
+        # The companion assertion: the report step *does* validate, because it has
+        # to decide whether to invoke. Without this, deleting the check outright
+        # would satisfy the assertion above.
+        _emit(workspace, FakeValidatingReporter)
+        assert calls == ["validated"]
+
+    def test_no_shipped_reporter_declares_itself_unsupported(self, workspace, tmp_path):
+        """Recorded as a fact about the shipped set, not as an assumption.
+
+        Every one of the 19 has a defensible merged or per-project answer, so this
+        gate never fires in practice today. Asserting it means a future reporter
+        that does declare ``UNSUPPORTED`` cannot slip in and start failing every
+        workspace run without someone reading this test and deciding that is what
+        they want.
+        """
+        from automated_security_helper.workspace.reporting import (
+            unsupported_reporter_names,
+        )
+        from tests.unit.workspace.test_reporter_workspace_behaviour import (
+            _iter_reporter_classes,
+        )
+
+        plan, _, _ = workspace
+        assert (
+            unsupported_reporter_names(
+                plan,
+                tmp_path / "never-written",
+                reporter_classes=list(_iter_reporter_classes().values()),
+            )
+            == ()
+        )
+
+
+class TestUnsupportedReportersRefuseLoudly:
+    def test_an_unsupported_reporter_is_refused_and_fails_the_run(self, workspace):
+        """Acceptance criterion 23's deliberate non-zero exit.
+
+        No reporter shipped in this repository declares UNSUPPORTED -- every one
+        has a defensible merged or per-project answer -- so the mechanism is
+        proven here with a test double rather than left to be discovered by the
+        first external plugin that needs it. Building it untested would have made
+        the enum member a comment.
+        """
+        outcome = _emit(workspace, FakeUnsupportedReporter)
+
+        assert outcome.unsupported_reporters == ("fake-unsupported",)
+        assert outcome.refused is True
+
+    def test_the_refusal_names_the_reporter_in_the_manifest(self, workspace):
+        _, output_dir, _ = workspace
+        _emit(workspace, FakeUnsupportedReporter)
+
+        entry = _manifest(output_dir)["reporters"]["fake-unsupported"]
+        assert entry["behaviour"] == "unsupported"
+        assert entry["workspace_artifact"] is None
+
+    def test_a_run_with_no_unsupported_reporter_is_not_refused(self, workspace):
+        """The companion assertion: ``refused`` is not stuck True."""
+        outcome = _emit(workspace, FakeMergedReporter, FakePerProjectReporter)
+        assert outcome.refused is False
+        assert outcome.unsupported_reporters == ()
+
+
+class TestTheOutputFormatFilter:
+    def test_a_reporter_outside_the_requested_formats_is_skipped(self, workspace):
+        outcome = _emit(
+            workspace,
+            FakeMergedReporter,
+            FakeWorkspaceScopedReporter,
+            output_formats=("scoped.json",),
+        )
+        assert set(outcome.workspace_artifacts) == {"fake-workspace-scoped"}
+
+    def test_an_empty_format_filter_means_every_reporter(self, workspace):
+        """Matches ``ReportPhase``: no ``--output-format`` is not "none"."""
+        outcome = _emit(
+            workspace,
+            FakeMergedReporter,
+            FakeWorkspaceScopedReporter,
+            output_formats=(),
+        )
+        assert set(outcome.workspace_artifacts) == {
+            "fake-merged",
+            "fake-workspace-scoped",
+        }
+
+
+class TestTheManifestIsExhaustive:
+    def test_every_reporter_appears_whatever_its_behaviour(self, workspace):
+        """The property that makes the manifest trustworthy.
+
+        An operator asking "where is my csv report" must get an answer for every
+        reporter, including the ones that deliberately produced nothing. A
+        manifest that listed only successes would leave the withheld ones
+        indistinguishable from reporters that were never considered.
+        """
+        _, output_dir, _ = workspace
+        _emit(
+            workspace,
+            FakeMergedReporter,
+            FakePerProjectReporter,
+            FakeWorkspaceScopedReporter,
+            FakeUnsupportedReporter,
+            FakeRaisingReporter,
+        )
+
+        assert set(_manifest(output_dir)["reporters"]) == {
+            "fake-merged",
+            "fake-per-project",
+            "fake-workspace-scoped",
+            "fake-unsupported",
+            "fake-raising",
+        }
+
+    def test_all_nineteen_shipped_reporters_are_accounted_for(self, workspace):
+        """Acceptance criterion 23, over the whole shipped set rather than a sample.
+
+        The default plugin registry resolves 15 reporters: the four under
+        ``ash_aws_plugins`` are registered only when an operator names that module
+        in ``ash_plugin_modules``. So a default workspace run's manifest has 15
+        entries, and that is correct -- the manifest is exhaustive over what was
+        registered, not over what exists on disk.
+
+        This asserts the other half: when all nineteen *are* registered, every one
+        gets an entry carrying the behaviour it declared. Without it, "every
+        reporter has an asserted workspace behaviour" would hold for the
+        declaration and be untested for the four an operator has to opt into --
+        which are precisely the four that publish side effects.
+
+        Dependency validation is stubbed to succeed, and that is not merely to
+        avoid flakiness. The four AWS reporters' real ``validate_plugin_dependencies``
+        calls Bedrock and Security Hub, so without the stub this unit test reached a
+        live AWS account -- slow, dependent on ambient credentials, and touching
+        someone's real region to decide the outcome of a test about declarations.
+        Stubbing it also makes the assertion stronger: all nineteen are *considered*,
+        so each one's behaviour is exercised through the branch that acts on it
+        rather than through the skip branch.
+
+        Artefacts are not asserted. The four AWS reporters are all PER_PROJECT, so
+        being considered does not invoke them -- which is what makes stubbing their
+        dependency check safe rather than a way of triggering a publish.
+        """
+        from contextlib import ExitStack
+        from unittest.mock import patch
+
+        from tests.unit.workspace.test_reporter_workspace_behaviour import (
+            EXPECTED_BEHAVIOURS,
+            _iter_reporter_classes,
+        )
+
+        _, output_dir, _ = workspace
+        classes = list(_iter_reporter_classes().values())
+
+        # Patched on every class that *defines* the method, not on the base.
+        # Patching the base alone silently does nothing for the four AWS
+        # reporters, because each overrides it -- and the first version of this
+        # test did exactly that and went on calling Bedrock and Security Hub for
+        # real while appearing to be isolated.
+        definers = [
+            cls for cls in classes if "validate_plugin_dependencies" in cls.__dict__
+        ]
+        assert definers, "no reporter overrides validate_plugin_dependencies"
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(
+                    ReporterPluginBase,
+                    "validate_plugin_dependencies",
+                    return_value=True,
+                )
+            )
+            for cls in definers:
+                stack.enter_context(
+                    patch.object(cls, "validate_plugin_dependencies", return_value=True)
+                )
+            _emit(workspace, *classes)
+
+        entries = _manifest(output_dir)["reporters"]
+        assert {name: entry["behaviour"] for name, entry in entries.items()} == {
+            name: behaviour.value for name, behaviour in EXPECTED_BEHAVIOURS.items()
+        }
+        not_considered = sorted(
+            name for name, entry in entries.items() if not entry["considered"]
+        )
+        # yaml and spdx ship disabled; nothing else should be turned away once
+        # dependencies are satisfied.
+        assert not_considered == ["spdx", "yaml"]
+
+    def test_unsatisfied_dependencies_are_distinguished_from_disabled(self, workspace):
+        """Two reasons, two knobs: credentials or an install, versus the config.
+
+        Collapsing them told an operator with no AWS credentials that they had
+        disabled the reporter, which sends them to edit a file that is already
+        correct. Asserted with a double rather than by letting a real AWS reporter
+        fail its own check, so the test needs no account and cannot flake.
+        """
+        _, output_dir, _ = workspace
+
+        class _UnavailableConfig(ReporterPluginConfigBase):
+            name: str = "fake-unavailable"
+            extension: str = "unavailable.txt"
+            enabled: bool = True
+
+        class FakeUnavailableReporter(ReporterPluginBase[_UnavailableConfig]):
+            workspace_behaviour = ReporterWorkspaceBehaviour.MERGED
+
+            def model_post_init(self, context):
+                if self.config is None:
+                    self.config = _UnavailableConfig()
+                return super().model_post_init(context)
+
+            def validate_plugin_dependencies(self) -> bool:
+                return False
+
+            def report(self, model) -> str:  # pragma: no cover - never invoked
+                raise AssertionError("an unavailable reporter must not be invoked")
+
+        _emit(workspace, FakeUnavailableReporter, FakeDisabledReporter)
+        entries = _manifest(output_dir)["reporters"]
+
+        assert entries["fake-unavailable"]["skipped"] == "dependencies-unsatisfied"
+        assert entries["fake-disabled"]["skipped"] == "disabled"
+
+    def test_the_manifest_records_the_workspace_root(self, workspace):
+        plan, output_dir, _ = workspace
+        _emit(workspace, FakeMergedReporter)
+        assert _manifest(output_dir)["workspace_root"] == plan.workspace_root
+
+
+class TestExecuteWorkspaceRunsTheReportStep:
+    """The wiring, driven through the real ``execute_workspace``.
+
+    Asserted end to end rather than by checking that a mock was called, because
+    the two things most likely to be wrong are the *gate* (does it run when the
+    operator asked for the report phase, and not otherwise) and the *ordering*
+    (the manifest is written after the results file it describes). Neither is
+    visible to a call assertion.
+    """
+
+    @staticmethod
+    def _scanned_workspace(tmp_path):
+        from automated_security_helper.models.asharp_model import AshAggregatedResults
+        from automated_security_helper.schemas.sarif_schema_model import SarifReport
+
+        root = tmp_path / "ws"
+        for key in ("api", "web"):
+            (root / key / "src").mkdir(parents=True, exist_ok=True)
+        (root / "fixture.code-workspace").write_text(
+            json.dumps({"folders": [{"path": "api"}, {"path": "web"}]}),
+            encoding="utf-8",
+        )
+        plan = _plan(root, "api", "web")
+
+        class _Orchestrator:
+            def __init__(self, **kwargs):
+                self.key = Path(kwargs["source_dir"]).name
+
+            @classmethod
+            def create(cls, **kwargs):
+                return cls(**kwargs)
+
+            def execute_scan(self, phases=None):
+                model = AshAggregatedResults()
+                model.sarif = SarifReport.model_validate(
+                    {
+                        "version": "2.1.0",
+                        "runs": [
+                            _run(
+                                self.key,
+                                rule=f"RULE-{self.key.upper()}",
+                                uri=f"src/{self.key}.py",
+                            )
+                        ],
+                    }
+                )
+                return model
+
+        return plan, _Orchestrator
+
+    def _execute(self, tmp_path, *, phases, reporter_classes=None):
+        from automated_security_helper.workspace.execution import (
+            ProjectScanSettings,
+            execute_workspace,
+        )
+
+        plan, orchestrator = self._scanned_workspace(tmp_path)
+        settings = ProjectScanSettings(
+            output_dir=tmp_path / "out",
+            phases=phases,
+            max_parallel_projects=2,
+        )
+        result = execute_workspace(
+            plan,
+            settings,
+            orchestrator_factory=orchestrator.create,
+            reporter_classes=reporter_classes,
+        )
+        return plan, tmp_path / "out", result
+
+    def test_the_report_step_runs_when_the_report_phase_was_requested(self, tmp_path):
+        _, output_dir, result = self._execute(
+            tmp_path,
+            phases=("scan", "report"),
+            reporter_classes=[FakeMergedReporter],
+        )
+        assert (output_dir / REPORTS_DIR_NAME / MANIFEST_FILENAME).is_file()
+        assert result.report_outcome is not None
+        assert "fake-merged" in result.report_outcome.workspace_artifacts
+
+    def test_the_report_step_is_skipped_when_the_phase_was_not_requested(
+        self, tmp_path
+    ):
+        """``--phases scan`` must not produce reports, at workspace level either.
+
+        The companion assertion to the test above: without it, a gate that was
+        wired backwards -- or not wired at all -- would still pass the positive
+        case.
+        """
+        _, output_dir, result = self._execute(
+            tmp_path, phases=("scan",), reporter_classes=[FakeMergedReporter]
+        )
+        assert not (output_dir / REPORTS_DIR_NAME / MANIFEST_FILENAME).exists()
+        assert result.report_outcome is None
+
+    def test_the_merged_artefact_covers_both_projects_end_to_end(self, tmp_path):
+        _, output_dir, _ = self._execute(
+            tmp_path,
+            phases=("scan", "report"),
+            reporter_classes=[FakeMergedReporter],
+        )
+        content = (output_dir / REPORTS_DIR_NAME / "ash.merged.txt").read_text(
+            encoding="utf-8"
+        )
+        assert "RULE-API" in content
+        assert "RULE-WEB" in content
+
+    def test_an_unsupported_reporter_refuses_before_any_project_is_scanned(
+        self, tmp_path
+    ):
+        """Refused up front, so no results file exists to contradict the exit.
+
+        The absence of ``ash_aggregated_results.json`` is the load-bearing
+        assertion, not the exception type. If the refusal happened after the scan,
+        that file would exist carrying ``exit_code`` 0 or 2 while the process
+        exited non-zero for a reason the file does not mention.
+        """
+        from automated_security_helper.core.exceptions import WorkspaceDefinitionError
+
+        with pytest.raises(WorkspaceDefinitionError) as caught:
+            self._execute(
+                tmp_path,
+                phases=("scan", "report"),
+                reporter_classes=[FakeUnsupportedReporter],
+            )
+
+        assert "fake-unsupported" in str(caught.value)
+        assert not (tmp_path / "out" / "ash_aggregated_results.json").exists()
+        assert not (tmp_path / "out" / "projects").exists()
+
+    def test_an_unsupported_reporter_does_not_refuse_without_the_report_phase(
+        self, tmp_path
+    ):
+        """The gate is the same one, so a scan-only run is unaffected.
+
+        An operator running ``--phases scan`` has not asked for a report, so a
+        reporter that cannot produce one is not their problem yet.
+        """
+        _, _, result = self._execute(
+            tmp_path, phases=("scan",), reporter_classes=[FakeUnsupportedReporter]
+        )
+        assert result.exit_code == 2  # the fixture findings, not a refusal
+
+
+class TestSarifStaysOneRunPerProject:
+    """Acceptance criterion 24, asserted on the file a reporter actually wrote.
+
+    Phase 2a asserted this on the aggregator's output. It is re-asserted here on
+    the ``sarif`` reporter's output because that is a different artefact: the
+    reporter dumps ``model.sarif``, and ``SarifReport.merge_sarif_report`` -- a
+    method on that very object -- collapses every run into ``runs[0]``. Nothing
+    but a test stops a future change from calling it on the way out.
+    """
+
+    def test_the_sarif_report_carries_one_run_per_project(self, workspace):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.sarif_reporter import (
+            SarifReporter,
+        )
+
+        _, output_dir, _ = workspace
+        _emit(workspace, SarifReporter)
+
+        document = json.loads(
+            (output_dir / REPORTS_DIR_NAME / "ash.sarif").read_text(encoding="utf-8")
+        )
+        assert len(document["runs"]) == 2
+
+    def test_each_run_declares_its_own_project_root(self, workspace):
+        plan, output_dir, _ = workspace
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.sarif_reporter import (
+            SarifReporter,
+        )
+
+        _emit(workspace, SarifReporter)
+        document = json.loads(
+            (output_dir / REPORTS_DIR_NAME / "ash.sarif").read_text(encoding="utf-8")
+        )
+
+        roots = [
+            run["originalUriBaseIds"][PROJECT_ROOT_URI_BASE_ID]["uri"]
+            for run in document["runs"]
+        ]
+        assert len(set(roots)) == 2
+        for project, root in zip(plan.projects, roots):
+            assert root.endswith(f"/{project.key}/")
+
+    def test_one_project_is_extractable_by_selecting_its_run(self, workspace):
+        """The other half of criterion 24.
+
+        ``workspace.projects[i].sarif_run_index`` names the run, and taking that
+        run whole must yield a document valid for one project on its own -- which
+        is what makes a per-project ``github_ghas`` artefact derivable from the
+        merged SARIF rather than only from the per-project subtree.
+        """
+        _, output_dir, results_path = workspace
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.sarif_reporter import (
+            SarifReporter,
+        )
+
+        _emit(workspace, SarifReporter)
+        document = json.loads(
+            (output_dir / REPORTS_DIR_NAME / "ash.sarif").read_text(encoding="utf-8")
+        )
+        unified = json.loads(results_path.read_text(encoding="utf-8"))
+
+        for entry in unified["workspace"]["projects"]:
+            selected = document["runs"][entry["sarif_run_index"]]
+            assert list(selected["originalUriBaseIds"]) == [PROJECT_ROOT_URI_BASE_ID]
+            for result in selected["results"]:
+                assert result["properties"]["workspace_project"] == entry["project"]
+                for location in result["locations"]:
+                    artifact = location["physicalLocation"]["artifactLocation"]
+                    assert not artifact["uri"].startswith("/")
+                    assert artifact["uriBaseId"] == PROJECT_ROOT_URI_BASE_ID


### PR DESCRIPTION
Stacked on #456. This is the second half of workspace mode: Phase 2b (the project dimension through all 19 reporters) and Phase 3 (the workspace policy file with a severity ceiling and per-project push-down).

50 files, +8,135/-109 against #456's branch.

## Why this PR exists separately

#465 carried this content and merged into #462's branch rather than into #456's. #462 was then squash-merged into #456's branch, which absorbed Phase 2a but not this. The result was that Phase 2b and Phase 3 had no open pull request while #456 — the only one — did not contain them.

This branch is that content replayed onto #456's current head. It is a single commit, one ahead and zero behind, and the five files that define the two phases are byte-identical to what #465 merged:

| file | bytes |
| --- | --- |
| `automated_security_helper/workspace/reporting.py` | 28,101 |
| `automated_security_helper/config/ash_workspace_config.py` | 9,782 |
| `automated_security_helper/workspace/policy.py` | 24,028 |
| `automated_security_helper/schemas/AshWorkspaceConfig.json` | 6,601 |
| `scripts/verify_workspace_policy.py` | 18,215 |

The rebase also picked up what #456's branch had gained from `main` in the meantime — the Dockerfile, the Homebrew formula, `cli/mcp/`, `config/resolve_config.py`, `core/resource_management/scan_tracking.py` and `npm_audit_scanner.py` among 21 files — so this is strictly ahead of the merged content rather than a revert of anything.

The pre-rebase commit is preserved as `save/workspace-phase2b-phase3` in case anyone wants to compare.

## Verified on this tree, not inherited from #465

- `tests/unit/workspace/`: **543 passed**
- `test_workspace_policy.py` + `test_workspace_reporting.py`: **96 passed**
- Rebase applied with **zero conflicts**

## Not finished: three config fields are inert

`workspace.suppressions`, `workspace.ignore_paths` and `workspace.additional_scanners` parse, validate, appear in the generated JSON schema and show up in the `--dry-run` plan — but **never reach any scanner**. An operator writing a workspace-level suppression today would see it echoed back in the plan and reasonably believe findings were suppressed. Nothing would be.

`max_severity_threshold` is unaffected and fully wired; the verdict is computed in `workspace/execution.py` from the plan rather than from the resolved config.

The reason they are not wired is deliberate. Scanners read suppressions and ignore paths from the resolved `AshConfig`, and there is no way to hand the orchestrator one: `ASHScanOrchestrator.__init__` resolves and reassigns its own `config`, and the only other channel, `config_overrides`, **fails open** — `apply_config_overrides` logs a warning and returns the *original* config when an override cannot be applied. Routing a severity policy through that means a typo scans with no policy while the operator believes a ceiling is enforced.

That is fixed by #474 (orchestrator accepts a pre-resolved config) and #475 (overrides fail closed), both open against `main`. The wiring lands here once they do, along with 12 tests already written on `feat/workspace-policy-wiring`. Four of those twelve are load-bearing — verified by building four wrong implementations and measuring which tests caught each.

**Please do not merge this to `main` until the three fields are wired**, or remove them from the schema first. A config field that validates and silently does nothing is worse than one that does not exist, and for suppressions in a security scanner it is a false negative.

## Sequencing

`main` <- #456 (phases 0, 1, 2a) <- this PR (phases 2b, 3).

Note that the merge queue squashes. When #456 merges, this branch's history will contain commits whose content is already upstream under different shas, which git reads as a conflict — and a conflicting PR produces **zero** CI runs rather than red ones, which looks like a queue delay. Rebase this branch onto `main` at that point rather than waiting for checks that will not start.
