### PR TITLE
docs: correct reporter and converter options, and widen the gate to all three

### DIFF
--- a/docs/content/docs/configuration-guide.md
+++ b/docs/content/docs/configuration-guide.md
@@ -101,11 +101,10 @@ converters:
   jupyter:
     enabled: true
     options:
-      # Converter-specific options
+      tool_version: null      # Version constraint for the conversion tool
+      install_timeout: 300    # Seconds allowed for tool installation
   archive:
-    enabled: true
-    options:
-      # Converter-specific options
+    enabled: true             # The archive converter exposes no options
 ```
 
 ### Scanners Configuration
@@ -216,24 +215,19 @@ reporters:
       include_detailed_findings: true
 
   html:
-    enabled: true
-    options:
-      include_detailed_findings: true
+    enabled: true             # The HTML reporter exposes no options
 
-  json:
+  flat-json:                  # Note the hyphen; there is no 'json' reporter
     enabled: true
     options:
-      pretty_print: true
+      include_metadata: true
+      include_scanner_metrics: true
 
   csv:
-    enabled: true
-    options:
-      include_all_fields: false
+    enabled: true             # The CSV reporter exposes no options
 
   sarif:
-    enabled: true
-    options:
-      include_help_uri: true
+    enabled: true             # The SARIF reporter exposes no options
 
   github-ghas:
     enabled: true

--- a/docs/content/docs/plugins/builtin/converters.md
+++ b/docs/content/docs/plugins/builtin/converters.md
@@ -26,11 +26,8 @@ ASH includes 2 built-in converters that preprocess files to make them suitable f
 converters:
   archive:
     enabled: true
-    options:
-      max_extraction_depth: 3
-      max_file_size: "100MB"
-      preserve_permissions: true
-      extract_nested: true
+    # The archive converter exposes no options. It extracts supported archives
+    # so their contents can be scanned; there is nothing to tune per run.
 ```
 
 **Key Features**:
@@ -57,10 +54,8 @@ converters:
   jupyter:
     enabled: true
     options:
-      extract_code_cells: true
-      extract_markdown_cells: false
-      preserve_cell_numbers: true
-      output_format: "python"
+      tool_version: null      # Version constraint for the conversion tool
+      install_timeout: 300    # Seconds allowed for tool installation
 ```
 
 **Key Features**:
@@ -93,19 +88,14 @@ converters:
 converters:
   archive:
     enabled: true
-    options:
-      max_extraction_depth: 2
-      max_file_size: "50MB"
-      allowed_extensions: [".zip", ".tar.gz", ".7z"]
-      exclude_patterns: ["*.exe", "*.dll"]
+    # The archive converter exposes no options. It extracts supported archives
+    # so their contents can be scanned; there is nothing to tune per run.
 
   jupyter:
     enabled: true
     options:
-      extract_code_cells: true
-      extract_markdown_cells: true
-      cell_separator: "# %%"
-      validate_syntax: true
+      tool_version: null
+      install_timeout: 300
 ```
 
 ## Best Practices
@@ -115,10 +105,7 @@ converters:
 ```yaml
 converters:
   archive:
-    options:
-      max_extraction_depth: 3    # Prevent zip bombs
-      max_file_size: "100MB"     # Limit resource usage
-      scan_extracted_only: true  # Don't scan original archives
+    enabled: false             # The only lever is whether extraction runs at all
 ```
 
 ### Jupyter Processing
@@ -126,9 +113,7 @@ converters:
 ```yaml
 converters:
   jupyter:
-    options:
-      preserve_cell_numbers: true  # Accurate line mapping
-      validate_syntax: true        # Skip malformed cells
+    enabled: true                # Cell-to-line mapping is always preserved
 ```
 
 ## Integration with Scanners
@@ -151,18 +136,14 @@ ash analysis.ipynb --scanners bandit,detect-secrets
 ```yaml
 converters:
   archive:
-    options:
-      ignore_extraction_errors: true
-      log_extraction_details: true
+    enabled: true                # Extraction errors are logged and the scan continues
 ```
 
 **Large archives**:
 ```yaml
 converters:
   archive:
-    options:
-      max_file_size: "500MB"
-      max_extraction_depth: 1
+    enabled: true
 ```
 
 ### Jupyter Issues
