### PR TITLE
docs: recommend building the ASH image inside your own organization

### DIFF
--- a/docs/content/.nav.yml
+++ b/docs/content/.nav.yml
@@ -3,6 +3,7 @@ nav:
   - Getting Started:
       - Quick Start Guide: docs/quick-start-guide.md
       - Installation Guide: docs/installation-guide.md
+      - Building Your Own Container Image: docs/building-your-own-image.md
       - Migrating from ASH v2 to v3: docs/migration-guide.md
       - Troubleshooting UV Installation: docs/troubleshooting-uv-installation.md
       - UV Tool Installation Guide: docs/uv-tool-installation-guide.md

--- a/docs/content/docs/advanced-usage.md
+++ b/docs/content/docs/advanced-usage.md
@@ -149,6 +149,12 @@ ash --mode container --oci-runner finch
 
 ### Custom Container Images
 
+ASH does not publish a container image to a public registry. Building it yourself and
+hosting it in your own registry is the recommended posture, so that the provenance and
+patching cadence of the image that reads your source code belong to you. See
+[Building your own container image](building-your-own-image.md) for the reasoning, the
+rebuild cadence it commits you to, and offline builds.
+
 ```bash
 # Specify a custom container image
 export ASH_IMAGE_NAME="my-registry/ash:custom"

--- a/docs/content/docs/advanced-usage.md.template
+++ b/docs/content/docs/advanced-usage.md.template
@@ -149,6 +149,12 @@ ash --mode container --oci-runner finch
 
 ### Custom Container Images
 
+ASH does not publish a container image to a public registry. Building it yourself and
+hosting it in your own registry is the recommended posture, so that the provenance and
+patching cadence of the image that reads your source code belong to you. See
+[Building your own container image](building-your-own-image.md) for the reasoning, the
+rebuild cadence it commits you to, and offline builds.
+
 ```bash
 # Specify a custom container image
 export ASH_IMAGE_NAME="my-registry/ash:custom"

