### PR TITLE
feat(plugins): make ASH installable with npx skills, and document agent installs

### DIFF
--- a/.github/workflows/ash-agent-plugins-drift.yml
+++ b/.github/workflows/ash-agent-plugins-drift.yml
@@ -1,0 +1,117 @@
+name: Agent Plugins Drift
+
+# WHY THIS LIVES AT THE REPOSITORY ROOT
+#
+# ash-agent-plugins/ ships its own workflow at
+# ash-agent-plugins/.github/workflows/validate.yml, and ash-agent-plugins/README.md
+# describes it as the gate that keeps the committed plugin files matching
+# transpiler output. That is true only when ash-agent-plugins/ is checked out as
+# its own repository, which it is designed to be. Inside this monorepo the file is
+# inert: GitHub reads workflows only from .github/workflows/ at the repository
+# root, so nothing in that nested directory has ever run here. The root
+# .pre-commit-config.yaml has no transpiler hook either.
+#
+# The cost of that gap was not theoretical. It let a permanent drift failure sit
+# on main undetected: ash-agent-plugins/.gitignore ignored .vscode/, which
+# silently swallowed the copilot backend's generated .vscode/mcp.json, so
+# `agentic-plugins check` reported drift on a clean checkout and no amount of
+# re-running the transpiler could clear it.
+#
+# This workflow is the same check, invoked from the root with
+# ash-agent-plugins/agentic-coding/transpiler prefixes so it runs in ASH's own CI.
+# The nested workflow is left alone -- it remains correct for the standalone
+# layout, and the two do not conflict.
+#
+# WHAT THE CHECK ACTUALLY PROVES
+#
+# `agentic-plugins check` rebuilds every backend into a temporary directory and
+# byte-compares against the committed output, then runs schema and structural
+# validation over the result. It fails if a committed plugin file disagrees with
+# what _base/ would generate today -- which is what stops the generated trees from
+# drifting away from their single source of truth. The repository-root skills/
+# tree is covered by the same comparison, so it cannot silently diverge from the
+# generic-skill artifact either.
+#
+# PATH FILTERS, WRITTEN FROM SCRATCH
+#
+# The nested workflow has no path filters at all, so there was nothing to copy.
+# These four cover every input the check reads and every output it compares
+# against:
+#
+#   - the transpiler itself, which includes _base/ (the source of truth),
+#     templates/, schemas/ and tests/
+#   - the generated per-platform plugin trees, the right-hand side of the
+#     byte comparison
+#   - the generated repository-root skills/ tree, likewise
+#   - ash-agent-plugins/.gitignore, because a pattern added there can make a
+#     generated file untrackable and reintroduce exactly the permanent drift
+#     described above -- an edit to that one file, alone, must run this gate
+#
+# This workflow file is in its own filter. Unlike ash-typescript-ci.yml, which
+# deliberately omits itself because its target directory does not exist on the
+# default branch yet, everything this gate checks is present, so the change that
+# edits the gate is tested by the gate.
+#
+# Consequence to be aware of: a change outside these paths cannot break the
+# plugin trees, but it also will not run this job.
+
+on:
+  push:
+    branches:
+      - "*"
+    tags:
+      - "*"
+    paths:
+      - "ash-agent-plugins/agentic-coding/transpiler/**"
+      - "ash-agent-plugins/agentic-coding/plugins/**"
+      - "ash-agent-plugins/.gitignore"
+      - "skills/**"
+      - ".github/workflows/ash-agent-plugins-drift.yml"
+  pull_request:
+    branches:
+      - "*"
+    paths:
+      - "ash-agent-plugins/agentic-coding/transpiler/**"
+      - "ash-agent-plugins/agentic-coding/plugins/**"
+      - "ash-agent-plugins/.gitignore"
+      - "skills/**"
+      - ".github/workflows/ash-agent-plugins-drift.yml"
+  workflow_dispatch: {}
+
+# Least privilege: this workflow only reads the repository and runs the checker.
+permissions:
+  contents: read
+
+concurrency:
+  # One in-flight run per pull request; pushing again supersedes the previous run.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Only pull_request runs may be cancelled. A merge_group run must finish or the
+  # queue loses its verdict.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  drift-and-validate:
+    name: Plugin output matches _base/
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      # The transpiler resolves its own paths from __file__ and discovers the
+      # repository root by walking up for .git, so neither command depends on the
+      # working directory. Both are run from the root anyway, because that is
+      # where the checkout puts us and because a repository-anchored backend needs
+      # the real .git to be present.
+      - name: Check drift and validate generated output
+        run: uv run --project ash-agent-plugins/agentic-coding/transpiler agentic-plugins check
+
+      - name: Run transpiler regression suite
+        run: uv run --project ash-agent-plugins/agentic-coding/transpiler --extra test pytest ash-agent-plugins/agentic-coding/transpiler/tests/

--- a/.github/workflows/ash-agent-plugins-drift.yml
+++ b/.github/workflows/ash-agent-plugins-drift.yml
@@ -52,8 +52,32 @@ name: Agent Plugins Drift
 # default branch yet, everything this gate checks is present, so the change that
 # edits the gate is tested by the gate.
 #
-# Consequence to be aware of: a change outside these paths cannot break the
-# plugin trees, but it also will not run this job.
+# Consequence to be aware of: on push and pull_request, a change outside these
+# paths cannot break the plugin trees, but it also will not run this job. The
+# merge_group leg carries no such filter, for the reasons below.
+#
+# THE MERGE QUEUE LEG
+#
+# This repository runs a merge queue -- ash-unified-ci.yml declares merge_group
+# -- and merge_group is a distinct event from both pull_request and push. A gate
+# that omits it does not run on queue entries, which is exactly where this one
+# earns its keep: PR A edits _base/, PR B edits a generated tree, each passes
+# alone, and the queue combines them into the drift the gate exists to catch.
+# Skipping the queue is how a permanent drift failure reaches main a second way.
+#
+# merge_group takes no paths filter. GitHub scopes paths and paths-ignore to
+# push, pull_request and pull_request_target -- the workflow-syntax heading is
+# literally on.<push|pull_request|pull_request_target>.<paths|paths-ignore> --
+# and the merge_group reference documents only types. So this leg is unfiltered
+# and runs on every queue entry.
+#
+# That is the wanted behavior rather than a limitation worked around. A queue
+# entry is a merge of several pull requests, so the change that introduces drift
+# may itself have touched none of the filtered paths; a per-entry path filter
+# would reintroduce the very hole the merge_group trigger closes. Filtering here
+# would also break the queue outright once this becomes a required check: a
+# skipped required check never reports, so the merge waits on a verdict that
+# never arrives.
 
 on:
   push:
