### PR TITLE
fix(scanners): set the detect-secrets scan root on every scan

### DIFF
--- a/automated_security_helper/core/progress.py
+++ b/automated_security_helper/core/progress.py
@@ -78,10 +78,12 @@ class LiveProgressDisplay:
         # Create a log panel for displaying log messages
         self.log_panel = RichLogPanel(max_lines=max_log_lines)
 
-        # Set up a log handler to capture logs with appropriate level based on flags
+        # Set up a log handler to capture logs with appropriate level based on flags.
+        # 15 is VERBOSE, and it is the default rather than a level `verbose` raises us
+        # to, so that flag needs no branch of its own here. Lowering this default to
+        # INFO would change what every run prints, not just verbose ones -- see
+        # tests/unit/core/test_progress.py, which pins the mapping.
         log_level = 15
-        if verbose:
-            log_level = 15  # VERBOSE level
         if debug:
             log_level = logging.DEBUG
 

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
@@ -540,12 +540,15 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                 executor = ThreadPoolExecutor(max_workers=1)
                 # scan_files() reads each name as os.path.join(self.root, name),
                 # which is only a no-op for absolute names. ``source_dir`` may be
-                # relative -- ``ash --source-dir ./sub`` reaches the orchestrator
-                # as given -- and the scan set inherits that, so absolutize here:
-                # with a relative name a non-empty root would send detect-secrets
-                # looking for <root>/<root>/<file> and quietly find nothing. Kept
-                # separate from ``scannable`` so the baseline exclude patterns
-                # above still match against the paths they were written for.
+                # relative: the CLI absolutizes it in run_ash_scan, but a library
+                # caller reaches ASHScanOrchestrator directly and
+                # model_post_init only coerces a str to Path -- it does not
+                # anchor it -- so source_dir="./sub" arrives relative and the
+                # scan set inherits that. Absolutize here: with a relative name a
+                # non-empty root would send detect-secrets looking for
+                # <root>/<root>/<file> and quietly find nothing. Kept separate
+                # from ``scannable`` so the baseline exclude patterns above still
+                # match against the paths they were written for.
                 scan_paths = [str(Path(item).absolute()) for item in scannable]
                 future = executor.submit(
                     self._secrets_collection.scan_files, *scan_paths

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/detect_secrets_scanner.py
@@ -406,7 +406,32 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
                         baseline=json.load(f),
                     )
 