--- a/docs/content/docs/building-your-own-image.md
+++ b/docs/content/docs/building-your-own-image.md
@@ -1,0 +1,124 @@
+# Building your own container image
+
+ASH does not publish a container image to a public registry, and is not planning to.
+The recommended posture is that the organization running ASH builds the image and
+hosts it in its own registry.
+
+## Why you build it yourself
+
+ASH reads your source code. An image that scans your repositories sits in the same
+trust position as your build tooling, so the question "what is in this image, when did
+it change, and who approved that change" needs an answer that belongs to you rather
+than to an upstream publisher.
+
+Building it yourself gives you four things a pulled public image cannot:
+
+- **A known provenance.** The image came from a Dockerfile in a commit you can name,
+  built by a pipeline you control.
+- **A patching cadence you set.** You decide when the base image and the bundled
+  scanner tools move, rather than inheriting whenever an upstream tag was pushed.
+- **A scanning surface you can inspect.** The image can be scanned, signed, and
+  admitted by the same controls you already apply to your own images.
+- **No new external dependency at scan time.** Your CI pulls from your registry, so a
+  scan does not fail because a public registry is unavailable or rate-limited.
+
+The tradeoff is real and worth stating plainly: you own the rebuild cadence. An image
+built once and never rebuilt ages, and ASH's bundled scanners age with it. See
+[Keeping it current](#keeping-it-current).
+
+## Build it once, host it internally
+
+```bash
+# Build the image
+ash build-image --build-target non-root
+
+# Tag and push to your own registry
+docker tag automated-security-helper:non-root \
+  my-registry.example.com/security/ash:3.6.0
+docker push my-registry.example.com/security/ash:3.6.0
+```
+
+Two build targets exist:
+
+| Target | Runs as | Use when |
+|---|---|---|
+| `non-root` | An unprivileged user | The default. Prefer it. |
+| `ci` | Root | The runner's UID/GID mapping makes an unprivileged user impractical |
+
+Point ASH at your published image with `ASH_IMAGE_NAME`:
+
+```bash
+export ASH_IMAGE_NAME="my-registry.example.com/security/ash:3.6.0"
+ash --mode container --source-dir .
+```
+
+Tag with the ASH version you built rather than only `latest`, so a scan result can be
+traced back to a specific image. A moving `latest` makes two scans that disagree
+impossible to explain.
+
+## Keeping it current
+
+ASH orchestrates external scanners, and their versions are not all pinned. A rebuild
+can therefore change which findings you get, in both directions — a scanner release
+can add checks or drop them. That is an argument for rebuilding on a schedule you
+choose and reviewing the delta, not for rebuilding as rarely as possible.
+
+A workable cadence:
+
+- Rebuild when you upgrade ASH, and tag the image with that ASH version.
+- Rebuild on a fixed interval regardless, so base-image CVE fixes land.
+- Compare a scan of a known repository across the old and new image before promoting
+  the new one. A jump in finding counts is usually a scanner version change rather
+  than a change in your code.
+
+## Air-gapped and offline builds
+
+Building with `--offline` caches the tool vulnerability databases into the image
+itself, so a scan needs no network access:
+
+```bash
+ash build-image --build-target non-root --offline
+```
+
+The build itself still requires network access — that is when the dependencies and
+databases are fetched. Only the resulting scan is offline. An offline image's
+databases are frozen at build time, which makes the rebuild cadence above load-bearing
+rather than optional.
+
+## If you would rather not run a container
+
+`--mode local` runs ASH as a Python process with no image involved:
+
+```bash
+uvx automated-security-helper --mode local --source-dir .
+```
+
+This avoids the image question entirely, at a cost: a few of the tools ASH
+orchestrates cannot be installed through Python packaging alone, so local mode runs a
+smaller set of scanners than container mode. Check the scanner table in the run summary
+to see which ones participated rather than assuming parity.
+
+## If you build per run in CI
+
+Building on every run is supported and is the simplest thing that works, but it is the
+slowest. On GitHub Actions, ASH passes `--cache-from`/`--cache-to type=gha`
+automatically when `ACTIONS_CACHE_URL` or `ACTIONS_RESULTS_URL` is set, with a separate
+cache scope per build target, so a warm cache skips most of the build. Nothing needs
+configuring for that.
+
+Even with caching, a registry-hosted image is faster and gives you the provenance
+story above. Per-run builds are best treated as a starting point rather than a
+destination.
+
+## Extending the image
+
+`--custom-containerfile` builds your own Dockerfile on top of ASH's, with the ASH image
+passed in as the `ASH_BASE_IMAGE` build argument:
+
+```bash
+ash build-image --build-target ci --custom-containerfile ./Dockerfile.internal
+```
+
+Supplying a custom containerfile forces the `ci` build target, so the run-as-non-root
+configuration is not applied. Securing the final image is then yours to do — set a
+non-root `USER` in your own Dockerfile if you need one.

--- a/docs/content/docs/migration-guide.md.template
+++ b/docs/content/docs/migration-guide.md.template
@@ -219,7 +219,7 @@ scanners:
   bandit:
     enabled: true
     options:
-      confidence_level: HIGH
+      confidence_level: high  # lowercase only; HIGH is rejected
 reporters:
   markdown:
     enabled: true


### PR DESCRIPTION
Companion to closing #153 as not planned. If ASH does not publish a container image, adopters need to be told what to do instead — and the recommendation should be explicit rather than implied by an absence.

## The page

The argument is **trust lifecycle**. ASH reads your source code, so the image scanning your repositories sits in the same trust position as your build tooling. "What is in this image, when did it change, who approved that change" should have an answer owned by the organization being scanned.

It states the cost of that posture, not just the benefit: you own the rebuild cadence, and ASH's bundled scanner tools are not all pinned, so a rebuild can change which findings you get **in either direction**. Recommends a fixed rebuild interval, tagging with the ASH version instead of a moving `latest`, and diffing a known repository across old and new images before promoting.

Also covered, each a real alternative rather than a workaround:

- `--offline` at build time caches vulnerability databases into the image so the scan needs no network — while the build still does. Frozen databases make the rebuild cadence load-bearing.
- `--mode local` avoids images entirely, at the cost of a smaller scanner set.
- Per-run builds get GHA layer caching automatically when `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` is set, one scope per build target.
- `--custom-containerfile` forces the `ci` target, so run-as-non-root is not applied and securing the final image becomes the operator's job — stated plainly, since the flag's own help text buries it.

Every command, flag and variable was checked against source rather than assumed: `ash build-image` (`cli/main.py:32`), `ASH_IMAGE_NAME` (`run_ash_container.py:891`), `BuildTarget` non-root/ci (`core/enums.py:82-84`), GHA cache args (`run_ash_container.py:379-392`).

## A generated file nearly ate part of this, and it caught a live regression

`advanced-usage.md` takes the cross-link, and it is **generated** from `advanced-usage.md.template` by `scripts/version_template_manager.py`, which the release workflow runs. Editing only the `.md` would have been reverted at the next release, so the template carries the edit.

Checking for that turned up a **live regression from #479**: `migration-guide.md` is generated too, and #479 fixed `confidence_level: HIGH` → `high` only in the generated file. The template still said `HIGH`, so running the generator put the invalid value back — and `confidence_level` is `Literal['all','low','medium','high']`, so uppercase is *rejected*, not ignored. Fixed in the template here.

The docs gate added in #479 is what surfaced it, on its own author's change. That is the gate doing exactly what it was added for.

## Verification

- Docs freshness **8/8** (it failed before the template fix, which is how the regression was found).
- `mkdocs build --strict` exits 0; the page builds to `public/docs/building-your-own-image/` (71 KB) and is linked from the home nav.
- Regenerating from templates leaves the cross-link and the `confidence_level` fix intact — confirmed by running the generator and re-diffing.
- Unit suite 4516 passed, 0 failed.