@@ -171,9 +152,7 @@ converters:
 ```yaml
 converters:
   jupyter:
-    options:
-      skip_invalid_cells: true
-      validate_json: true
+    enabled: true                # A notebook that will not parse is reported, not skipped silently
 ```
 
 ## Next Steps

--- a/docs/content/docs/plugins/builtin/index.md
+++ b/docs/content/docs/plugins/builtin/index.md
@@ -49,14 +49,10 @@ scanners:
 
 reporters:
   html:
-    enabled: true
-    options:
-      include_suppressed: false
+    enabled: true             # The HTML reporter exposes no options
 
   sarif:
-    enabled: true
-    options:
-      include_rule_metadata: true
+    enabled: true             # The SARIF reporter exposes no options
 ```
 
 ## Plugin Categories

--- a/docs/content/docs/plugins/builtin/reporters.md
+++ b/docs/content/docs/plugins/builtin/reporters.md
@@ -33,10 +33,8 @@ ASH includes 14 built-in reporters that generate scan results in various formats
 reporters:
   csv:
     enabled: true
-    options:
-      include_suppressed: false
-      delimiter: ","
-      quote_char: "\""
+    # The CSV reporter exposes no options. Suppressed findings are filtered by
+    # global_settings.suppressions, not per reporter.
 ```
 
 **Output Structure**:
@@ -64,10 +62,7 @@ reporters:
 reporters:
   cyclonedx:
     enabled: true
-    options:
-      format: "json"  # json, xml
-      include_licenses: true
-      include_vulnerabilities: true
+    # The CycloneDX reporter exposes no options.
 ```
 
 **Key Features**:
@@ -92,11 +87,12 @@ reporters:
 **Configuration**:
 ```yaml
 reporters:
-  flatjson:
+  flat-json:              # Note the hyphen; 'flatjson' is not a reporter name
     enabled: true
     options:
-      pretty_print: true
       include_metadata: true
+      include_scanner_metrics: true
+      include_summary_metrics: true
 ```
 
 **Output Structure**:
@@ -130,11 +126,10 @@ reporters:
 **Configuration**:
 ```yaml
 reporters:
-  gitlab_sast:
+  gitlab-sast:            # Note the hyphen; 'gitlab_sast' is not a reporter name
     enabled: true
     options:
-      version: "15.0.4"
-      include_dismissed: false
+      exclude_suppressed: false
 ```
 
 **Key Features**:
@@ -160,7 +155,7 @@ reporters:
   gitlab-sast:
     enabled: true
     options:
-      include_suppressed: false
+      exclude_suppressed: false
 ```
 
 **Output Structure**:
@@ -276,11 +271,7 @@ jobs:
 reporters:
   html:
     enabled: true
-    options:
-      include_suppressed: false
-      theme: "light"  # light, dark
-      show_metrics: true
-      embed_assets: true
+    # The HTML reporter exposes no options.
 ```
 
 **Key Features**:
@@ -308,8 +299,7 @@ reporters:
   junitxml:
     enabled: true
     options:
-      suite_name: "ASH Security Scan"
-      failure_on_finding: true
+      respect_severity_threshold: true
 ```
 
 **Key Features**:
@@ -336,9 +326,13 @@ reporters:
   markdown:
     enabled: true
     options:
-      include_toc: true
-      include_suppressed: false
-      max_findings_per_scanner: 50
+      include_summary: true
+      include_findings_table: true
+      include_detailed_findings: true
+      max_detailed_findings: 50
+      use_collapsible_details: true
+      compact: false
+      top_hotspots_limit: 10
 ```
 
 **Key Features**:
@@ -364,9 +358,7 @@ reporters:
 reporters:
   ocsf:
     enabled: true
-    options:
-      version: "1.0.0"
-      include_raw_data: false
+    # The OCSF reporter exposes no options.
 ```
 
 **Key Features**:
@@ -392,10 +384,7 @@ reporters:
 reporters:
   sarif:
     enabled: true