-                self._secrets_collection.root = Path(target).absolute()
+            # ``root`` has to be set for every scan, not only for the baseline
+            # case above. SecretsCollection.scan_files() has two branches: a
+            # single file goes through scan_file() and is keyed by the path it
+            # was handed, but two or more files go through a multiprocessing
+            # pool and are keyed by os.path.relpath(secret.filename, self.root).
+            # SecretsCollection defaults ``root`` to '', and os.path.abspath('')
+            # is the process working directory -- so reported finding paths
+            # silently depended on where ASH happened to be invoked from, and on
+            # Windows there is no relative path between two drives at all:
+            # scanning a tree on D: from a process on C: raised
+            # "ValueError: path is on mount 'C:', start on mount 'D:'"
+            # in place of the findings.
+            #
+            # Anchor it to the directory the scan set is enumerated from just
+            # below, which is an ancestor of every scanned file by construction,
+            # so the relative path is always expressible. ``absolute()`` and not
+            # ``resolve()``: the file list keeps whatever symlinked prefix it was
+            # walked with, and resolving only one side of os.path.relpath() would
+            # turn every key into a chain of '..' segments.
+            scan_root = (
+                self.context.work_dir
+                if target_type == "converted"
+                else self.context.source_dir
+            )
+            self._secrets_collection.root = Path(scan_root).absolute()
+
             # Find all files to scan from the scan set
             scannable = [
                 str(item)
@@ -513,8 +538,17 @@ class DetectSecretsScanner(ScannerPluginBase[DetectSecretsScannerConfig]):
             with transient_settings(scan_settings_dict) as settings:
                 ASH_LOGGER.debug(f"Settings: {settings}")
                 executor = ThreadPoolExecutor(max_workers=1)
+                # scan_files() reads each name as os.path.join(self.root, name),
+                # which is only a no-op for absolute names. ``source_dir`` may be
+                # relative -- ``ash --source-dir ./sub`` reaches the orchestrator
+                # as given -- and the scan set inherits that, so absolutize here:
+                # with a relative name a non-empty root would send detect-secrets
+                # looking for <root>/<root>/<file> and quietly find nothing. Kept
+                # separate from ``scannable`` so the baseline exclude patterns
+                # above still match against the paths they were written for.
+                scan_paths = [str(Path(item).absolute()) for item in scannable]
                 future = executor.submit(
-                    self._secrets_collection.scan_files, *scannable
+                    self._secrets_collection.scan_files, *scan_paths
                 )
                 try:
                     future.result(timeout=scan_timeout)

--- a/tests/unit/core/test_progress.py
+++ b/tests/unit/core/test_progress.py
@@ -1,0 +1,123 @@
+"""Tests for LiveProgressDisplay's log-level selection.
+
+Why this exists. ``LiveProgressDisplay.__init__`` turns the ``verbose`` and
+``debug`` flags into the level of the handler it attaches to ``ASH_LOGGER``, and
+nothing tested that mapping. Under that gap the constructor carried a dead
+branch for years: it set ``log_level = 15``, then ``if verbose: log_level = 15``.
+The value was already 15, so the branch could not change anything, and no test
+failed when it was deleted -- because no test looked at the level at all.
+
+So these tests do not exist to catch the dead branch. They exist to catch the
+change that gap invites next. The natural reading of the old code is that the
+default was meant to be ``logging.INFO`` and ``verbose`` was meant to raise it to
+VERBOSE; someone acting on that reading would lower the default and change what
+every run prints, verbose or not. That is a behavior change requiring the
+original author's intent, not a cleanup, so the mapping is pinned here and the
+default stays at VERBOSE until someone decides otherwise on purpose.
+
+Note on what is asserted. The tests read ``display.log_handler.level`` rather
+than capturing emitted output. That is the value under test -- the level the
+handler filters at -- and reading it avoids ``caplog``/``capsys`` entirely.
+Worth avoiding: ``pytest.ini`` sets ``log_cli = True``, and pytest's live-logging
+handler on the ``ash`` logger suspends and resumes capture around each write,
+which can close a captured stream and raise ``ValueError: I/O operation on closed
+file``. See ``_keep_live_logging_off_the_ash_logger`` in ``tests/conftest.py``.
+"""
+
+import logging
+
+import pytest
+
+from automated_security_helper.core.progress import LiveProgressDisplay
+from automated_security_helper.utils.log import ASH_LOGGER
+
+# ``utils.log`` registers VERBOSE at 15 via ``addLoggingLevel("VERBOSE", 15)``.
+# Spelled as a literal here for the same reason ``progress.py`` uses one: the
+# module-level ``VERBOSE_LEVEL`` reads back whatever is registered under that
+# name, so it is only usually 15, and these tests are pinning the number.
+VERBOSE = 15
+
+
+@pytest.fixture
+def make_display():
+    """Build ``LiveProgressDisplay`` objects, detaching their handlers on teardown.
+
+    ``__init__`` calls ``ASH_LOGGER.addHandler``, and ``ASH_LOGGER`` is a
+    process-global logger, so a test that constructs a display and walks away
+    leaks a handler into every test that follows it in the same xdist worker.
+    Teardown removes only the handlers these tests added; it must not clear
+    ``ASH_LOGGER.handlers``, which would also detach the session-scoped
+    live-logging handler that ``tests/conftest.py`` manages.
+    """
+    created = []
+
+    def _make(*, verbose: bool, debug: bool) -> LiveProgressDisplay:
+        # show_progress=False keeps the Live display from taking over the
+        # terminal; the level is computed regardless of that flag.
+        display = LiveProgressDisplay(show_progress=False, verbose=verbose, debug=debug)
+        created.append(display)
+        return display
+
+    yield _make
+
+    for display in created:
+        ASH_LOGGER.removeHandler(display.log_handler)
+
+
+@pytest.mark.parametrize(
+    ("verbose", "debug", "expected_level"),
+    [
+        (False, False, VERBOSE),
+        (True, False, VERBOSE),
+        (False, True, logging.DEBUG),
+        (True, True, logging.DEBUG),
+    ],
+)
+def test_log_handler_level_for_each_flag_combination(
+    make_display, verbose, debug, expected_level
+):
+    """Every (verbose, debug) pair maps to exactly one handler level.
+
+    VERBOSE is the floor, and ``debug`` wins wherever it is set. Lowering the
+    no-flags case to INFO fails here, which is the point.
+    """
+    display = make_display(verbose=verbose, debug=debug)
+
+    assert display.log_handler.level == expected_level, (
+        f"verbose={verbose}, debug={debug} produced "
+        f"{logging.getLevelName(display.log_handler.level)} "
+        f"({display.log_handler.level}), expected "
+        f"{logging.getLevelName(expected_level)} ({expected_level})"
+    )
+
+
+@pytest.mark.parametrize("debug", [False, True])
+def test_verbose_does_not_change_the_level(make_display, debug):
+    """``verbose`` is deliberately not a lever on this level.
+
+    This is the property that made the old ``if verbose:`` branch dead, stated
+    directly: the level is the same whether or not ``verbose`` is set. It is
+    separate from the mapping test above because it still holds if the default
+    moves -- so re-adding a ``verbose`` branch that actually does something
+    fails here, while a change to the default fails the mapping test instead.
+    """
+    without_verbose = make_display(verbose=False, debug=debug)
+    with_verbose = make_display(verbose=True, debug=debug)
+
+    assert with_verbose.log_handler.level == without_verbose.log_handler.level
+
+
+def test_verbose_is_still_recorded_on_the_instance():
+    """``verbose`` survives as public state even though it sets no level.
+
+    Deleting the dead branch left ``self.verbose = verbose`` as the parameter's
+    only use. ``LiveProgressDisplay`` is public API in a published package, so
+    the attribute stays whether or not this module reads it; this pins that, so
+    a later "unused parameter" cleanup has to break a test rather than a caller.
+    """
+    display = LiveProgressDisplay(show_progress=False, verbose=True, debug=False)
+    try:
+        assert display.verbose is True
+        assert display.debug is False
+    finally:
+        ASH_LOGGER.removeHandler(display.log_handler)

--- a/tests/unit/plugin_modules/test_detect_secrets_scan_root.py
+++ b/tests/unit/plugin_modules/test_detect_secrets_scan_root.py
@@ -1,0 +1,236 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests: SecretsCollection.root must be anchored on every scan.
+
+``SecretsCollection.scan_files()`` has two branches. A single file goes through
+``scan_file()`` and is keyed by the path it was handed. Two or more files go
+through a multiprocessing pool and are keyed by
+``os.path.relpath(secret.filename, self.root)`` -- only that branch computes a
+relative path, so only that branch can fail.
+
+``SecretsCollection.__init__`` defaults ``root`` to ``''``, and
+``os.path.abspath('')`` is the process working directory. The scanner used to
+assign ``root`` only for source scans that had a baseline file, so every other
+scan keyed its findings against wherever ASH happened to be launched from. Two
+consequences:
+
+* reported finding paths moved when the working directory moved, and
+* on Windows there is no relative path between two drives at all, so a scan
+  target on a different drive from the ASH process raised
+  ``ValueError: path is on mount 'C:', start on mount 'D:'`` -- reaching the user
+  as a ScannerError in place of their findings.
+
+The fix anchors ``root`` to the directory the scan set was enumerated from
+(``source_dir``, or ``work_dir`` for converted targets), which is an ancestor of
+every scanned file by construction, and hands ``scan_files()`` absolute names so
+the ``os.path.join(root, name)`` it performs internally stays a no-op.
+
+Windows cannot be executed here, so ``ntpath`` -- the pure-Python Windows flavour
+of ``os.path``, whose semantics are the ones that run on Windows regardless of
+host -- stands in for it.
+"""
+
+import json
+import ntpath
+import os
+from pathlib import Path
+
+import pytest
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.default_config import get_default_config
+from automated_security_helper.plugin_modules.ash_builtin.scanners.detect_secrets_scanner import (
+    DetectSecretsScanner,
+    DetectSecretsScannerConfig,
+)
+
+# A fake value. Written to a file it trips detect-secrets' keyword plugin, which
+# is all these tests need from it.
+_KEYWORD_LINE = 'secret = "base64_encoded_secret=="'  # pragma: allowlist secret
+
+# Where _write_secret_files puts them, relative to the directory it is given.
+_EXPECTED_KEYS = {"first.py", "nested/second.py"}
+
+
+def _write_secret_files(directory: Path) -> None:
+    """Write two secret-bearing files, one of them nested.
+
+    Two is the load-bearing number: a scan set of one file takes the
+    ``scan_file()`` branch, which never consults ``root``.
+    """
+    nested = directory / "nested"
+    nested.mkdir(parents=True, exist_ok=True)
+    (directory / "first.py").write_text(_KEYWORD_LINE)
+    (nested / "second.py").write_text(_KEYWORD_LINE)
+
+
+def _scanner(
+    source_dir: Path, output_dir: Path, work_dir: Path | None = None
+) -> DetectSecretsScanner:
+    return DetectSecretsScanner(
+        context=PluginContext(
+            source_dir=source_dir,
+            output_dir=output_dir,
+            work_dir=work_dir if work_dir is not None else output_dir / "converted",
+            config=get_default_config(),
+        ),
+        config=DetectSecretsScannerConfig(),
+    )
+
+
+def _keys(scanner: DetectSecretsScanner) -> set:
+    """Collection keys, separator-normalised.
+
+    ``os.path.relpath`` returns backslashes on Windows and the assertions are
+    about which file each finding names, not about which separator this platform
+    spells it with.
+    """
+    return {Path(key).as_posix() for key in scanner._secrets_collection.data}
+
+
+def test_source_scan_anchors_root_to_the_source_dir(tmp_path):
+    """A source scan with no baseline file must still anchor root."""
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    _write_secret_files(source_dir)
+    output_dir.mkdir()
+
+    scanner = _scanner(source_dir, output_dir)
+    report = scanner.scan(target=source_dir, target_type="source")
+
+    assert report is not False
+    assert scanner._secrets_collection.root == source_dir.absolute()
+    assert _keys(scanner) == _EXPECTED_KEYS
+
+
+def test_converted_scan_anchors_root_to_the_work_dir(tmp_path):
+    """A converted scan reads from work_dir, so that is what root must name.
+
+    ``target`` and ``work_dir`` coincide in production, but the scan set is
+    enumerated from ``work_dir``, and root has to agree with the file list rather
+    than with the caller's argument.
+    """
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    work_dir = output_dir / "converted"
+    source_dir.mkdir()
+    _write_secret_files(work_dir)
+
+    scanner = _scanner(source_dir, output_dir, work_dir=work_dir)
+    report = scanner.scan(target=work_dir, target_type="converted")
+
+    assert report is not False
+    assert scanner._secrets_collection.root == work_dir.absolute()
+    assert _keys(scanner) == _EXPECTED_KEYS
+
+
+def test_baseline_scan_anchors_root(tmp_path):
+    """The baseline branch replaces the collection object, so it must be anchored
+    after the swap, not before it -- ``load_from_baseline`` returns a fresh
+    ``SecretsCollection`` whose root is back at ``''``."""
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    _write_secret_files(source_dir)
+    output_dir.mkdir()
+    baseline = source_dir / ".secrets.baseline"
+    baseline.write_text(
+        json.dumps(
+            {
+                "version": "1.5.0",
+                "plugins_used": [],
+                "filters_used": [],
+                "results": {},
+            }
+        )
+    )
+
+    scanner = _scanner(source_dir, output_dir)
+    scanner.config.options.baseline_file = baseline
+    report = scanner.scan(target=source_dir, target_type="source")
+
+    assert report is not False
+    assert scanner._secrets_collection.root == source_dir.absolute()
+
+
+def test_keys_do_not_depend_on_the_working_directory(tmp_path, monkeypatch):
+    """Same tree, working directory outside it: the keys must not move.
+
+    This is the pre-fix defect in its POSIX form. With root at ``''`` the keys
+    were computed against the working directory, so they came back as a chain of
+    parent hops and changed whenever ASH was launched from somewhere else.
+    """
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    _write_secret_files(source_dir)
+    output_dir.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    scanner = _scanner(source_dir, output_dir)
+    scanner.scan(target=source_dir, target_type="source")
+
+    assert _keys(scanner) == _EXPECTED_KEYS
+
+
+def test_keys_stay_inside_root_so_relpath_cannot_fail_on_windows(tmp_path, monkeypatch):
+    """The property that makes the Windows failure unreachable.
+
+    ``ntpath.relpath`` raises only when the two paths are on different drives,
+    and it cannot do that when root is an ancestor of the file -- which is
+    exactly the case where the key comes back relative and free of parent hops.
+    Asserted from a working directory outside the scanned tree, because the
+    pre-fix root of ``''`` was the working directory.
+    """
+    source_dir = tmp_path / "src"
+    output_dir = tmp_path / "out"
+    _write_secret_files(source_dir)
+    output_dir.mkdir()
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    scanner = _scanner(source_dir, output_dir)
+    scanner.scan(target=source_dir, target_type="source")
+
+    assert scanner._secrets_collection.data, "expected the scan to find secrets"
+    for key in scanner._secrets_collection.data:
+        assert not os.path.isabs(key), f"key escaped root as an absolute path: {key}"
+        assert os.pardir not in Path(key).parts, f"key escaped root: {key}"
+
+
+def test_relative_source_dir_still_reports_findings(tmp_path, monkeypatch):
+    """``ash --source-dir ./sub`` reaches the scanner as the relative string, and
+    the scan set inherits it.
+
+    ``scan_files()`` reads each name as ``os.path.join(self.root, name)``, so an
+    anchored root plus a relative name would send detect-secrets looking for
+    ``<root>/<root>/<file>`` and quietly report nothing at all.
+    """
+    _write_secret_files(tmp_path / "sub")
+    (tmp_path / "out").mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    scanner = _scanner(Path("sub"), Path("out"))
+    report = scanner.scan(target=Path("sub"), target_type="source")
+
+    assert report is not False
+    assert report.runs[0].results, "a relative source_dir reported no findings"
+    assert _keys(scanner) == _EXPECTED_KEYS
+
+
+def test_ntpath_relpath_has_no_answer_across_drives():
+    """The Windows mechanism itself, pinned so the reason for the fix is legible.
+
+    This is the call ``scan_files()`` makes on every secret it finds in its
+    multiprocessing branch.
+    """
+    scanned = r"C:\some\tree\first.py"
+
+    with pytest.raises(ValueError, match="path is on mount"):
+        ntpath.relpath(scanned, r"D:\checkout")
+
+    # Anchored on the directory the file was enumerated from, the same call is a
+    # plain filename.
+    assert ntpath.relpath(scanned, r"C:\some\tree") == "first.py"

--- a/tests/unit/plugin_modules/test_detect_secrets_scan_root.py
+++ b/tests/unit/plugin_modules/test_detect_secrets_scan_root.py
@@ -201,8 +201,14 @@ def test_keys_stay_inside_root_so_relpath_cannot_fail_on_windows(tmp_path, monke
 
 
 def test_relative_source_dir_still_reports_findings(tmp_path, monkeypatch):
-    """``ash --source-dir ./sub`` reaches the scanner as the relative string, and
-    the scan set inherits it.
+    """A relative ``source_dir`` reaches the scanner as given, and the scan set
+    inherits it.
+
+    Not through the CLI, which anchors it in ``run_ash_scan``. Through a library
+    caller: ``ASHScanOrchestrator.model_post_init`` coerces a ``str`` to ``Path``
+    without anchoring it, so ``source_dir="./sub"`` stays relative all the way
+    into ``PluginContext``. That is the door this test comes through, which is
+    why it builds the scanner directly rather than invoking the CLI.
 
     ``scan_files()`` reads each name as ``os.path.join(self.root, name)``, so an
     anchored root plus a relative name would send detect-secrets looking for


### PR DESCRIPTION
## What this fixes

Two unrelated defects, neither of which changes behavior for anyone who is not already hitting them.

## The detect-secrets scanner raised instead of reporting, on Windows

`SecretsCollection.root` was assigned only inside
`if target_type == "source" and self.config.options.baseline_file is not None`. For a converted-target
scan, and for a source scan with no baseline, `root` stayed at its default of `''`, and
`os.path.abspath('')` is the process working directory.

That matters because of a branch in `detect_secrets`. `SecretsCollection.scan_files` sends a single
file through `scan_file`, keyed by the path it was handed, but sends two or more through a
multiprocessing pool, keyed by `os.path.relpath(secret.filename, self.root)`. Only the pool branch
computes that relative path.

There is no relative path between two Windows drives. So a user scanning a tree on one drive from an
ASH process on another, with two or more files containing secrets, got

```
ScannerError: DetectSecretsScanner failed: path is on mount 'C:', start on mount 'D:'
```

in place of their findings. Reproduced without a Windows host via `ntpath.relpath`, which raises that
exact message for a cross-drive pair and returns a plain filename when the start path is the
containing directory.

`root` is now set on every scan, anchored to the directory the scan set is enumerated from, which is an
ancestor of every scanned file by construction. `absolute()` rather than `resolve()`, because the file
list keeps whatever symlinked prefix it was walked with and resolving only one side of
`os.path.relpath` would turn every key into a chain of `..` segments.

**This also makes reported finding paths stable.** They previously depended on the directory ASH
happened to be invoked from. They are now relative to the scan root.

### A second defect the first fix would otherwise have introduced

`scan_files` reads each name as `os.path.join(self.root, name)`, which is only a no-op when the name is
absolute. Once `root` is non-empty, a relative name would send detect-secrets looking for
`<root>/<root>/<file>` and quietly find nothing — a silent regression created by the fix itself. The
scan paths are therefore absolutized, kept separate from the list the baseline exclude patterns are
matched against so those patterns still see the spelling they were written for.

## A dead branch in the progress display

```python
log_level = 15
if verbose:
    log_level = 15  # VERBOSE level
if debug:
    log_level = logging.DEBUG
```

`log_level` is already 15, so the `verbose` branch cannot change anything. Deleting it is a no-op,
confirmed by enumerating all four `(verbose, debug)` combinations before and after.

The deletion itself is undetectable by any test, which is how it survived. So this adds the test that
was missing: one that pins the resulting level for each of the four combinations. That is what will
catch a future well-meaning change to the default.

**A question for maintainers, deliberately not answered here.** There are two readings of that code.
Either the `verbose` branch is redundant, which is what this PR assumes, or the default was meant to be
`INFO` and the real defect is that every run gets VERBOSE-level logging unconditionally. The second
would change output for every user, so it needs the original intent rather than a guess. The new test
pins the current mapping either way, so changing it later is a visible decision instead of a silent
drift.

## Verification

- 14 new tests across two files. Full suite **4530 passed / 114 skipped / 0 failed**, identical
  serially and under `-n auto`; the baseline at this branch point is 4516/114/0.
- Reverting `detect_secrets_scanner.py` to the base commit fails 5 of its 7 new tests, so they detect
  the defect rather than merely covering the line.
- The progress tests pass both with and without the deletion, which is expected for a no-op. They were
  mutation-checked instead: changing the default from 15 to `logging.INFO` fails them, and making
  `debug` no longer win fails them.
- `ruff check` unchanged from base on both files (17 and 4 pre-existing findings respectively);
  `ruff format --check` clean.

## One adjacent defect left alone

`detect_secrets_scanner.py` filters output files with `"/.ash/" not in str(item)`. On Windows
`str(item)` uses backslashes, so that filter never fires and `.ash/` output gets scanned for secrets.
It is pre-existing, in the same file, and one line to fix, but it is a different defect from the one
this PR is about.