@@ -76,6 +100,8 @@ on:
       - "ash-agent-plugins/.gitignore"
       - "skills/**"
       - ".github/workflows/ash-agent-plugins-drift.yml"
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch: {}
 
 # Least privilege: this workflow only reads the repository and runs the checker.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 - [Installation Options](#installation-options)
   - [Quick Install (Recommended)](#quick-install-recommended)
   - [Other Installation Methods](#other-installation-methods)
-    - [Using `uvx`](#using-uvx)
+    - [Using Homebrew (macOS/Linux)](#using-homebrew-macoslinux)
+    - [Using `pipx`](#using-pipx)
     - [Using `pip`](#using-pip)
     - [Clone the Repository](#clone-the-repository)
 - [Basic Usage](#basic-usage)
@@ -27,6 +28,10 @@
   - [Available MCP Tools](#available-mcp-tools)
   - [Usage Examples](#usage-examples)
   - [Configuration Support](#configuration-support)
+- [Installing ASH into an AI Coding Agent](#installing-ash-into-an-ai-coding-agent)
+  - [Option 1: Install the skill](#option-1-install-the-skill)
+  - [Option 2: Install a platform plugin](#option-2-install-a-platform-plugin)
+  - [Option 3: Configure the MCP server directly](#option-3-configure-the-mcp-server-directly)
 - [Configuration](#configuration)
 - [Using ASH with pre-commit](#using-ash-with-pre-commit)
 - [Output Files](#output-files)
@@ -336,6 +341,70 @@ The MCP server supports all ASH configuration methods:
 - **CLI parameters**: Severity thresholds, custom output directories
 
 For detailed information about streaming capabilities and advanced usage, see the [MCP Streaming Guide](docs/content/tutorials/mcp-streaming-guide.md).
+
+
+## Installing ASH into an AI Coding Agent
+
+You do not have to wire the MCP server by hand. This repository also ships prebuilt
+integrations under [`ash-agent-plugins/`](ash-agent-plugins/README.md), generated from
+one source of truth so every agent gets the same content.
+
+There are three ways in, ordered here by how much work they ask of you. They are
+alternatives, not steps — pick one. All three end up calling the same ASH MCP server,
+so scan behavior does not change between them.
+
+Install ASH first and make sure `ash` runs from your shell; see
+[Installation Options](#installation-options). These integrations tell an agent how to
+call ASH. They do not install ASH.
+
+### Option 1: Install the skill
+
+```bash
+npx skills add awslabs/automated-security-helper
+```
+
+That installs the `ash-mcp` skill, which teaches an agent the start-scan, poll-progress,
+fetch-results workflow and when to reach for it. `skills` is
+[Vercel's open agent-skills CLI](https://github.com/vercel-labs/skills). It detects which
+supported agent you have and writes the skill into that agent's own directory, so you do
+not need to know which one you are running or where it keeps its skills. Pass `--list` to
+see what it finds without installing anything, or `--agent` to target a specific agent.
+
+A skill carries instructions, not MCP configuration. If your agent is not already pointed
+at the ASH MCP server, use one of the two options below as well.
+
+### Option 2: Install a platform plugin
+
+A plugin is the fuller integration: MCP server wiring, slash commands, an agent
+definition, and rules files in the platform's native format. Two of the more common
+agents install with a single command, run from the repository root:
+
+```bash
+# Claude Code — load the plugin directly
+claude --plugin-dir ./ash-agent-plugins/agentic-coding/plugins/claude
+
+# Codex CLI — register the plugin marketplace, then install from it
+codex plugin marketplace add ./ash-agent-plugins/agentic-coding/plugins/codex
+```
+
+Cursor and GitHub Copilot are copy-in rather than CLI installs. Working from
+`ash-agent-plugins/agentic-coding/plugins/`, copy `cursor/.cursor/` into the root of your
+own repository; for Copilot copy both `copilot/.github/` and `copilot/.vscode/`, which
+needs VS Code 1.104 or newer. Merge into a directory of the same name if you already have
+one rather than replacing it.
+
+Fifteen platforms have a plugin tree and each has its own install step.
+[`ash-agent-plugins/README.md`](ash-agent-plugins/README.md) holds the full table, one
+generated tree per platform with the exact command or copy step for each. Treat that table
+as the authoritative list. It is deliberately not duplicated here, because it changes
+whenever a platform is added and a second copy would go stale.
+
+### Option 3: Configure the MCP server directly
+
+If your agent has no plugin tree but does speak MCP, point it at the server yourself.
+[Client Configuration](#client-configuration) above has JSON you can paste for Amazon Q
+Developer CLI, Claude Desktop, and Cline; the same shape works for any MCP client that
+takes a command and arguments.
 
 
 ## Configuration

--- a/ash-agent-plugins/.gitignore
+++ b/ash-agent-plugins/.gitignore
@@ -5,6 +5,14 @@ __pycache__/
 *.swp
 *.swo
 .vscode/
+# ...but the copilot backend's output tree legitimately contains a .vscode/
+# directory: VS Code reads MCP server config from .vscode/mcp.json, so that is
+# where the transpiler has to emit it. The pattern above is meant to ignore a
+# developer's own editor settings, and it was silently swallowing generated
+# output instead, which made `agentic-plugins check` permanently report drift
+# for a file git would not let anyone commit. Re-include the directory itself
+# (a file cannot be re-included while its parent directory stays excluded).
+!agentic-coding/plugins/*/.vscode/
 .idea/
 *.log
 .ash/ash_output/

--- a/ash-agent-plugins/README.md
+++ b/ash-agent-plugins/README.md
@@ -1,6 +1,6 @@
 # Agentic Coding Plugins for ASH
 
-A unified source-of-truth (`agentic-coding/transpiler/_base/`) plus a config-driven Python transpiler that emits plugin packages for **15 AI coding agent platforms** plus the **agentskills.io generic-skill release** from one canonical content set. Wraps the [ASH (Automated Security Helper)](https://github.com/awslabs/automated-security-helper) MCP server so any agent can run security scans through the same backing service.
+A unified source-of-truth (`agentic-coding/transpiler/_base/`) plus a config-driven Python transpiler that emits plugin packages for **15 AI coding agent platforms** plus **two agentskills.io skill releases** from one canonical content set — 17 outputs in total, which is the number `agentic-plugins check` reports. Wraps the [ASH (Automated Security Helper)](https://github.com/awslabs/automated-security-helper) MCP server so any agent can run security scans through the same backing service.
 
 ## What this gets you
 
@@ -22,6 +22,9 @@ A unified source-of-truth (`agentic-coding/transpiler/_base/`) plus a config-dri
 | 14 | **Aider** | `agentic-coding/plugins/aider/` | Copy `.aider.conf.yml` and `CONVENTIONS.md` (no MCP support in Aider) |
 | 15 | **MCPB / Claude Desktop** | `agentic-coding/plugins/mcpb/` | Double-click `ash.mcpb` for one-click install in Claude Desktop |
 | 16 | **Generic Skill ([agentskills.io](https://agentskills.io/specification))** | `agentic-coding/plugins/generic-skill/` | Drop `skills/<name>/` into any agentskills-compatible agent's skills directory. Natively consumed by Claude Code, Codex, OpenCode, Cline, Kiro. |
+| 17 | **Repository-root skill tree** | `skills/` (repository root, not under `plugins/`) | `npx skills add awslabs/automated-security-helper` |
+
+Rows 16 and 17 hold the same skill content and differ only in where it lands. Row 17 is emitted at the repository root because [Vercel's `skills` CLI](https://github.com/vercel-labs/skills) looks for `skills/<name>/` there and does not search the rest of the tree, which is what makes the `owner/repo` shorthand above resolve. Row 16's copy stays inside the plugin tree for people assembling a custom integration who want the bare artifact and no repository layout imposed on them. Both are generated from `_base/`, so they cannot disagree.
 
 Plus a **universal `AGENTS.md`** at `agentic-coding/plugins/AGENTS.md`, read natively by Codex, Cursor, Windsurf, OpenCode, Copilot (1.104+), Cline, Roo, Kiro, Goose, Aider, and Factory CLI.
 
@@ -33,7 +36,14 @@ This complements (does NOT replace) the per-platform plugin trees. The per-platf
 
 ## Architecture
 
-**Single source of truth, class-per-backend, deterministic transpiler.** Humans edit `agentic-coding/transpiler/_base/` and (when adding a new platform) write a backend module under `agentic-coding/transpiler/transpiler/backends/<name>/`. The transpiler regenerates all platform outputs. A pre-commit hook + CI verifies that committed plugin files match what the transpiler would produce.
+**Single source of truth, class-per-backend, deterministic transpiler.** Humans edit `agentic-coding/transpiler/_base/` and (when adding a new platform) write a backend module under `agentic-coding/transpiler/transpiler/backends/<name>/`. The transpiler regenerates all platform outputs.
+
+CI verifies that committed plugin files match what the transpiler would produce. Which workflow does that depends on how this directory is being used, and the distinction is worth stating plainly because getting it wrong once let a drift failure sit unnoticed on the ASH default branch:
+
+- **Inside the ASH monorepo**, `.github/workflows/ash-agent-plugins-drift.yml` at the repository root runs `agentic-plugins check` and the transpiler's pytest suite, path-filtered to the transpiler, both generated output trees, `.gitignore`, and the workflow file itself.
+- **When `ash-agent-plugins/` is used as its own repository**, `.github/workflows/validate.yml` in this directory applies instead, and adds the per-CLI smoke-test matrix.
+
+Only one of the two ever runs, because GitHub reads workflows solely from the repository root. The nested `validate.yml` therefore does nothing inside the monorepo, which is why the root workflow exists. There is no pre-commit hook for the transpiler at the ASH repository root; `pre-commit install` in the Development workflow below applies when this directory is its own repository.
 
 Each backend is a class that subclasses `BaseBackend` and declares its layout via class-level constants (`PLUGIN_MANIFEST`, `MCP`, `SKILL`, `COMMANDS`, `AGENTS`, `INSTRUCTION_FILE`, `RULES_DIR`, `CUSTOM_MODES`, `CONFIG_FILE`, `MARKETPLACE`, `EXTENSION_MANIFEST`, `MCPB_BUNDLE`). Build behavior comes from `BaseBackend.build()`'s section-emitter dispatch; backends with multi-step builds opt into the `PHASES` machinery (setup/build/release stages with topo-sorted `depends_on`). Backends can also expose backend-specific Click subcommands via a `CLI_GROUP` class var, and override `smoke_test()` to confirm the generated package loads under the platform's CLI.
 
@@ -87,17 +97,18 @@ pre-commit install
 $EDITOR agentic-coding/transpiler/_base/skill.md
 $EDITOR agentic-coding/transpiler/transpiler/backends/claude/__init__.py
 
-# 3. Re-build all 15 platforms
+# 3. Re-build all 17 outputs
 uv run --project agentic-coding/transpiler agentic-plugins build
 
 # 4. Verify drift + validation
 uv run --project agentic-coding/transpiler agentic-plugins check
 
-# 5. Commit — pre-commit re-runs build + check
+# 5. Commit. In a standalone checkout of this directory, pre-commit re-runs
+#    build + check; in the ASH monorepo, CI is what checks it.
 git commit -am "feat: improve scan workflow"
 ```
 
-The Click CLI surfaces four lifecycle phases. Each subcommand takes an optional backend NAME; without one, the command runs across all 15 backends:
+The Click CLI surfaces five lifecycle commands. Each takes an optional backend NAME; without one, the command runs across all 17 backends:
 
 ```bash
 agentic-plugins build [NAME]       # build platform plugin packages
@@ -107,7 +118,7 @@ agentic-plugins release [NAME]     # phase stage="release" (e.g. MCPB → dist/)
 agentic-plugins smoke-test [NAME]  # confirm each plugin loads under its platform CLI
 ```
 
-CI runs `agentic-plugins check` and `agentic-plugins smoke-test` on every push and PR. `check` runs both passes unconditionally so a single CI run surfaces every problem; the exit code is non-zero if either fails. Drift is architecturally impossible to merge; spec violations are caught before they reach users.
+CI runs `agentic-plugins check` on every push and pull request that touches the paths listed under Architecture above; the standalone workflow also runs `agentic-plugins smoke-test` as a per-CLI matrix. `check` runs both of its passes unconditionally so a single run surfaces every problem, and its exit code is non-zero if either fails, which is what keeps a drifted plugin tree from merging.
 
 ## Output validation
 
@@ -122,15 +133,15 @@ To refresh the cached external schemas after upstream changes:
 ```bash
 bash agentic-coding/transpiler/schemas/refresh.sh
 git diff agentic-coding/transpiler/schemas/   # review what changed
-uv run --project agentic-coding/transpiler transpile --check  # confirm we still validate
+uv run --project agentic-coding/transpiler agentic-plugins check  # confirm we still validate
 ```
 
 You can run validation independently of drift detection:
 
 ```bash
-uv run --project agentic-coding/transpiler transpile --check          # drift + validation (CI gate)
-uv run --project agentic-coding/transpiler transpile --validate-only  # validation alone
-uv run --project agentic-coding/transpiler transpile --drift-only     # drift alone
+uv run --project agentic-coding/transpiler agentic-plugins check                  # drift + validation (CI gate)
+uv run --project agentic-coding/transpiler agentic-plugins check --validate-only  # validation alone
+uv run --project agentic-coding/transpiler agentic-plugins check --drift-only     # drift alone
 ```
 
 ## MCPB / Claude Desktop one-click install

--- a/ash-agent-plugins/agentic-coding/plugins/copilot/.vscode/mcp.json
+++ b/ash-agent-plugins/agentic-coding/plugins/copilot/.vscode/mcp.json
@@ -1,0 +1,17 @@
+{
+  "servers": {
+    "ash": {
+      "command": "uvx",
+      "args": [
+        "--from=git+https://github.com/awslabs/automated-security-helper@v3.4.0",
+        "ash",
+        "mcp"
+      ],
+      "env": {
+        "FASTMCP_LOG_LEVEL": "ERROR"
+      },
+      "timeout": 120000,
+      "disabled": false
+    }
+  }
+}

--- a/ash-agent-plugins/agentic-coding/transpiler/tests/test_output_anchors.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tests/test_output_anchors.py
@@ -163,7 +163,14 @@ def test_check_drift_hands_every_build_a_fully_sandboxed_anchor_pair(tmp_path, m
                 f"build; that build would rmtree and rewrite {got}"
             )
             assert tmp_path not in got.parents, (
-                f"sandboxed {field_name} anchor {got} is not in a throwaway directory"
+                f"check_drift put the sandboxed {field_name} anchor at {got}, "
+                f"inside {tmp_path} -- the tree holding the real anchors. The "
+                "sandbox must be an independent throwaway directory: a build "
+                "rmtree's its output first, so a sandbox carved out of the "
+                "caller's tree destroys the very tree the check compares "
+                "against. Note that tmp_path is the real-anchor tree here and "
+                "not the sandbox root, so containment is the failure, not the "
+                "passing condition."
             )
 
 

--- a/ash-agent-plugins/agentic-coding/transpiler/tests/test_output_anchors.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tests/test_output_anchors.py
@@ -1,0 +1,196 @@
+"""Regression tests for the output-anchor mechanism and its escape guard.
+
+Both hazards guarded here are destructive rather than merely wrong, which is why
+they get tests rather than a comment.
+
+1. `emitters.run_section_emitters` starts with `reset(out)` ->
+   `shutil.rmtree(out)`. A backend under the `repository` anchor whose
+   OUTPUT_DIR is empty, `.`, absolute, or contains `..` resolves to the
+   repository root or above it, so building it deletes the checkout.
+
+2. `orchestrator.check_drift` sandboxes a build into a tempdir and byte-compares
+   the result. If it sandboxed only one of the two anchors, the tempdir build of
+   a repository-anchored backend would rmtree and rewrite the very tree the
+   check is comparing against -- and would then report no drift, having caused
+   it. That failure is silent: a green gate that destroyed data.
+"""
+from __future__ import annotations
+
+import pytest
+
+from transpiler import orchestrator
+from transpiler.core import (
+    BaseBackend,
+    OutputAnchors,
+    resolve_output_dir,
+    validated_output_dir,
+)
+from transpiler.registry import BackendRegistry
+
+
+# ---------------------------------------------------------------------------
+# Hazard 1: the escape guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        "",            # resolves to the anchor root itself
+        "   ",         # ditto, once stripped
+        ".",           # ditto; PurePath(".").parts is empty
+        "..",          # one level above the anchor
+        "../evil",
+        "skills/../..",
+        "/etc",        # absolute on POSIX
+        "C:/Windows",  # absolute on Windows; PurePosixPath would not notice
+        "..\\evil",    # backslash is a separator on Windows only
+        "\\\\server\\share",  # UNC root
+    ],
+)
+def test_guard_rejects_output_dir_that_escapes_its_anchor(bad):
+    """Each of these would make `out` land on or above the anchor root, and the
+    build rmtree's `out` before writing."""
+    with pytest.raises(ValueError):
+        validated_output_dir("hypothetical-backend", bad)
+
+
+@pytest.mark.parametrize("good", ["skills", "generic-skill", "claude", "a/b/c"])
+def test_guard_accepts_a_plain_relative_output_dir(good):
+    assert validated_output_dir("hypothetical-backend", good) == good
+
+
+def test_guard_rejects_a_non_string_output_dir():
+    with pytest.raises(ValueError):
+        validated_output_dir("hypothetical-backend", None)  # type: ignore[arg-type]
+
+
+def test_every_registered_backend_passes_the_guard():
+    """The guard is only worth having if it actually runs over real backends."""
+    for name, cls in BackendRegistry.all().items():
+        assert validated_output_dir(name, cls.OUTPUT_DIR) == cls.OUTPUT_DIR
+
+
+def test_registration_rejects_an_escaping_output_dir():
+    """Fail at import, not mid-build after other backends already wrote output."""
+
+    class Escaping(BaseBackend):
+        NAME = "test-escaping-backend"
+        OUTPUT_DIR = "../.."
+        OUTPUT_ANCHOR = "repository"
+
+    with pytest.raises(ValueError, match="escapes its anchor"):
+        BackendRegistry.register(Escaping)
+
+    assert "test-escaping-backend" not in BackendRegistry.all(), (
+        "a backend that failed the guard must not end up in the registry"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor selection
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_output_dir_honors_the_declared_anchor(tmp_path):
+    anchors = OutputAnchors(plugins=tmp_path / "plugins", repository=tmp_path / "repo")
+
+    class PluginsAnchored(BaseBackend):
+        NAME = "test-plugins-anchored"
+        OUTPUT_DIR = "somewhere"
+
+    class RepoAnchored(BaseBackend):
+        NAME = "test-repo-anchored"
+        OUTPUT_DIR = "somewhere"
+        OUTPUT_ANCHOR = "repository"
+
+    assert resolve_output_dir(PluginsAnchored, anchors) == tmp_path / "plugins" / "somewhere"
+    assert resolve_output_dir(RepoAnchored, anchors) == tmp_path / "repo" / "somewhere"
+
+
+def test_default_anchors_are_two_distinct_real_roots():
+    anchors = orchestrator.default_anchors()
+    assert anchors.plugins.name == "plugins"
+    assert (anchors.repository / ".git").exists(), (
+        "the repository anchor must be a real checkout, discovered by walking up "
+        "for .git rather than by a hardcoded hop count"
+    )
+    assert anchors.repository != anchors.plugins
+
+
+def test_repository_root_discovery_raises_rather_than_guessing(tmp_path):
+    """A plausible-looking fallback here is the dangerous outcome, because the
+    resolved directory gets rmtree'd."""
+    with pytest.raises(RuntimeError, match="no .git found"):
+        orchestrator.find_repository_root(tmp_path)
+
+
+def test_sandbox_replaces_both_anchors_with_distinct_subdirs(tmp_path):
+    sandboxed = OutputAnchors.sandbox(tmp_path)
+    assert tmp_path in sandboxed.plugins.parents
+    assert tmp_path in sandboxed.repository.parents
+    assert sandboxed.plugins != sandboxed.repository, (
+        "distinct so two backends on different anchors cannot collide in a sandbox"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Hazard 2: check_drift must sandbox BOTH anchors
+# ---------------------------------------------------------------------------
+
+
+def test_check_drift_hands_every_build_a_fully_sandboxed_anchor_pair(tmp_path, monkeypatch):
+    """Both fields must point inside a throwaway directory -- not just `plugins`."""
+    real_anchors = OutputAnchors(plugins=tmp_path / "plugins", repository=tmp_path / "repo")
+    real_anchors.plugins.mkdir(parents=True)
+    real_anchors.repository.mkdir(parents=True)
+
+    handed: list[OutputAnchors] = []
+
+    def spy(backend_name: str, anchors: OutputAnchors | None = None) -> None:
+        handed.append(anchors)
+
+    monkeypatch.setattr(orchestrator, "build_one", spy)
+    orchestrator.check_drift(anchors=real_anchors)
+
+    assert handed, "check_drift built nothing; the assertion below would be vacuous"
+    for anchors in handed:
+        assert anchors is not None
+        for field_name in ("plugins", "repository"):
+            got = getattr(anchors, field_name)
+            assert got != getattr(real_anchors, field_name), (
+                f"check_drift passed the real {field_name} anchor to a sandboxed "
+                f"build; that build would rmtree and rewrite {got}"
+            )
+            assert tmp_path not in got.parents, (
+                f"sandboxed {field_name} anchor {got} is not in a throwaway directory"
+            )
+
+
+def test_check_drift_does_not_rewrite_the_tree_it_is_comparing(tmp_path):
+    """The behavioral form of the same hazard, and the one that fails loudly.
+
+    Plant deliberately-wrong content at the repository-anchored backend's output
+    path. A correct drift check reports drift and leaves the file alone. A check
+    whose tempdir build escaped into the real repository anchor would delete the
+    planted file, write generated content in its place, and then compare that
+    freshly-written tree against itself -- reporting success.
+    """
+    anchors = OutputAnchors(plugins=tmp_path / "plugins", repository=tmp_path / "repo")
+    anchors.plugins.mkdir(parents=True)
+
+    planted = anchors.repository / "skills" / "ash-mcp" / "SKILL.md"
+    planted.parent.mkdir(parents=True)
+    planted.write_text("SENTINEL — deliberately not what the transpiler generates\n")
+
+    result = orchestrator.check_drift(anchors=anchors)
+
+    assert planted.exists(), "check_drift deleted the tree it was asked to compare"
+    assert planted.read_text().startswith("SENTINEL"), (
+        "check_drift overwrote the tree it was asked to compare; its sandboxed "
+        "build escaped into the repository anchor"
+    )
+    assert result == 1, (
+        "planted content differs from generated output, so drift must be reported; "
+        "a pass here means the check compared a tree against itself"
+    )

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/__init__.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/__init__.py
@@ -22,3 +22,4 @@ from . import amazonq  # noqa: F401
 from . import aider  # noqa: F401
 from . import mcpb  # noqa: F401
 from . import generic_skill  # noqa: F401  -- format-only release of agentskills
+from . import skills_root  # noqa: F401  -- repo-root skills/, found by the skills CLI

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/skills_root/__init__.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/skills_root/__init__.py
@@ -23,13 +23,65 @@ Constraints and non-goals
 -------------------------
 - `OUTPUT_DIR` is `skills`, never the empty string. `emitters.run_section_emitters`
   begins with `reset(out)` -> `shutil.rmtree(out)`, so a backend resolving to the
-  repository root itself would delete the repository. `BaseBackend` rejects an
-  `OUTPUT_DIR` that escapes its anchor for exactly this reason.
-- The two path templates are re-rooted one level down relative to
+  repository root itself would delete the repository. `core.validated_output_dir`
+  rejects an OUTPUT_DIR that escapes its anchor for exactly this reason, and
+  `BackendRegistry.register` calls it at import time.
+- The two path templates are re-rooted one level up relative to
   `GenericSkillBackend`, whose `skills/{skill_name}/SKILL.md` assumes `out` is the
-  parent of the skills root.
+  *parent* of the skills root. Here `out` **is** the skills root.
 - This backend does not replace generic-skill. That artifact is the portable
   format-only release users copy into their own agent directories; this one is a
   fixed location in *this* repository so the CLI can find it without arguments.
+  Both are generated from `_base/`, so they cannot disagree about content.
+
+Known limitation
+----------------
+`validate.validate_structural_sanity` walks the plugins tree only, so the root
+`skills/` tree gets its frontmatter checked by this backend's inherited
+`smoke_test` and its bytes checked by `orchestrator.check_drift`, but not by that
+third pass. The generic-skill twin is structurally validated and is rendered from
+the same `_base/skill.md` through the same `SkillConfig` fields, so a content
+regression would surface there.
 """
 from __future__ import annotations
+
+from dataclasses import replace
+
+from ...core import BuildContext
+from ...registry import register_backend
+from ..generic_skill import GenericSkillBackend
+
+
+@register_backend
+class SkillsRootBackend(GenericSkillBackend):
+    NAME = "skills-root"
+
+    OUTPUT_DIR = "skills"
+    """Relative to the repository root, giving `<repo>/skills/`. Never "" or "."
+    — those resolve to the anchor itself, which the build deletes."""
+
+    OUTPUT_ANCHOR = "repository"
+
+    # Only the two paths differ from generic-skill. Deriving them with
+    # `replace()` rather than writing a fresh SkillConfig means
+    # `frontmatter_fields`, `include_references` and any field added later are
+    # inherited rather than duplicated, so the two trees cannot disagree about
+    # what a SKILL.md contains.
+    SKILL = replace(
+        GenericSkillBackend.SKILL,
+        path="{skill_name}/SKILL.md",
+        references_path="{skill_name}/references/{ref_name}",
+    )
+
+    def smoke_test(self, ctx: BuildContext) -> dict | None:
+        """Reuse generic-skill's structural checks and `skills-ref validate`.
+
+        The inherited implementation treats `ctx.out` as the directory
+        *containing* `skills/` — it looks for `ctx.out / "skills"` and passes
+        `ctx.out` to `skills-ref validate`. For this backend `ctx.out` is the
+        skills root itself, so hand the parent `ctx.out.parent`: the repository
+        root, whose child `skills/` is exactly what the parent expects. That
+        also makes the parent's error strings ("skills/<name>/SKILL.md missing")
+        read correctly as repository-relative paths.
+        """
+        return super().smoke_test(replace(ctx, out=ctx.out.parent))

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/skills_root/__init__.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/backends/skills_root/__init__.py
@@ -1,0 +1,35 @@
+"""Repository-root `skills/` backend — discoverable by the `skills` CLI.
+
+Why this exists
+---------------
+Vercel's `skills` CLI (npm `skills`, `vercel-labs/skills`) discovers skills only
+at a **repository-root `skills/<name>/` directory**. It does not search the tree.
+Measured against this repository before this backend existed:
+
+    npx skills add awslabs/automated-security-helper
+    -> No skills found
+
+...while pointing the same CLI directly at the generic-skill output tree found
+the skill fine. The content and frontmatter were already correct; only the
+location was wrong.
+
+Rather than hand-maintain a second copy of `SKILL.md` at the repository root --
+which would drift from `_base/` the first time anyone edited one and not the
+other -- the root tree is generated from the same `_base/` source as every other
+output, by a backend whose output anchor is the repository root instead of
+`agentic-coding/plugins/`.
+
+Constraints and non-goals
+-------------------------
+- `OUTPUT_DIR` is `skills`, never the empty string. `emitters.run_section_emitters`
+  begins with `reset(out)` -> `shutil.rmtree(out)`, so a backend resolving to the
+  repository root itself would delete the repository. `BaseBackend` rejects an
+  `OUTPUT_DIR` that escapes its anchor for exactly this reason.
+- The two path templates are re-rooted one level down relative to
+  `GenericSkillBackend`, whose `skills/{skill_name}/SKILL.md` assumes `out` is the
+  parent of the skills root.
+- This backend does not replace generic-skill. That artifact is the portable
+  format-only release users copy into their own agent directories; this one is a
+  fixed location in *this* repository so the CLI can find it without arguments.
+"""
+from __future__ import annotations

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/cli.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/cli.py
@@ -18,7 +18,7 @@ import click
 
 from . import backends as _backends_pkg  # noqa: F401  triggers registration
 from . import orchestrator
-from .core import BuildContext
+from .core import BuildContext, resolve_output_dir
 from .registry import BackendRegistry
 
 
@@ -52,15 +52,15 @@ def setup(name: str | None) -> None:
     Most backends have no setup work; the command is a no-op unless a backend
     declares PHASES with `stage="setup"`."""
     m = orchestrator._load_manifest()
-    out_root = orchestrator.OUTPUT_ROOT
+    anchors = orchestrator.default_anchors()
     targets = _all_or_one(name)
     for backend_name in targets:
         BackendCls = BackendRegistry.get(backend_name)
         backend = BackendCls()
         ctx = BuildContext(
             manifest=m,
-            out=out_root / BackendCls.OUTPUT_DIR,
-            plugins_root=out_root,
+            out=resolve_output_dir(BackendCls, anchors),
+            plugins_root=anchors.plugins,
             base_dir=orchestrator.BASE_DIR,
             schemas_dir=orchestrator.SCHEMAS_DIR,
         )
@@ -142,8 +142,10 @@ def check(drift_only: bool, validate_only: bool) -> None:
         # Lazy import keeps jsonschema and frontmatter out of the build hot path
         from validate import validate_all
         m = orchestrator._load_manifest()
+        anchors = orchestrator.default_anchors()
         errors = validate_all(
-            plugins_root=orchestrator.OUTPUT_ROOT,
+            plugins_root=anchors.plugins,
+            repository_root=anchors.repository,
             schemas_dir=orchestrator.SCHEMAS_DIR,
             configs={
                 name: _backend_to_platform_config(BackendRegistry.get(name))
@@ -196,7 +198,7 @@ def smoke_test(name: str | None) -> None:
     Each backend that supports smoke testing implements a `smoke_test(ctx)`
     method on its class; backends without one print 'skipped'."""
     m = orchestrator._load_manifest()
-    out_root = orchestrator.OUTPUT_ROOT
+    anchors = orchestrator.default_anchors()
     targets = _all_or_one(name)
 
     failed: list[str] = []
@@ -208,8 +210,8 @@ def smoke_test(name: str | None) -> None:
         backend = BackendCls()
         ctx = BuildContext(
             manifest=m,
-            out=out_root / BackendCls.OUTPUT_DIR,
-            plugins_root=out_root,
+            out=resolve_output_dir(BackendCls, anchors),
+            plugins_root=anchors.plugins,
             base_dir=orchestrator.BASE_DIR,
             schemas_dir=orchestrator.SCHEMAS_DIR,
         )
@@ -399,6 +401,7 @@ def _backend_to_platform_config(BackendCls):
     from types import SimpleNamespace
     return SimpleNamespace(
         output_dir=BackendCls.OUTPUT_DIR,
+        output_anchor=BackendCls.OUTPUT_ANCHOR,
         plugin_manifest=BackendCls.PLUGIN_MANIFEST,
         extension_manifest=BackendCls.EXTENSION_MANIFEST,
         marketplace=BackendCls.MARKETPLACE,

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/core.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/core.py
@@ -18,8 +18,112 @@ import re
 import shutil
 import subprocess
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import ClassVar, Literal
+
+
+# ---------------------------------------------------------------------------
+# Output anchors — the roots a backend's OUTPUT_DIR can hang from
+# ---------------------------------------------------------------------------
+
+
+OutputAnchor = Literal["plugins", "repository"]
+
+
+@dataclass(frozen=True)
+class OutputAnchors:
+    """The roots available to backends, as two independent explicit fields.
+
+    Neither is derived from the other, and that is load-bearing rather than
+    stylistic. `orchestrator.check_drift` sandboxes a build by handing it a
+    temporary directory and byte-comparing the result. If `repository` were
+    computed by walking up from `plugins` (or vice versa), a sandboxed build
+    would resolve outside its own tempdir, and because
+    `emitters.run_section_emitters` starts with `reset(out)` ->
+    `shutil.rmtree(out)`, it would delete whatever it landed on. Keeping the
+    two fields separate means sandboxing one cannot silently fail to sandbox
+    the other: `sandbox()` sets both, and there is no code path that fills in
+    one from the other.
+    """
+
+    plugins: Path
+    """agentic-coding/plugins/ — where per-platform plugin trees are written."""
+
+    repository: Path
+    """The repository root — where tooling that scans a checkout expects to
+    find things, e.g. the `skills` CLI's `skills/<name>/` layout."""
+
+    @classmethod
+    def sandbox(cls, tmp: Path) -> OutputAnchors:
+        """Anchors confined to `tmp`, for drift checks and tests.
+
+        Both anchors become distinct subdirectories of `tmp`. Distinct rather
+        than both equal to `tmp` so that two backends anchored differently can
+        never resolve to the same output directory inside a sandbox, which
+        would make a drift comparison silently compare the wrong trees.
+        """
+        return cls(plugins=tmp / "plugins", repository=tmp / "repository")
+
+    def root_for(self, anchor: OutputAnchor) -> Path:
+        if anchor == "plugins":
+            return self.plugins
+        if anchor == "repository":
+            return self.repository
+        raise ValueError(
+            f"unknown OUTPUT_ANCHOR {anchor!r}; expected 'plugins' or 'repository'"
+        )
+
+
+def validated_output_dir(name: str, output_dir: str) -> str:
+    """Reject an OUTPUT_DIR that does not stay strictly inside its anchor.
+
+    This is a safety guard, not input validation. The resolved output directory
+    is passed to `emitters.run_section_emitters`, whose first act is
+    `reset(out)` -> `shutil.rmtree(out)`. Under the `repository` anchor an
+    empty, `.`-valued, absolute, or `..`-containing OUTPUT_DIR resolves to the
+    repository root or above it, so a build would delete the checkout. Raising
+    here is the only acceptable outcome; there is no sensible fallback.
+
+    Both POSIX and Windows path flavors are consulted because they disagree
+    about what is absolute and what a separator is: `PurePosixPath` does not
+    treat `C:\\x` as absolute and does not split on backslash, while
+    `PureWindowsPath` does not treat a bare `/x` as absolute (it has no drive).
+    A value that is dangerous on either platform is rejected on both.
+    """
+    if not isinstance(output_dir, str) or not output_dir.strip():
+        raise ValueError(
+            f"backend {name!r} declares an empty OUTPUT_DIR; it would resolve to "
+            f"its anchor root, which the build then deletes"
+        )
+    flavors = (PurePosixPath(output_dir), PureWindowsPath(output_dir))
+    for p in flavors:
+        if p.is_absolute() or p.anchor:
+            raise ValueError(
+                f"backend {name!r} declares an absolute OUTPUT_DIR "
+                f"{output_dir!r}; it must be relative to its anchor"
+            )
+        if ".." in p.parts:
+            raise ValueError(
+                f"backend {name!r} declares OUTPUT_DIR {output_dir!r}, which "
+                f"escapes its anchor via '..'"
+            )
+    if not any(p.parts for p in flavors):
+        raise ValueError(
+            f"backend {name!r} declares OUTPUT_DIR {output_dir!r}, which resolves "
+            f"to its anchor root; the build would delete the anchor"
+        )
+    return output_dir
+
+
+def resolve_output_dir(backend_cls: type[BaseBackend], anchors: OutputAnchors) -> Path:
+    """The single funnel from (backend, anchors) to an output directory.
+
+    Every site that needs a backend's output path goes through here so the
+    escape guard cannot be bypassed by a caller that reassembles the path
+    itself.
+    """
+    output_dir = validated_output_dir(backend_cls.NAME, backend_cls.OUTPUT_DIR)
+    return anchors.root_for(backend_cls.OUTPUT_ANCHOR) / output_dir
 
 
 # ---------------------------------------------------------------------------
@@ -353,6 +457,19 @@ class BaseBackend:
 
     NAME: ClassVar[str] = ""
     OUTPUT_DIR: ClassVar[str] = ""
+
+    OUTPUT_ANCHOR: ClassVar[OutputAnchor] = "plugins"
+    """Which root OUTPUT_DIR is relative to. Almost always "plugins" — a
+    backend's output is a plugin tree under agentic-coding/plugins/.
+
+    "repository" is for output that external tooling only finds at a fixed
+    location in a checkout, where a copy under plugins/ would be invisible to
+    it. Today only `skills-root`: the `skills` CLI discovers skills at a
+    repository-root `skills/<name>/` directory and does not search the tree.
+
+    Resolve through `resolve_output_dir`, never by joining a root and
+    OUTPUT_DIR by hand — the join is where the escape guard lives, and the
+    resolved directory is rmtree'd at the start of every build."""
 
     FORMAT: ClassVar[Format | None] = None
     """Optional Format this backend produces. Today informational only —

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/orchestrator.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/orchestrator.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 
 from . import backends as _backends_pkg  # noqa: F401  triggers registration
-from .core import BuildContext, Manifest
+from .core import BuildContext, Manifest, OutputAnchors, resolve_output_dir
 from .jinja_renderer import render
 from .registry import BackendRegistry
 
@@ -20,6 +20,45 @@ TRANSPILER_DIR = HERE.parent                         # transpiler/
 BASE_DIR = TRANSPILER_DIR / "_base"
 SCHEMAS_DIR = TRANSPILER_DIR / "schemas"
 OUTPUT_ROOT = TRANSPILER_DIR.parent / "plugins"      # agentic-coding/plugins/
+
+
+def find_repository_root(start: Path = TRANSPILER_DIR) -> Path:
+    """Walk up from `start` to the first directory containing a `.git` entry.
+
+    The repository root is not a fixed number of hops above the transpiler.
+    `ash-agent-plugins/` is designed to be extractable as its own repository —
+    it carries its own workflows, pre-commit config, LICENSE and .gitignore —
+    so the transpiler sits three levels below the root inside the ASH monorepo
+    and two levels below it standalone. A hardcoded `parents[2]` would be
+    silently wrong in one of the two layouts, and because a build rmtree's its
+    output directory, silently wrong here means deleting the wrong tree.
+
+    Checks `exists()` rather than `is_dir()` because `.git` is a file, not a
+    directory, in a linked worktree or a submodule.
+
+    Raises rather than guessing: a caller that reaches here without a
+    repository has no correct answer available, and a plausible-looking
+    fallback would be the dangerous outcome.
+    """
+    start = start.resolve()
+    for candidate in (start, *start.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    raise RuntimeError(
+        f"no .git found in {start} or any parent; cannot locate the repository "
+        f"root. Backends with OUTPUT_ANCHOR = 'repository' need a real checkout "
+        f"(a source tarball or an installed wheel is not enough)."
+    )
+
+
+def default_anchors() -> OutputAnchors:
+    """The real anchors for this checkout.
+
+    Resolved lazily rather than as module constants so that importing the
+    transpiler outside a git checkout still works; only backends that actually
+    need the repository root pay for its discovery.
+    """
+    return OutputAnchors(plugins=OUTPUT_ROOT, repository=find_repository_root())
 
 
 def _load_manifest() -> Manifest:
@@ -48,39 +87,40 @@ def render_universal_agents_md(out_root: Path) -> None:
     (out_root / "AGENTS.md").write_text(rendered)
 
 
-def build_one(backend_name: str, out_root: Path | None = None) -> None:
+def build_one(backend_name: str, anchors: OutputAnchors | None = None) -> None:
     """Build a single backend by name."""
-    out_root = out_root or OUTPUT_ROOT
+    anchors = anchors or default_anchors()
     m = _load_manifest()
     BackendCls = BackendRegistry.get(backend_name)
     backend = BackendCls()
     backend.build(
         manifest=m,
-        out=out_root / BackendCls.OUTPUT_DIR,
-        plugins_root=out_root,
+        out=resolve_output_dir(BackendCls, anchors),
+        plugins_root=anchors.plugins,
         base_dir=BASE_DIR,
         schemas_dir=SCHEMAS_DIR,
     )
 
 
-def build_all(out_root: Path | None = None) -> None:
+def build_all(anchors: OutputAnchors | None = None) -> None:
     """Build every registered backend + the universal AGENTS.md."""
-    out_root = out_root or OUTPUT_ROOT
-    out_root.mkdir(parents=True, exist_ok=True)
-    render_universal_agents_md(out_root)
+    anchors = anchors or default_anchors()
+    anchors.plugins.mkdir(parents=True, exist_ok=True)
+    render_universal_agents_md(anchors.plugins)
     for name in BackendRegistry.names():
-        build_one(name, out_root=out_root)
+        build_one(name, anchors=anchors)
 
 
-def release_one(backend_name: str, dist_dir: Path, out_root: Path | None = None) -> None:
-    out_root = out_root or OUTPUT_ROOT
+def release_one(backend_name: str, dist_dir: Path,
+                anchors: OutputAnchors | None = None) -> None:
+    anchors = anchors or default_anchors()
     m = _load_manifest()
     BackendCls = BackendRegistry.get(backend_name)
     backend = BackendCls()
     ctx = BuildContext(
         manifest=m,
-        out=out_root / BackendCls.OUTPUT_DIR,
-        plugins_root=out_root,
+        out=resolve_output_dir(BackendCls, anchors),
+        plugins_root=anchors.plugins,
         base_dir=BASE_DIR,
         schemas_dir=SCHEMAS_DIR,
         dist_dir=dist_dir,
@@ -88,11 +128,11 @@ def release_one(backend_name: str, dist_dir: Path, out_root: Path | None = None)
     backend.release(ctx)
 
 
-def release_all(dist_dir: Path, out_root: Path | None = None) -> None:
-    out_root = out_root or OUTPUT_ROOT
+def release_all(dist_dir: Path, anchors: OutputAnchors | None = None) -> None:
+    anchors = anchors or default_anchors()
     dist_dir.mkdir(parents=True, exist_ok=True)
     for name in BackendRegistry.names():
-        release_one(name, dist_dir, out_root=out_root)
+        release_one(name, dist_dir, anchors=anchors)
 
 
 # ---------------------------------------------------------------------------
@@ -110,13 +150,22 @@ def _files_in(path: Path) -> dict[str, bytes]:
     }
 
 
-def check_drift(out_root: Path | None = None) -> int:
+def check_drift(anchors: OutputAnchors | None = None) -> int:
     """Return 0 if generated outputs match what build_all() would produce; 1 otherwise.
 
-    Runs build_all into a tempdir, then byte-compares against the on-disk plugins
-    directory."""
-    out_root = out_root or OUTPUT_ROOT
+    Builds each backend into a tempdir, then byte-compares against its on-disk
+    output directory.
+
+    The tempdir build is handed `OutputAnchors.sandbox(td)`, which replaces
+    *both* anchors. Sandboxing only the plugins anchor would leave a
+    repository-anchored backend resolving to the real checkout, and since a
+    build begins by rmtree'ing its output directory, a drift *check* would
+    delete and rewrite the very tree it is supposed to be comparing against —
+    always reporting no drift, having caused it.
+    """
+    anchors = anchors or default_anchors()
     drift: list[tuple[str, list[str], list[str], list[str]]] = []
+    out_root = anchors.plugins
 
     # Universal AGENTS.md
     m = _load_manifest()
@@ -139,10 +188,10 @@ def check_drift(out_root: Path | None = None) -> int:
     for name in BackendRegistry.names():
         BackendCls = BackendRegistry.get(name)
         with tempfile.TemporaryDirectory() as td:
-            tmp_root = Path(td)
-            build_one(name, out_root=tmp_root)
-            on_disk = _files_in(out_root / BackendCls.OUTPUT_DIR)
-            generated = _files_in(tmp_root / BackendCls.OUTPUT_DIR)
+            sandboxed = OutputAnchors.sandbox(Path(td))
+            build_one(name, anchors=sandboxed)
+            on_disk = _files_in(resolve_output_dir(BackendCls, anchors))
+            generated = _files_in(resolve_output_dir(BackendCls, sandboxed))
             if on_disk != generated:
                 added = sorted(set(generated) - set(on_disk))
                 removed = sorted(set(on_disk) - set(generated))

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/registry.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/registry.py
@@ -25,6 +25,13 @@ class BackendRegistry:
                 f"backend '{backend_cls.NAME}' already registered "
                 f"({cls._backends[backend_cls.NAME].__name__} vs {backend_cls.__name__})"
             )
+        # Fail at import rather than mid-build. Registration is the point where
+        # a backend commits to being built, and a build rmtree's its output
+        # directory before writing, so an OUTPUT_DIR that escapes its anchor is
+        # destructive rather than merely wrong. Imported locally to keep
+        # registry.py free of a module-level dependency on core.
+        from .core import validated_output_dir
+        validated_output_dir(backend_cls.NAME, backend_cls.OUTPUT_DIR)
         cls._backends[backend_cls.NAME] = backend_cls
         return backend_cls
 

--- a/ash-agent-plugins/agentic-coding/transpiler/validate.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/validate.py
@@ -299,13 +299,23 @@ def validate_paths_exist(
     configs: dict[str, Any],
     plugin_name: str,
     skill_name: str,
+    repository_root: Path | None = None,
 ) -> list[Error]:
-    """For each platform, confirm that configs.yaml's declared output paths
-    actually exist in the generated tree. Catches transpiler omissions.
+    """For each platform, confirm that its declared output paths actually exist
+    in the generated tree. Catches transpiler omissions.
 
     Path templating uses **values consistent with the renderer's interpolate_path
     so future placeholders ({command_name}, {ref_name}, etc.) added to a config
-    don't crash the validator with KeyError."""
+    don't crash the validator with KeyError.
+
+    A backend's paths are relative to its own anchor, not always to
+    `plugins_root`: a backend declaring `output_anchor = "repository"` writes
+    into the repository root instead. Resolving every config against
+    `plugins_root` would report that backend's output directory as missing while
+    it sat correctly on disk somewhere else. `repository_root` is optional so
+    callers that only build plugin trees need not supply it; a config that asks
+    for an anchor the caller did not provide is an error rather than a silent
+    fallback to `plugins_root`, which would resolve to the wrong tree."""
     errors: list[Error] = []
     template_values = {
         "plugin_name": plugin_name,
@@ -323,8 +333,27 @@ def validate_paths_exist(
                               "This is a transpiler bug, not a content issue."))
             return None
 
+    anchor_roots: dict[str, Path | None] = {
+        "plugins": plugins_root,
+        "repository": repository_root,
+    }
+
     for name, cfg in configs.items():
-        out = plugins_root / cfg.output_dir
+        anchor = getattr(cfg, "output_anchor", "plugins")
+        if anchor not in anchor_roots:
+            errors.append(err(cfg.output_dir,
+                              f"platform {name} declares unknown output_anchor {anchor!r}",
+                              "Valid anchors are 'plugins' and 'repository'."))
+            continue
+        anchor_root = anchor_roots[anchor]
+        if anchor_root is None:
+            errors.append(err(cfg.output_dir,
+                              f"platform {name} is anchored at {anchor!r} but the "
+                              f"validator was not given that root",
+                              f"Pass {anchor}_root= to validate_all."))
+            continue
+
+        out = anchor_root / cfg.output_dir
         if not out.exists():
             errors.append(err(out, f"platform {name} output directory missing", "Run the transpiler."))
             continue
@@ -590,14 +619,20 @@ def validate_all(
     configs: dict[str, Any],
     plugin_name: str,
     skill_name: str,
+    repository_root: Path | None = None,
 ) -> list[Error]:
     """Run all three validation tiers and return collected errors.
 
-    Empty list means everything passed. Caller decides exit behavior."""
+    Empty list means everything passed. Caller decides exit behavior.
+
+    `repository_root` is only needed when some backend declares
+    `output_anchor = "repository"`; every other check is scoped to
+    `plugins_root`."""
     return [
         *validate_external_schemas(plugins_root, schemas_dir),
         *validate_structural_sanity(plugins_root),
-        *validate_paths_exist(plugins_root, configs, plugin_name, skill_name),
+        *validate_paths_exist(plugins_root, configs, plugin_name, skill_name,
+                              repository_root=repository_root),
         *validate_claude_plugin_name(plugins_root),
         *validate_roo_slug(plugins_root),
         *validate_windsurf_trigger(plugins_root),

--- a/skills/ash-mcp/SKILL.md
+++ b/skills/ash-mcp/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: ash-mcp
+description: Run security scans with the ASH (Automated Security Helper) MCP server. Use this skill whenever the user asks to scan for vulnerabilities, run a security check, find CVEs, audit dependencies, check for secrets, run SAST or SCA, scan IaC (Terraform/CloudFormation/Kubernetes), check for hardcoded credentials, or mentions ASH, Bandit, Semgrep, Checkov, Grype, Syft, or detect-secrets. Also trigger when the user wants to find security issues, harden a codebase, or asks "is my code secure". Do NOT trigger for code review without security context, performance audits, or test writing.
+version: 1.0.0
+---
+
+# ASH MCP — Security Scanning Workflow
+
+ASH (Automated Security Helper) wraps nine security scanners behind a single MCP interface. The server exposes scans as async tools — start a scan, poll for progress, fetch filtered results.
+
+This skill assumes the ASH MCP server is configured (the plugin/power that ships this skill provides it).
+
+## The mandatory three-step workflow
+
+Every scan follows this exact pattern. Skipping the poll step means stale progress visibility — the scan keeps running server-side, but you lose real-time updates.
+
+### Step 1 — Start the scan
+
+Call `run_ash_scan` with the absolute path to the project. The call returns immediately with a `scan_id`.
+
+```
+run_ash_scan(
+    source_dir="/absolute/path/to/project",
+    severity_threshold="MEDIUM",   # CRITICAL | HIGH | MEDIUM | LOW | INFO
+    config_path=None,              # Optional path to .ash.yaml
+    clean_output=True
+)
+```
+
+Returns a dict with `scan_id`, `status: "running"`, `directory_path` (the resolved absolute scan root), and an `important.next_steps` block. **Always store the `scan_id`** — every subsequent call needs it.
+
+For the output directory, prefer reading `output_directory` from any subsequent `get_scan_progress` response (it pre-computes the path). If you need the output dir before the first poll, derive it from this response's `directory_path` as `<directory_path>/.ash/ash_output/`.
+
+The server's `important.next_steps` block recommends polling `progress['is_complete']`. Ignore that — `is_complete` stays `False` for cancelled scans. Always check `status` independently, as described in Step 2.
+
+The MCP server always runs scans in local mode (Python-only, no Docker). For container or precommit modes, use the ASH CLI directly. Scanner selection lives in `.ash/.ash.yaml`, not in tool parameters.
+
+### Step 2 — Poll progress every 5 seconds
+
+Loop on `get_scan_progress` until the scan is complete. The 5-second cadence is what the ASH MCP server's own docstring requests for reliable progress streaming over long scans.
+
+```
+get_scan_progress(scan_id="<uuid>")
+```
+
+Stop polling when `status` is one of `completed | failed | cancelled`. Do **not** rely on `is_complete` alone — it stays `False` for cancelled scans, so polling on `is_complete` will loop forever after a cancel. Typical scans take 30-120 seconds.
+
+For progress display, use `completed_scanners / total_scanners` — but check `total_scanners > 0` first (it's zero during pre-flight before any scanner registers; show "initializing" in that case). The response also includes `severity_counts` and per-scanner breakdown to surface in user-facing updates.
+
+The scan itself runs server-side regardless of polling cadence — polling is for progress visibility, not for keeping the scan alive.
+
+### Step 3 — Fetch results with the right filter
+
+Once the scan is complete, call `get_scan_results`. Match the filter to the user's intent.
+
+| User goal | Filter combination |
+|-----------|-------------------|
+| "How bad is it?" | `filter_level="summary"` + `actionable_only=True` |
+| "Show me the critical issues" | `filter_level="full"` + `severities="critical,high"` |
+| "Audit Bandit only" | `scanners="bandit"` + `filter_level="full"` |
+| "Generate exec summary" | Use `get_scan_result_paths`, then read `ash.summary.md` |
+
+```
+get_scan_results(
+    output_dir="/absolute/path/to/project/.ash/ash_output",
+    filter_level="summary",
+    severities="critical,high",
+    actionable_only=True
+)
+```
+
+For HTML/SARIF/CSV reports, prefer `get_scan_result_paths` and read the files directly with native file tools — it avoids piping large payloads through MCP.
+
+## Tool inventory
+
+For full parameter details, see [tool-reference.md](references/tool-reference.md).
+
+- `run_ash_scan` — Start a scan asynchronously
+- `get_scan_progress` — Poll progress (call every 5s)
+- `get_scan_results` — Fetch filtered results
+- `get_scan_summary` — Counts only, no findings
+- `get_scan_result_paths` — File paths to all reports
+- `list_active_scans` — All current/recent scans
+- `cancel_scan` — Stop a running scan
+- `check_installation` — Verify ASH is installed
+
+## Choosing scanners
+
+ASH runs all nine scanners by default. To run only a subset, edit `.ash/.ash.yaml` at the project root before scanning — `run_ash_scan` does not accept a scanners argument. To filter results post-scan, use the `scanners` parameter on `get_scan_results`.
+
+For result-time filtering by scanner:
+
+- **Python issues** → `scanners="bandit,semgrep"`
+- **Secrets only** → `scanners="detect-secrets"`
+- **IaC review** → `scanners="checkov,cfn_nag,cdk-nag"`
+- **Dependencies** → `scanners="grype,npm-audit"`
+- **SBOM generation** → `scanners="syft"`
+
+## When something goes wrong
+
+See [troubleshooting.md](references/troubleshooting.md) for the common failures: connection timeouts, empty results, stuck scans, container/Docker issues, suppression rules not applying.
+
+The fast checks: scan never starts → run `check_installation` first. Scan returns no findings → drop `actionable_only` and widen `severities`. Stale progress visibility → you weren't polling every 5 seconds.

--- a/skills/ash-mcp/references/tool-reference.md
+++ b/skills/ash-mcp/references/tool-reference.md
@@ -1,0 +1,147 @@
+# ASH MCP Tool Reference
+
+The ASH MCP server exposes eight tools and two resources.
+
+## run_ash_scan
+
+Starts a scan asynchronously. Returns a `scan_id` immediately — the scan continues in the background regardless of MCP connection state.
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `source_dir` | string \| null | current dir | Absolute path to scan |
+| `severity_threshold` | string | `"MEDIUM"` | Findings below this are filtered out at scan time |
+| `config_path` | string \| null | `<source>/.ash/.ash.yaml` | Custom config path |
+| `clean_output` | boolean | `true` | Wipe stale reports before starting |
+
+Output reports are written to `<source_dir>/.ash/ash_output/` — there is no parameter to override this. Scanner selection, mode, and other tuning live in `.ash/.ash.yaml`, not in tool arguments.
+
+Returns:
+```json
+{
+  "success": true,
+  "status": "running",
+  "scan_id": "<uuid>",
+  "progress": 0.0,
+  "message": "Scan started, initializing scanners. Use get_scan_progress to track progress.",
+  "directory_path": "<absolute path scanned>",
+  "important": {
+    "connection_management": "<server's polling guidance>",
+    "next_steps": ["..."]
+  }
+}
+```
+
+The `directory_path` field tells you the resolved absolute path the server is scanning — derive `output_dir` for `get_scan_results` from this value (`<directory_path>/.ash/ash_output`) rather than constructing it independently.
+
+**Heads-up:** the server's own docstring and the `important.next_steps` array suggest polling `progress['is_complete']`. This is incomplete advice — `is_complete` stays `False` for cancelled scans. Always check `status` independently. (See `get_scan_progress` below.)
+
+## get_scan_progress
+
+Poll progress every 5 seconds until complete. Keeps the MCP connection alive while the scan runs.
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `scan_id` | string | From `run_ash_scan` |
+
+Returns:
+```json
+{
+  "scan_id": "...",
+  "directory_path": "/path/to/scanned/project",
+  "output_directory": "/path/to/.ash/ash_output",
+  "start_time": "<iso8601>",
+  "end_time": "<iso8601 | null>",
+  "status": "running | completed | failed | cancelled",
+  "severity_threshold": "MEDIUM",
+  "config_path": "<path | null>",
+  "warnings": [...],
+  "error_message": "<str | null>",
+  "is_complete": bool,
+  "completed_scanners": int,
+  "total_scanners": int,
+  "total_findings": int,
+  "severity_counts": { "critical": int, "high": int, "medium": int, "low": int, "info": int, "suppressed": int },
+  "scanners": {
+    "<scanner_name>": {
+      "<target_type>": { ... per-scanner-target progress ... }
+    }
+  }
+}
+```
+
+There is no overall percentage field. To compute progress, use `completed_scanners / total_scanners` — but **guard against `total_scanners == 0`** during the pre-flight phase (before any scanner has registered). Show "initializing" or 0% when `total_scanners` is zero.
+
+There is no top-level `duration` field — derive elapsed time from `start_time` and `end_time` (or from current time while running).
+
+**`is_complete` does not flip to `True` for cancelled scans** — it returns `True` only for `completed` and `failed`. Always check `status` independently: stop polling when `status` is `completed`, `failed`, or `cancelled`. Polling on `is_complete` alone will loop forever on a cancelled scan.
+
+**Status enum:** the documented values are `pending | running | completed | failed | cancelled`. The registry uses `pending` briefly while a scan is queued, transitions to `running` once execution begins, and may also expose the legacy `in_progress` string from older `ScanProgress` instances. Treat `pending`, `running`, and `in_progress` as equivalent "not done yet" states.
+
+## get_scan_results
+
+Fetch finalized results with filtering. Run only after `get_scan_progress` reports complete.
+
+| Param | Type | Default | Notes |
+|-------|------|---------|-------|
+| `output_dir` | string | `".ash/ash_output"` | Absolute path strongly recommended; the server resolves relative paths against its own cwd, which usually isn't your project root |
+| `filter_level` | string | `"full"` | `full`, `summary`, `minimal` |
+| `scanners` | string \| null | all | Comma-separated subset |
+| `severities` | string \| null | all | `critical,high,medium,low,info` |
+| `actionable_only` | boolean | `false` | Drop suppressed findings |
+
+Returns full or filtered findings depending on `filter_level`.
+
+## get_scan_summary
+
+Metadata and counts only — no individual findings. Cheap for quick health checks.
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `output_dir` | string | Absolute path |
+
+Returns total count, severity breakdown, scanner statuses.
+
+## get_scan_result_paths
+
+Returns file paths to all generated reports. Useful when you want to read HTML, SARIF, CSV, or markdown directly with file tools instead of pulling JSON over MCP.
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `output_dir` | string | Absolute path |
+
+Returns a dict mapping format names to absolute paths.
+
+## list_active_scans
+
+All scans the server tracks (active + recently completed).
+
+No parameters. Returns a list of scan summaries.
+
+## cancel_scan
+
+Stop a running scan and free resources.
+
+| Param | Type | Notes |
+|-------|------|-------|
+| `scan_id` | string | The scan to stop |
+
+Returns confirmation.
+
+## check_installation
+
+Verify ASH is installed and the MCP server can spawn it. Run before the first scan in a session if you're unsure of the install state.
+
+No parameters. Returns version string and feature flags.
+
+## Resources
+
+- `ash://status` — Installation status (text)
+- `ash://help` — Usage guide (text)
+
+Read these via the standard MCP resource read mechanism for context-free help.
+
+## Severity levels
+
+`CRITICAL` > `HIGH` > `MEDIUM` > `LOW` > `INFO` > `SUPPRESSED`
+
+`actionable_only=True` drops `SUPPRESSED` findings (false positives, accepted risks).

--- a/skills/ash-mcp/references/troubleshooting.md
+++ b/skills/ash-mcp/references/troubleshooting.md
@@ -1,0 +1,64 @@
+# ASH Troubleshooting
+
+## Stale progress visibility during scan
+
+**Symptom:** `get_scan_progress` shows the same state for a long time, or the client appears to lose contact with the server.
+
+**Cause:** Not polling on the 5-second cadence the ASH server's docstring requests. The scan itself runs server-side regardless of polling — only the progress channel suffers.
+
+**Fix:** Poll `get_scan_progress(scan_id=...)` every 5 seconds while a scan is active. Even on small scans, this gives reliable per-scanner status. If the connection truly drops, reconnect and re-issue `get_scan_progress` with the stored `scan_id` — the server retains scan state.
+
+## Scan returns immediately with no findings
+
+**Symptom:** `get_scan_results` returns an empty `findings` list, but the project clearly has issues.
+
+**Causes & fixes:**
+1. `actionable_only=True` is dropping suppressed findings — set it to `false` to see everything.
+2. `severities` filter is too tight — try `severities=None` first.
+3. `severity_threshold` at scan time was too high — re-scan with `severity_threshold="LOW"`.
+4. Scanners didn't run — check `get_scan_summary` output for scanner-level failures.
+
+## "ASH not installed"
+
+**Symptom:** `check_installation` returns failure or `run_ash_scan` errors with "command not found."
+
+**Fix:** The MCP server needs ASH on its PATH. The standard install via `uvx`:
+```
+uvx --from=git+https://github.com/awslabs/automated-security-helper@v3.4.0 ash mcp
+```
+This always uses the pinned ASH version regardless of system installs.
+
+## Scan never completes
+
+**Symptom:** `get_scan_progress` shows `status: running` indefinitely.
+
+**Causes:**
+1. Project too large — default scan timeout is 2400s (40 min). For larger codebases, set `scan_timeout_seconds` higher in `.ash/.ash.yaml` or scan a subdirectory.
+2. Stuck scanner — call `cancel_scan(scan_id)` and retry. To isolate which scanner is hanging, narrow the scanner set in `.ash/.ash.yaml` and re-scan.
+3. Server-side dependency stalled — restart the MCP server. The previous scan's state is lost, but the next scan will start clean.
+
+Note: container-mode hangs are not possible via the MCP server — it always runs in local mode. If you suspect a Docker issue, you're not using the MCP integration; check your CLI invocation.
+
+## "Permission denied" reading output
+
+**Symptom:** `get_scan_result_paths` returns paths but the files can't be read.
+
+**Cause:** This typically only happens with CLI container-mode scans, which leave files owned by root. The MCP server runs in local mode, so this should not occur via MCP.
+
+**Fix:** If you arrived here from MCP, check filesystem permissions on the project directory. If you're mixing CLI container scans with MCP reads, `chown` the output directory.
+
+## Empty `scanners` map in progress
+
+**Symptom:** `get_scan_progress` shows `scanners: {}` and `completed_scanners: 0`, `total_scanners: 0` for a long time.
+
+**Cause:** The scan is still in the pre-flight phase (cloning, dependency analysis). This is normal for the first 5-15 seconds of a scan, longer for large projects.
+
+**Fix:** Keep polling. If it's still empty after 60 seconds, cancel and check the ASH server logs.
+
+## SUPPRESSED findings keep appearing
+
+**Symptom:** Findings flagged as suppressed/false-positive show up in `actionable_only=True` results.
+
+**Cause:** Suppression rules are stored in `.ash/.ash.yaml` under `global_settings.ignore_paths` and per-scanner config blocks. If those aren't being read, suppressions don't apply.
+
+**Fix:** Confirm `.ash/.ash.yaml` exists at the project root and has the right syntax. Run with `actionable_only=False` to see ALL findings (including suppressed) and verify the suppression rules match.


### PR DESCRIPTION
## What

Makes ASH installable with Vercel's open agent-skills CLI, and documents the three ways to wire ASH into an AI coding agent.

1. A new transpiler backend emits a repository-root `skills/ash-mcp/` tree from the existing `_base/` source.
2. A CI job gates the generated plugin trees against drift, in ASH's own workflows.
3. `.gitignore` no longer hides the generated Copilot `mcp.json`.
4. The root `README.md` gains an install section; `ash-agent-plugins/README.md` gets corrected.

## Why the root directory

The `skills` CLI discovers skills at a repository-root `skills/<name>/` path. ASH's skill content and frontmatter were already valid, but every copy lived under `ash-agent-plugins/agentic-coding/plugins/<target>/skills/`, so the CLI found nothing. Measured before this change:

```
$ npx skills add <checkout> --list
No skills found
No valid skills found. Skills require a SKILL.md with name and description.
```

And after:

```
$ npx skills add <checkout> --list
Found 1 skill
  ash-mcp
    Run security scans with the ASH (Automated Security Helper) MCP server. ...
```

The tree is generated rather than copied, so it cannot drift from `_base/`. It is byte-identical to the `generic-skill` backend's output (`diff -r`, no differences); the two differ only in where they land. `generic-skill` stays inside the plugin tree for anyone assembling a custom integration.

## How the output root is expressed

Every existing backend wrote under `agentic-coding/plugins/`. Rather than a relative escape in a template, `BaseBackend` gained a declared anchor selector resolved through one funnel:

```python
OutputAnchor = Literal["plugins", "repository"]

class BaseBackend:
    OUTPUT_ANCHOR: ClassVar[OutputAnchor] = "plugins"

def resolve_output_dir(backend_cls, anchors: OutputAnchors) -> Path:
    output_dir = validated_output_dir(backend_cls.NAME, backend_cls.OUTPUT_DIR)
    return anchors.root_for(backend_cls.OUTPUT_ANCHOR) / output_dir
```

All six sites that compute an output directory now go through it. The repository root is found by walking up for a `.git` entry and raising if none is found, rather than a fixed hop count: `ash-agent-plugins/` is designed to be extractable as its own repository, where the transpiler sits two levels below the root instead of three. It tests `exists()` rather than `is_dir()`, because `.git` is a file in a linked worktree.

### Two guards, both proven able to fail

`run_section_emitters` begins with `reset(out)`, which is `shutil.rmtree`. A backend resolving to the repository root would delete the repository. Two safeguards:

- `validated_output_dir` rejects an `OUTPUT_DIR` that is empty, `.`, `..`, absolute, or a UNC root, consulting both `PurePosixPath` and `PureWindowsPath` — `PurePosixPath` does not treat `C:\x` as absolute and does not split on backslash. It runs at registration, so a misdeclaration fails at import rather than mid-build.
- `check_drift` builds into a temporary directory. Its two anchors are independent explicit fields with a sandbox constructor, not derived from one another; deriving the repository anchor from the sandboxed plugins root would resolve two levels above the temporary directory and then rmtree there.

Both were verified by mutation rather than by observing a pass. Sandboxing only the plugins anchor produces:

```
AssertionError: check_drift overwrote the tree it was asked to compare;
its sandboxed build escaped into the repository anchor
```

Weakening the escape guard fails 9 tests. Transpiler tests go from 3 to 26.

## The CI gate, and why one was needed

`ash-agent-plugins/README.md` claimed a pre-commit hook and CI verified that committed plugin files match transpiler output. That holds only when `ash-agent-plugins/` is its own repository. In this repository it was inert: GitHub reads workflows only from the repository root, so `ash-agent-plugins/.github/workflows/validate.yml` never ran, and the root `.pre-commit-config.yaml` has no transpiler hook. All 16 generated trees were unguarded against hand-edits.

`.github/workflows/ash-agent-plugins-drift.yml` runs `agentic-plugins check` plus the transpiler test suite. Its path filters cover the transpiler tree, `_base/`, the generated `skills/` tree, and the workflow file itself — the nested workflow has no filters, so these were written from scratch. Proven to fail: hand-editing the generated `SKILL.md` exits 1 naming `[skills-root] ~ ash-mcp/SKILL.md`; reverting exits 0.

## A prerequisite fix

`agentic-plugins check` was **already failing on `main`**. `ash-agent-plugins/.gitignore` matched `.vscode/`, which made the Copilot backend's generated `.vscode/mcp.json` untrackable, so a clean checkout reported a missing declared path and Copilot drift that no rebuild could clear. Nobody had seen it because the only workflow running that check does not execute here.

This is more than a red gate. On `main` the Copilot tree contains no `.vscode/` at all, so that README's instruction to copy `.github/` and `.vscode/` into your repository was unfollowable — the directory was not in the repository. The Copilot MCP wiring ships for the first time here.

## Documentation

Root `README.md` had no mention that the plugin distribution exists. It now covers the skill, the per-platform plugins, and the MCP server directly, as alternatives rather than steps, with the prerequisite stated and a pointer to the existing MCP section. The 17-row platform table is **not** duplicated; the root README links to it, because a second hand-maintained copy is the drift this repository keeps paying for.

Corrections made while there, all pre-existing:

- The false CI claim, in the three places it appeared.
- Three documented `transpile --check` / `--validate-only` / `--drift-only` invocations. All three fail with `ImportError`: `pyproject.toml` declares `transpile = "transpiler.cli:transpile_compat"`, and that symbol does not exist. Replaced with `agentic-plugins check`, flags verified against `--help`.
- The platform count, now measured from the registry: 15 platform plugins plus 2 agentskills-format releases, 17 outputs total.
- Three table-of-contents entries: one for a heading that does not exist, two headings that were missing.

Two commands were deliberately described rather than scripted. `cp -r .../.cursor ./` nests a second `.cursor` inside an existing one, so it ships a footgun; and `codex plugin marketplace add` registers a marketplace rather than installing a plugin, which the plugins README overstates.

## Known limitation

`npx skills add awslabs/automated-security-helper` starts working when this merges. The CLI resolves that shorthand against the repository's default branch, so before merge the documented command reports "No skills found". The local-path form is verified working today. The documentation describes the merged state.

## Follow-ups, not in scope here

- The Architecture section of `ash-agent-plugins/README.md` documents `transpile.py`, `schema.py`, and `configs.yaml`. None of the three exists; the configuration moved into `BaseBackend` class variables. Fixing it means rewriting the directory tree plus prose in two sections that still treat `configs.yaml` as live.
- The broken `transpile` console script entry point.
- `agentic-plugins smoke-test` reports a `codex` version mismatch against the pinned value in `_base/cli_versions.json` on hosts with a newer `codex`. CI installs the pinned version, so the gate here is unaffected.