-    options:
-      include_rule_metadata: true
-      schema_version: "2.1.0"
-      pretty_print: false
+    # The SARIF reporter exposes no options.
 ```
 
 **Key Features**:
@@ -421,10 +410,7 @@ reporters:
 reporters:
   spdx:
     enabled: true
-    options:
-      format: "json"  # json, yaml, tag-value
-      include_files: true
-      document_name: "ASH-SPDX-Report"
+    # The SPDX reporter exposes no options.
 ```
 
 **Key Features**:
@@ -451,10 +437,11 @@ reporters:
   text:
     enabled: true
     options:
-      show_summary: true
-      show_suppressed: false
-      max_line_length: 120
-      color_output: true
+      include_summary: true
+      include_findings_table: true
+      include_detailed_findings: true
+      max_detailed_findings: 50
+      top_hotspots_limit: 10
 ```
 
 **Key Features**:
@@ -480,10 +467,7 @@ reporters:
 reporters:
   yaml:
     enabled: true
-    options:
-      pretty_print: true
-      include_metadata: true
-      flow_style: false
+    # The YAML reporter exposes no options.
 ```
 
 **Key Features**:
@@ -524,27 +508,20 @@ reporters:
   text:
     enabled: true
     options:
-      show_summary: true
-      color_output: true
+      include_summary: true
+      include_detailed_findings: false
 
   # Detailed analysis
   html:
     enabled: true
-    options:
-      theme: "light"
-      include_suppressed: false
 
   # CI/CD integration
   sarif:
     enabled: true
-    options:
-      include_rule_metadata: true
 
   # Data processing
   csv:
     enabled: true
-    options:
-      include_suppressed: true
 ```
 
 ## Best Practices
@@ -570,15 +547,14 @@ reporters: [sarif, junitxml, gitlab-sast]
 ### Performance Considerations
 
 ```yaml
-# Optimize for speed
+# Optimize for speed. The HTML and CSV reporters expose no options, so the lever
+# is which reporters run at all rather than how each one behaves.
 reporters:
   html:
-    options:
-      embed_assets: false  # Faster generation
+    enabled: false          # Skip the largest artifact
 
   csv:
-    options:
-      include_suppressed: false  # Smaller files
+    enabled: true
 ```
 
 ### Output Organization
@@ -647,18 +623,16 @@ pipeline {
 **Large report files**:
 ```yaml
 reporters:
-  html:
+  markdown:                 # html has no options; markdown is the one that caps detail
     options:
-      max_findings_per_scanner: 100
-      include_suppressed: false
+      max_detailed_findings: 100
 ```
 
 **Encoding issues**:
 ```yaml
 reporters:
   csv:
-    options:
-      encoding: "utf-8"
+    enabled: true           # The CSV reporter exposes no options
 ```
 
 **CI/CD integration failures**:

--- a/docs/content/docs/plugins/community/trivy-plugin.md
+++ b/docs/content/docs/plugins/community/trivy-plugin.md
@@ -207,18 +207,14 @@ The Trivy plugin integrates with ASH's unified reporting system, producing resul
 reporters:
   sarif:
     enabled: true
-    options:
-      output_file: "trivy-results.sarif"
-  
+    # Reporters write to the scan's output directory under a fixed name; there
+    # is no per-reporter output_file option.
+
   html:
     enabled: true
-    options:
-      output_file: "security-report.html"
-  
+
   markdown:
     enabled: true
-    options:
-      output_file: "SECURITY.md"
 ```
 
 ## Performance Considerations
@@ -825,12 +821,10 @@ scanners:
 reporters:
   csv:
     enabled: true
-    options:
-      output_file: "license-report.csv"
+    # Reporters write to the scan's output directory under a fixed name; there
+    # is no per-reporter output_file option.
   html:
     enabled: true
-    options:
-      output_file: "license-report.html"
 ```
 
 ```bash
@@ -1791,8 +1785,8 @@ scanners:
 reporters:
   csv:
     enabled: true
-    options:
-      output_file: "license-report.csv"
+    # Reporters write to the scan's output directory under a fixed name; there
+    # is no per-reporter output_file option.
 ```
 
 ```bash

