### PR TITLE
ci: add one stable check name so unified CI can be a required check

### DIFF
--- a/.github/workflows/ash-unified-ci.yml
+++ b/.github/workflows/ash-unified-ci.yml
@@ -440,3 +440,88 @@ jobs:
 
       - uses: ./.github/actions/validate-mcp
         if: matrix.method == 'mcp'
+
+  # ---------------------------------------------------------------------------
+  # One check name that can actually be required
+  # ---------------------------------------------------------------------------
+  #
+  # Every job above names itself from its matrix, so this workflow contributes 84 distinct
+  # check-run names to a pull request and not one of them is stable. A ruleset's
+  # required_status_checks list holds literal context strings with no wildcard, so requiring
+  # `unit-test` means enumerating all 18 of its names -- and then any matrix edit either orphans
+  # a required context that no longer runs, which leaves a pull request pending forever, or
+  # quietly adds a leg that nothing requires. That maintenance cost is why the ruleset requires
+  # two contexts today while 150 of the 152 checks on a pull request are advisory.
+  #
+  # This job's name does not depend on the matrix, so it can be required once and stay correct
+  # across matrix changes. It reports the verdict the individual legs already computed.
+  #
+  # THE TWO WAYS A GATE LIKE THIS FAILS OPEN
+  #
+  # `if: always()` is load-bearing, not defensive. Without it a failed dependency makes this job
+  # *skipped*, and GitHub counts a skipped required check as a pass -- so the gate would
+  # disappear at exactly the moment it is supposed to speak. That is the whole failure mode this
+  # job exists to remove, so it must not reproduce it.
+  #
+  # The second way is drift: a job added to this workflow and not added to `needs` escapes the
+  # gate silently, and the gate keeps reporting success over a shrinking share of the suite. So
+  # the count is asserted rather than assumed. A census beats a list that nobody re-checks --
+  # the same reason .github/scripts/assert-coverage-completeness.mjs takes its file list from
+  # `git ls-files` rather than from the coverage report.
+  required-checks:
+    name: required-checks
+    if: always()
+    needs:
+      - lint
+      - unit-test
+      - scan-validation
+      - external-target-scan
+      - multi-project-attribution
+      - install-validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Assert every upstream job succeeded
+        env:
+          NEEDS_JSON: ${{ toJSON(needs) }}
+          # Bump deliberately when adding a job above, which is the point: the assertion below
+          # fails until this matches, so a new job cannot slip past the gate unnoticed.
+          EXPECTED_UPSTREAM_JOBS: "6"
+        shell: bash
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["NEEDS_JSON"])
+          expected = int(os.environ["EXPECTED_UPSTREAM_JOBS"])
+
+          for name, data in sorted(needs.items()):
+              print(f"{data.get('result', '?'):<10} {name}")
+
+          problems = []
+
+          if len(needs) != expected:
+              problems.append(
+                  f"this gate depends on {len(needs)} job(s) but expects {expected}. A job was "
+                  "added to the workflow without being added to this job's `needs`, so it is "
+                  "not covered by the required check. Add it and bump "
+                  "EXPECTED_UPSTREAM_JOBS."
+              )
+
+          # Every job in this workflow is unconditional -- none carries a job-level `if` -- so a
+          # result of anything other than success means something went wrong, including
+          # 'skipped'. Tolerating 'skipped' here would let a job that never ran read as a pass.
+          for name, data in sorted(needs.items()):
+              result = data.get("result")
+              if result != "success":
+                  problems.append(f"{name}: {result}")
+
+          if problems:
+              for problem in problems:
+                  print(f"::error::{problem}")
+              sys.exit(1)
+
+          print(f"all {len(needs)} upstream job(s) succeeded")
+          PY


### PR DESCRIPTION
Nothing in `ash-unified-ci.yml` can be a required check today, and the reason is structural rather than an oversight.

## Why

Every job in that workflow names itself from its matrix:

| Job | Name template | Distinct check names |
| --- | --- | --- |
| `unit-test` | `unit-test (${{ matrix.os }}, py${{ matrix.python-version }})` | 18 (5 os × 4 py − 2 excludes) |
| `scan-validation` | `scan (${{ matrix.method }}, ${{ matrix.os }})…` | 24 |
| `install-validation` | `${{ matrix.method }} (${{ matrix.os }}, py…)` | 20 each across pip / pipx / pre-commit / mcp, plus uvx, homebrew, podman, finch |
| `external-target-scan` | `external-target scan (${{ matrix.os }})` | 2 |
| `multi-project-attribution` | `multi-project attribution (${{ matrix.os }})` | 2 |
| `lint` | `lint` | 1 — the only stable one, and not required either |

Measured on one PR head: **152 check runs, of which the `Protect main` ruleset requires exactly two** — `ash / SAST, SCA, and IaC Scan` and `Validate PR title`. The other 150 are advisory.

A ruleset's `required_status_checks` list holds literal context strings and supports no wildcard. So requiring `unit-test` means enumerating all 18 generated names, and every matrix edit afterwards either

- **orphans** a required context that no longer runs — a required check with no run is pending forever, so the PR can never merge and the merge queue stalls behind it, or
- **adds** a leg that nothing requires, shrinking coverage silently.

That maintenance cost, with a wedged queue as the downside of getting it wrong, is why the list has two entries.

## What this adds

A `required-checks` job whose name doesn't depend on any matrix, so it can be required once and stay correct across matrix changes. It computes nothing itself — it reports the verdict the legs already produced.

**Two ways a gate like this fails open, both closed here.**

`if: always()` is load-bearing, not defensive. Without it a failed dependency makes this job *skipped*, and GitHub counts a skipped required check as a **pass** — the gate would vanish at exactly the moment it's meant to speak.

Drift is the second. A job added to the workflow and not added to `needs` escapes the gate silently while the gate keeps reporting success over a shrinking share of the suite. So the upstream count is asserted against `EXPECTED_UPSTREAM_JOBS` rather than assumed, and adding a job fails the gate until someone bumps it deliberately. Same reasoning as `assert-coverage-completeness.mjs` taking its census from `git ls-files` instead of from the report it's checking.

A result of `skipped` is treated as **failure**, not tolerated. Every job here is unconditional — none carries a job-level `if` — so a job that didn't run means something went wrong, and tolerating it would reintroduce the shape above.

## Verification

The assertion script was extracted from the workflow and run against synthetic `needs` payloads, so the gate's own logic is exercised rather than asserted:

| Scenario | Exit |
| --- | --- |
| all six succeed | 0 |
| one job failed | 1 |
| one job cancelled | 1 |
| one job **skipped** | 1 |
| one job missing from `needs` | 1 |

Plus: the YAML parses, the gate's `needs` covers every other job in the file with none left over, and `EXPECTED_UPSTREAM_JOBS` matches the actual job count.

**One property this depends on, checked rather than assumed.** `if: always()` makes the gate *run* when a dependency fails; it does not by itself make it *fail*. The step above inspects `needs.<job>.result` explicitly and exits non-zero on anything other than `success` — without that, the gate would run, its steps would succeed, and it would report success over a failed upstream job, which is a required check that structurally cannot fail and therefore worse than no gate.

That inspection is only as good as the value it reads, and every job here is a matrix, so the question is whether one failed leg makes the parent's result a failure. Measured on the run that produced the failure this branch's sibling PRs hit — run `33689012919`: 18 `unit-test` legs, 17 success and 1 failure, `fail-fast: false` so no leg was cancelled or masked, and the run concluded **failure**. One leg is enough.

The run conclusion is a proxy for the `needs` value rather than that value itself, so the decisive observation is this gate running on a PR where a leg genuinely fails. Recording it as verified-by-proxy rather than measured directly.

## What this deliberately does not do

**It does not change what gates a merge.** Adding `required-checks` to the `Protect main` ruleset is a repository-admin action and isn't attempted here, so this lands as a job that runs and reports while the ruleset still requires the same two contexts.

Merging this first and flipping the ruleset second is also the safe order — the context has to exist and be green on real PRs before it's required, or every open PR blocks on a check that has never reported.