--- a/docs/content/docs/plugins/converter-plugins.md
+++ b/docs/content/docs/plugins/converter-plugins.md
@@ -175,9 +175,8 @@ converters:
   jupyter:
     enabled: true
     options:
-      file_extensions: [".ipynb"]
-      preserve_line_numbers: true
-      include_markdown: false
+      tool_version: null      # Version constraint for the conversion tool
+      install_timeout: 300    # Seconds allowed for tool installation
 ```
 
 ## Testing Converter Plugins

--- a/scripts/verify_docs_freshness.py
+++ b/scripts/verify_docs_freshness.py
@@ -314,33 +314,36 @@ def check_suppression_field_name() -> list[str]:
 
 
 # ---------------------------------------------------------------------------
-# Check 8: documented scanner options exist and validate
+# Check 8: documented plugin options exist and validate
 # ---------------------------------------------------------------------------
 
 
-def _scanner_option_models() -> dict[str, type]:
-    """Map each built-in scanner's config name to its options model.
+def _plugin_option_models(config_suffix: str, options_base: type) -> dict[str, type]:
+    """Map each built-in plugin's config name to its options model.
 
-    Keyed on the ``name`` Literal of the scanner's config class, because that is
-    the string a user actually writes under ``scanners:`` -- ``npm-audit``, not
+    Keyed on the ``name`` Literal of the plugin's config class, because that is the
+    string a user actually writes in the config -- ``npm-audit``, not
     ``NpmAuditScanner``.
+
+    Every module under ``plugin_modules`` is walked rather than filtering on a
+    module-name suffix. Reporter and converter modules do not follow one naming
+    convention (``s3_reporter.py`` but also ``github_ghas_reporter.py``,
+    ``archive_converter.py``), and a suffix filter silently shrinks the model set,
+    which would make this check pass by simply not knowing about a plugin.
     """
     import importlib
     import pkgutil
 
     from automated_security_helper import plugin_modules
-    from automated_security_helper.base.options import ScannerOptionsBase
 
     models: dict[str, type] = {}
     for mod in pkgutil.walk_packages(
         plugin_modules.__path__, plugin_modules.__name__ + "."
     ):
-        if not mod.name.endswith("_scanner"):
-            continue
         try:
             module = importlib.import_module(mod.name)
         except Exception:  # noqa: BLE001, S112  # nosec B112 -- see below
-            # Deliberately broad and deliberately silent. A scanner module whose
+            # Deliberately broad and deliberately silent. A plugin module whose
             # optional dependency is missing in this environment is not a
             # documentation problem, and failing the docs gate on it would make
             # the gate depend on which extras happen to be installed.
@@ -352,11 +355,11 @@ def _scanner_option_models() -> dict[str, type]:
             obj = getattr(module, attr)
             if not isinstance(obj, type):
                 continue
-            if attr.endswith("ScannerConfig") and hasattr(obj, "model_fields"):
+            if attr.endswith(config_suffix) and hasattr(obj, "model_fields"):
                 field = obj.model_fields.get("name")
                 if field is not None and field.default:
                     config_name = field.default
-            elif attr.endswith("ConfigOptions") and issubclass(obj, ScannerOptionsBase):
+            elif attr.endswith("ConfigOptions") and issubclass(obj, options_base):
                 options_cls = obj
 
         if config_name and options_cls is not None:
@@ -365,12 +368,13 @@ def _scanner_option_models() -> dict[str, type]:
     return models
 
 
-def check_scanner_option_keys() -> list[str]:
-    """Every documented scanners.<name>.options block must validate.
+def check_plugin_option_keys() -> list[str]:
+    """Every documented <section>.<name>.options block must validate.
 
     Why this check exists
     ---------------------
-    ``ScannerOptionsBase`` sets ``extra="allow"``, so an option name that does not
+    The three options bases -- scanner, reporter, converter -- all set
+    ``extra="allow"``, so an option name that does not
     exist is accepted and then never read. A reader who copies it gets no error and
     no effect. That let 46 invented option keys accumulate across the configuration
     guide and the built-in plugin pages -- ``severity_level`` for bandit (the field
@@ -382,17 +386,44 @@ def check_scanner_option_keys() -> list[str]:
     lowercase-only while ``severity_threshold`` is uppercase-only, and cdk-nag's
     ``nag_packs`` is an object of per-pack booleans rather than a list.
 
-    Only blocks that parse as a mapping with a ``scanners`` key are considered, and
-    only for scanners this build knows about, so a snippet documenting a third-party
-    scanner is skipped rather than reported.
+    All three plugin kinds are covered, not just scanners. Scanners were fixed first
+    and reporters and converters were left, which hid 53 more invented reporter keys
+    and 30 converter keys behind a passing check -- seven reporters (``csv``,
+    ``cyclonedx``, ``html``, ``ocsf``, ``sarif``, ``spdx``, ``yaml``) and the
+    ``archive`` converter expose *no* options at all, so every option documented for
+    them was fictional.
+
+    ``global_settings`` is deliberately not in this table: it sets
+    ``extra="forbid"``, so a wrong key there is already a startup error rather than a
+    silent no-op, and it has accumulated none.
+
+    Only blocks that parse as a mapping with one of these section keys are
+    considered, and only for plugins this build knows about, so a snippet documenting
+    a third-party plugin is skipped rather than reported.
     """
     import yaml
     from pydantic import ValidationError
 
+    from automated_security_helper.base.options import (
+        ConverterOptionsBase,
+        ReporterOptionsBase,
+        ScannerOptionsBase,
+    )
+
+    # (config section key, config class suffix, options base class)
+    kinds = (
+        ("scanners", "ScannerConfig", ScannerOptionsBase),
+        ("reporters", "ReporterConfig", ReporterOptionsBase),
+        ("converters", "ConverterConfig", ConverterOptionsBase),
+    )
+
     failures: list[str] = []
-    models = _scanner_option_models()
-    if not models:
-        return ["Could not import any built-in scanner options model"]
+    models: dict[str, dict[str, type]] = {}
+    for section, config_suffix, base in kinds:
+        found = _plugin_option_models(config_suffix, base)
+        if not found:
+            return [f"Could not import any built-in {section} options model"]
+        models[section] = found
 
     fence = re.compile(r"```ya?ml\n(.*?)```", re.DOTALL)
 
@@ -410,44 +441,46 @@ def check_scanner_option_keys() -> list[str]:
                 continue
             if not isinstance(parsed, dict):
                 continue
-            scanners = parsed.get("scanners")
-            if not isinstance(scanners, dict):
-                continue
 
-            for scanner_name, scanner_cfg in scanners.items():
-                if not isinstance(scanner_cfg, dict):
-                    continue
-                options = scanner_cfg.get("options")
-                if not isinstance(options, dict):
-                    continue
-                model = models.get(scanner_name)
-                if model is None:
+            for section, _config_suffix, _base in kinds:
+                entries = parsed.get(section)
+                if not isinstance(entries, dict):
                     continue
 
-                for key in options:
-                    if key not in model.model_fields:
-                        failures.append(
-                            f"{rel_path}:~{line_no} scanners.{scanner_name}"
-                            f".options.{key} is not a field on "
-                            f"{model.__name__}; extra='allow' means it is "
-                            f"accepted and ignored"
+                for plugin_name, plugin_cfg in entries.items():
+                    if not isinstance(plugin_cfg, dict):
+                        continue
+                    options = plugin_cfg.get("options")
+                    if not isinstance(options, dict):
+                        continue
+                    model = models[section].get(plugin_name)
+                    if model is None:
+                        continue
+
+                    for key in options:
+                        if key not in model.model_fields:
+                            failures.append(
+                                f"{rel_path}:~{line_no} {section}.{plugin_name}"
+                                f".options.{key} is not a field on "
+                                f"{model.__name__}; extra='allow' means it is "
+                                f"accepted and ignored"
+                            )
+
+                    try:
+                        model.model_validate(options)
+                    except ValidationError as exc:
+                        detail = next(
+                            (
+                                ln.strip()
+                                for ln in str(exc).splitlines()[1:]
+                                if ln.strip() and "further information" not in ln
+                            ),
+                            str(exc).splitlines()[0],
                         )
-
-                try:
-                    model.model_validate(options)
-                except ValidationError as exc:
-                    detail = next(
-                        (
-                            ln.strip()
-                            for ln in str(exc).splitlines()[1:]
-                            if ln.strip() and "further information" not in ln
-                        ),
-                        str(exc).splitlines()[0],
-                    )
-                    failures.append(
-                        f"{rel_path}:~{line_no} scanners.{scanner_name}.options "
-                        f"does not validate against {model.__name__}: {detail}"
-                    )
+                        failures.append(
+                            f"{rel_path}:~{line_no} {section}.{plugin_name}.options "
+                            f"does not validate against {model.__name__}: {detail}"
+                        )
 
     return failures
 
@@ -466,7 +499,7 @@ def main() -> int:
         ("Version consistency", check_version_consistency),
         ("Config file path consistency", check_config_path),
         ("Suppression field name", check_suppression_field_name),
-        ("Scanner options in docs exist and validate", check_scanner_option_keys),
+        ("Plugin options in docs exist and validate", check_plugin_option_keys),
     ]
 
     all_failures: list[tuple[str, list[str]]] = []


### PR DESCRIPTION
Follow-up to #479, which fixed 46 invented option keys under `scanners:` and added a check for them. **It only covered scanners.** Reporters and converters have the same `extra="allow"` on their options bases, so the identical defect was sitting behind a passing gate.

| options base | `extra` | documented keys that are not fields |
|---|---|---|
| `ScannerOptionsBase` | `allow` | 46 — fixed in #479 |
| `ReporterOptionsBase` | `allow` | **53** |
| `ConverterOptionsBase` | `allow` | **30** |
| `global_settings` | **`forbid`** | **0** |

That last row is the argument. The one config section that forbids extras has accumulated nothing; the three that allow them accumulated 129 between them.

## What was wrong

Seven reporters — `csv`, `cyclonedx`, `html`, `ocsf`, `sarif`, `spdx`, `yaml` — and the `archive` converter expose **no options at all**. Every option documented for them was fictional: `theme`, `embed_assets`, `pretty_print`, `max_extraction_depth`, `max_file_size`, `document_name`. A reader who copied any of them got no error and no effect, because `extra="allow"` stores the key and nothing reads it.

Where a real equivalent exists, it is used:

- `include_suppressed` → `exclude_suppressed` (gitlab-sast)
- `max_findings_per_scanner` → `max_detailed_findings` (markdown)
- `suite_name` / `failure_on_finding` → `respect_severity_threshold` (junitxml)

Where none exists, the block now says so instead of inventing a plausible key. The `output_file` examples in the Trivy page are replaced with a note that reporters write to the scan's output directory under a fixed name.

**Three wrong plugin names** also turned up: `flatjson` and `json` (the reporter is `flat-json`) and `gitlab_sast` (`gitlab-sast`). The check cannot catch these — it skips names it does not recognize, which is how it avoids failing on the third-party plugins documented in the community pages. Fixed by hand, and the limitation is now stated in the docstring; telling a typo'd built-in from a legitimate third-party name is not something this check can do reliably.

## The check

`_scanner_option_models` becomes `_plugin_option_models(config_suffix, options_base)` and the check loops over all three sections.

The module-name filter is gone. It matched `*_scanner`, and reporter and converter modules do not follow one convention (`s3_reporter.py` but also `github_ghas_reporter.py`, `archive_converter.py`) — a suffix filter would silently shrink the model set and let the check pass by simply not knowing a plugin exists.

Verified by mutation, each arm run against the committed check:

| mutation | result |
|---|---|
| reintroduce junitxml `failure_on_finding` | FAIL, names the key and the model |
| reintroduce jupyter `max_file_size` | FAIL, names the key and the model |
| both reverted | 8 passed, 0 failed |

## Verification

- Docs freshness **8/8**.
- `mkdocs build --strict` exits **0**.
- Documented plugin option keys failing the check: **83 → 0**.
- Unit suite **4516 passed, 0 failed**.
- ruff on the changed script sits at the same 6 pre-existing findings; the single line it would reformat is in `check_cli_flags`, untouched here.

Net −31 lines: removing fictional options made the docs shorter.