### PR TITLE
fix(scanners): report SKIPPED when a scanner evaluated nothing

### DIFF
--- a/automated_security_helper/core/phases/scanner_executor.py
+++ b/automated_security_helper/core/phases/scanner_executor.py
@@ -36,12 +36,38 @@ def _target_count_attr(obj: Any, name: str) -> int | None:
 
     Coercing at this boundary keeps the trust boundary where the untrusted value enters,
     rather than teaching every consumer to be defensive about a field typed ``int``.
+
+    A negative is the one unusable value that gets a warning, because it is the only one that is
+    evidence of a defect rather than of a scanner that simply does not count targets. An absent
+    attribute, a MagicMock, a string or a float all mean "no counter here", which is the normal
+    state for nine of the builtin scanners; warning about those would fire on every clean run.
+
+    The warning matters because the silence used to be total, and the silence is what made two
+    individually-correct halves compose into a wrong answer. ``determine_status`` sends a negative
+    ``targets_attempted`` to ERROR, so the model looks defended -- but the negative never reaches
+    it, because this function turns it into None first. The scanner then reads as making no claim,
+    falls past both per-target guards into the severity gate, and reports PASSED off a broken
+    counter with nothing anywhere to say so.
+
+    The value is still dropped rather than passed through. Letting it reach the model would report
+    ERROR, which asserts "it tried and everything broke" -- a claim nobody has evidence for. All
+    that is known is that the plugin's accounting is wrong; its findings come from SARIF rather
+    than from the counter and remain usable, so failing the scan over an accounting bug would be
+    a worse answer than naming it. Raising is rejected for the same reason.
     """
     value = getattr(obj, name, None)
     # bool is an int subclass; excluded because a True/False counter is a caller bug and
     # silently reading it as 1/0 would hide that.
-    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-        return value
+    if isinstance(value, int) and not isinstance(value, bool):
+        if value >= 0:
+            return value
+        ASH_LOGGER.warning(
+            f"Scanner plugin {type(obj).__name__} reported {name}={value}. A target count "
+            "cannot be negative, so it is being ignored and the scanner treated as making no "
+            "claim about targets. Its status will come from findings alone, which means a scan "
+            "that evaluated nothing cannot be reported as SKIPPED. This is a defect in the "
+            "scanner plugin's own accounting."
+        )
     return None
 
 
@@ -51,7 +77,8 @@ def _non_negative_int_attr(obj: Any, name: str) -> int:
     ``targets_failed`` is such a counter: it is only ever read against ``targets_attempted``,
     so "no claim" and "zero failures" lead to the same decision and there is nothing to gain
     from keeping them apart. One coercion rule serves both callers, so the two cannot drift
-    apart on what counts as a usable value.
+    apart on what counts as a usable value -- including on warning about a negative, which is
+    just as much an accounting defect in a failure count as in an attempt count.
     """
     return _target_count_attr(obj, name) or 0
 

--- a/automated_security_helper/core/phases/scanner_executor.py
+++ b/automated_security_helper/core/phases/scanner_executor.py
@@ -19,24 +19,41 @@ from automated_security_helper.utils.sarif_utils import (
 _ResultsFn = Callable[[ScanResultsContainer, AshAggregatedResults], AshAggregatedResults]
 
 
-def _non_negative_int_attr(obj: Any, name: str) -> int:
-    """Read an integer counter off a scanner plugin, defaulting to 0 for anything else.
+def _target_count_attr(obj: Any, name: str) -> int | None:
+    """Read a target counter off a scanner plugin, or None when it makes no usable claim.
 
-    A plain ``getattr(obj, name, 0)`` is not safe here. Scanner plugins are arbitrary objects,
-    and a ``MagicMock`` auto-creates any attribute asked of it -- so the default never applies
-    and a mock lands in an int field, which is not validated on assignment. The first
-    ``> 0`` comparison downstream then raises
-    ``TypeError: '>' not supported between instances of 'MagicMock' and 'int'``.
+    None is the answer for an absent attribute and for a present-but-unusable one alike, and
+    that conflation is deliberate: both mean "this scanner has told us nothing about targets",
+    which is the state ``ScanResultsContainer.targets_attempted`` uses None for. Returning 0
+    instead would assert "it tracked targets and attempted none", which for a non-tracking
+    scanner is a false statement that resolves to SKIPPED.
+
+    A plain ``getattr(obj, name, None)`` is not safe here. Scanner plugins are arbitrary
+    objects, and a ``MagicMock`` auto-creates any attribute asked of it -- so the default never
+    applies and a mock lands in an int field, which is not validated on assignment. The first
+    comparison downstream then raises
+    ``TypeError: '>=' not supported between instances of 'MagicMock' and 'int'``.
 
     Coercing at this boundary keeps the trust boundary where the untrusted value enters,
     rather than teaching every consumer to be defensive about a field typed ``int``.
     """
-    value = getattr(obj, name, 0)
+    value = getattr(obj, name, None)
     # bool is an int subclass; excluded because a True/False counter is a caller bug and
     # silently reading it as 1/0 would hide that.
     if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
         return value
-    return 0
+    return None
+
+
+def _non_negative_int_attr(obj: Any, name: str) -> int:
+    """``_target_count_attr`` for a counter whose absence is indistinguishable from zero.
+
+    ``targets_failed`` is such a counter: it is only ever read against ``targets_attempted``,
+    so "no claim" and "zero failures" lead to the same decision and there is nothing to gain
+    from keeping them apart. One coercion rule serves both callers, so the two cannot drift
+    apart on what counts as a usable value.
+    """
+    return _target_count_attr(obj, name) or 0
 
 
 class ScannerExecutor:
@@ -248,12 +265,18 @@ class ScannerExecutor:
 
                     # Carry per-target outcome counts across, following the exit_code pattern
                     # above. This is what lets determine_status distinguish "scanned and found
-                    # nothing" from "failed on everything it tried" -- without it, status can
-                    # only be derived from findings and a total failure reports PASSED.
+                    # nothing" from "failed on everything it tried" and from "evaluated
+                    # nothing" -- without it, status can only be derived from findings and both
+                    # of the latter two report PASSED.
                     #
-                    # Scanners that do not track per-target outcomes report 0/0 and are
-                    # unaffected, so this is additive for every existing scanner.
-                    container.targets_attempted = _non_negative_int_attr(
+                    # This is the line where the tri-state has to be preserved rather than
+                    # flattened. A scanner that does not track targets has no
+                    # ``targets_attempted`` attribute at all, and _target_count_attr answers
+                    # None for it, which determine_status reads as "no claim" and leaves alone.
+                    # Reading an absent attribute as 0 here would assert that every
+                    # non-tracking scanner attempted zero targets, and every one of them would
+                    # report SKIPPED instead of PASSED.
+                    container.targets_attempted = _target_count_attr(
                         scanner_plugin, "targets_attempted"
                     )
                     container.targets_failed = _non_negative_int_attr(

--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -96,6 +96,10 @@ class ScannerStatisticsCalculator:
             - threshold_source: Source of the threshold ("global", "config", etc.)
             - excluded: Whether the scanner was explicitly excluded
             - dependencies_missing: Whether the scanner has missing dependencies
+            - error: Whether the scanner failed to run or produced no usable results
+            - evaluated_nothing: Whether a target-tracking scanner attempted zero targets.
+              Distinct from ``excluded``: the operator wanted this scanner, it ran, and there
+              was nothing for it to look at.
         """
         scanner_stats = {}
 
@@ -160,6 +164,10 @@ class ScannerStatisticsCalculator:
                 ScannerStatisticsCalculator.get_scanner_status_info(
                     asharp_model, scanner_name
                 )
+            )
+
+            evaluated_nothing = ScannerStatisticsCalculator.scanner_evaluated_nothing(
+                asharp_model, scanner_name
             )
 
             total = critical + high + medium + low + info
@@ -245,6 +253,7 @@ class ScannerStatisticsCalculator:
                 "excluded": excluded,
                 "dependencies_missing": dependencies_missing,
                 "error": error,
+                "evaluated_nothing": evaluated_nothing,
             }
 
         return scanner_stats
@@ -533,6 +542,99 @@ class ScannerStatisticsCalculator:
         return evaluation_threshold, scanner_threshold_def
 
     @staticmethod
+    def _status_info_from_report(report: Dict[str, Any]) -> Tuple[bool, bool, bool]:
+        """Read (excluded, dependencies_missing, error) off one serialized container.
+
+        ``excluded`` comes from the container's own ``excluded`` field and is never inferred
+        from the status string. Those two used to be the same thing, and the inference was sound
+        while it lasted: before per-target outcome tracking, ``determine_status`` had exactly
+        three return sites -- ERROR, FAILED, PASSED -- so the only way a container could carry
+        SKIPPED was ``for_excluded()``, where ``excluded`` genuinely held. A scanner that runs
+        and evaluates nothing now also reports SKIPPED, and re-deriving ``excluded`` from that
+        asserts the operator switched the scanner off, which is a different and false claim.
+
+        The cost of the false claim is not cosmetic. ``excluded`` and the SKIPPED it produces
+        both set ``ScannerMetrics.passed``, and a scanner runs against two targets, so a cdk-nag
+        that evaluated no source templates and found two CRITICAL issues in the converted tree
+        rendered as skipped-and-passed. No red row in the summary table, while the exit code
+        still failed the build off the very findings the row was hiding.
+
+        ``exclude_unset=True`` in the dump is what makes the field trustworthy in the other
+        direction: ``for_excluded()`` is the only caller that ever assigns ``excluded``, so the
+        key is absent from every report written by a scanner that actually ran, and ``.get``
+        falls back to the model default of False.
+
+        Shared by both report-shaped branches of ``get_scanner_status_info`` rather than
+        duplicated into each. The two blocks were identical, which is how one of them could
+        have been fixed and the other left behind.
+        """
+        excluded = bool(report.get("excluded", False))
+        dependencies_missing = False
+        error = False
+
+        match report.get("status"):
+            case "MISSING":
+                dependencies_missing = True
+            case "ERROR":
+                error = True
+            case "SKIPPED" | "FAILED" | "PASSED":
+                # All three are verdicts the scanner reached about its own run, and none of
+                # them says anything about configuration. SKIPPED is in this list rather than
+                # setting ``excluded`` because it reports a fact about the input -- there was
+                # nothing to evaluate -- and that fact travels in ``evaluated_nothing``.
+                pass
+            case _:
+                # An unrecognized status is not a verdict this code can reason about. Treated as
+                # excluded for backward compatibility, which keeps it out of the failure counts
+                # rather than inventing a severity for it.
+                excluded = True
+
+        return excluded, dependencies_missing, error
+
+    @staticmethod
+    def scanner_evaluated_nothing(
+        asharp_model: AshAggregatedResults, scanner_name: str
+    ) -> bool:
+        """True when a target-tracking scanner reported that it attempted zero targets.
+
+        The honest channel for "nothing was evaluated", replacing the old route where that fact
+        arrived disguised as ``excluded``. It lives in
+        ``ScanResultsContainer.targets_attempted``, which is tri-state: absent from a serialized
+        report means the scanner does not track per-target outcomes and is making no claim
+        (``exclude_none=True`` drops the None), while a present 0 means it tracked and attempted
+        none. Absent must never read as zero -- bandit, checkov, semgrep, grype, syft,
+        detect-secrets, opengrep, cfn-nag and npm-audit are all in the no-claim state, and
+        reading them as tracked-zero would turn every row of a clean report yellow.
+
+        Read across every target the scanner reported under, because ``ScanPhase`` gives each
+        scanner a task carrying both the source and the converted tree and only one of them may
+        have been empty. So: at least one target must have made a claim, and every claim must be
+        zero. Consulting a single target instead would report a half-empty scan as skipped and
+        discard whatever the other half found.
+
+        Mirrors the ``targets_attempted <= 0`` guard in ``determine_status`` rather than testing
+        ``== 0``, so the status a container computes for itself and the status rendered in the
+        summary table cannot disagree about the same counter. A negative count does not reach
+        this branch anyway: ``determine_status`` sends it to ERROR, and ``error`` is checked
+        first.
+        """
+        reports = asharp_model.additional_reports.get(scanner_name)
+        if not isinstance(reports, dict):
+            return False
+
+        claims = []
+        for target_report in reports.values():
+            if not isinstance(target_report, dict):
+                continue
+            attempted = target_report.get("targets_attempted")
+            # bool is an int subclass, and a True/False counter is a caller bug rather than a
+            # claim about targets, so it is not read as 1/0 here.
+            if isinstance(attempted, int) and not isinstance(attempted, bool):
+                claims.append(attempted)
+
+        return bool(claims) and all(attempted <= 0 for attempted in claims)
+
+    @staticmethod
     def get_scanner_status_info(
         asharp_model: AshAggregatedResults, scanner_name: str
     ) -> Tuple[bool, bool, bool]:
@@ -551,10 +653,15 @@ class ScannerStatisticsCalculator:
             scanner_name: Name of the scanner to get status information for
 
         Returns:
-            Tuple of (excluded, dependencies_missing), where:
+            Tuple of (excluded, dependencies_missing, error), where:
             - excluded: True if the scanner was explicitly excluded from the scan
             - dependencies_missing: True if the scanner has missing dependencies
             - error: True if the scanner failed to run or generate results
+
+        None of the three covers "the scanner ran and evaluated nothing". That is a fourth and
+        genuinely different fact, and it is answered by ``scanner_evaluated_nothing`` rather than
+        folded into ``excluded`` here -- see ``_status_info_from_report`` for what folding it in
+        used to cost.
         """
         excluded = False
         dependencies_missing = False
@@ -565,22 +672,11 @@ class ScannerStatisticsCalculator:
             and asharp_model.additional_reports[scanner_name]["None"]["scanner_name"]
             == scanner_name
         ):
-            status = asharp_model.additional_reports[scanner_name]["None"]["status"]
-            match status:
-                case "SKIPPED":
-                    excluded = True
-                case "MISSING":
-                    dependencies_missing = True
-                case "ERROR":
-                    error = True
-                case "FAILED" | "PASSED":
-                    # FAILED means scanner ran successfully and found actionable findings
-                    # PASSED means scanner ran successfully with no actionable findings
-                    # Both are valid completion statuses
-                    pass
-                case _:
-                    # For any other unknown status, treat as excluded for backward compatibility
-                    excluded = True
+            excluded, dependencies_missing, error = (
+                ScannerStatisticsCalculator._status_info_from_report(
+                    asharp_model.additional_reports[scanner_name]["None"]
+                )
+            )
         elif scanner_name in asharp_model.scanner_results:
             scanner_status_info = asharp_model.scanner_results[scanner_name]
 
@@ -599,23 +695,11 @@ class ScannerStatisticsCalculator:
             and asharp_model.additional_reports[scanner_name]["source"]["scanner_name"]
             and asharp_model.additional_reports[scanner_name]["source"]["status"]
         ):
-            # If the scanner is not found in the dictionary, check for errors
-            status = asharp_model.additional_reports[scanner_name]["source"]["status"]
-            match status:
-                case "SKIPPED":
-                    excluded = True
-                case "MISSING":
-                    dependencies_missing = True
-                case "ERROR":
-                    error = True
-                case "FAILED" | "PASSED":
-                    # FAILED means scanner ran successfully and found actionable findings
-                    # PASSED means scanner ran successfully with no actionable findings
-                    # Both are valid completion statuses
-                    pass
-                case _:
-                    # For any other unknown status, treat as excluded for backward compatibility
-                    excluded = True
+            excluded, dependencies_missing, error = (
+                ScannerStatisticsCalculator._status_info_from_report(
+                    asharp_model.additional_reports[scanner_name]["source"]
+                )
+            )
         else:
             # If the scanner is not found in the dictionary, check for errors
             error = True
@@ -631,14 +715,15 @@ class ScannerStatisticsCalculator:
         This method calculates the status of a scanner based on its findings, configuration,
         and execution status. The possible statuses are:
 
-        - "SKIPPED": The scanner was explicitly excluded from the scan
-        - "MISSING": The scanner has missing dependencies
+        - "ERROR": The scanner produced no usable results
         - "FAILED": The scanner found actionable findings (at or above the threshold)
-        - "PASSED": The scanner did not find any actionable findings
+        - "SKIPPED": The scanner was explicitly excluded, or it ran and evaluated no targets
+        - "MISSING": The scanner has missing dependencies
+        - "PASSED": The scanner evaluated targets and found nothing actionable
 
-        The method first checks if the scanner was excluded or has missing dependencies.
-        If neither of these conditions is true, it calculates the number of actionable
-        findings based on the scanner's threshold and determines the status accordingly.
+        Listed in the order the branches are checked. Findings are counted before the
+        did-not-run branches, so a scanner carrying actionable findings can never come back as a
+        status that reads as passing.
 
         Args:
             asharp_model: The AshAggregatedResults model containing scanner results
@@ -656,13 +741,11 @@ class ScannerStatisticsCalculator:
         if error:
             return "ERROR"
 
-        if excluded:
-            return "SKIPPED"
-
-        if dependencies_missing:
-            return "MISSING"
-
-        # Get actionable findings count
+        # Counted before the excluded and dependencies_missing branches, matching the precedence
+        # in ``unified_metrics.get_unified_scanner_metrics``. Two functions that answer "what is
+        # this scanner's status" must not disagree: whichever one a caller happens to reach, a
+        # scanner carrying findings has to come back FAILED rather than as a status that reads
+        # as passing.
         suppressed, critical, high, medium, low, info = (
             ScannerStatisticsCalculator.extract_sarif_counts_for_scanner(
                 asharp_model, scanner_name
@@ -677,7 +760,21 @@ class ScannerStatisticsCalculator:
             critical, high, medium, low, info, threshold
         )
 
-        return "FAILED" if actionable > 0 else "PASSED"
+        if actionable > 0:
+            return "FAILED"
+
+        if excluded:
+            return "SKIPPED"
+
+        if dependencies_missing:
+            return "MISSING"
+
+        if ScannerStatisticsCalculator.scanner_evaluated_nothing(
+            asharp_model, scanner_name
+        ):
+            return "SKIPPED"
+
+        return "PASSED"
 
     @staticmethod
     def get_summary_statistics(asharp_model: AshAggregatedResults) -> Dict[str, Any]:

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -172,15 +172,34 @@ def get_unified_scanner_metrics(
 
     # Convert the statistics to ScannerMetrics objects
     for scanner_name, stats in scanner_stats.items():
-        # Determine status
-        if stats["excluded"]:
-            status = "SKIPPED"
-        elif stats["dependencies_missing"]:
-            status = "MISSING"
-        elif stats["error"]:
+        # Determine status. The order of these branches is observable, not cosmetic:
+        #
+        #   error                -- no usable results came back at all, which is the loudest
+        #                           thing that can be said about a scanner.
+        #   actionable > 0       -- it produced findings. Checked ahead of the three
+        #                           "did not run" branches below, and this is the ordering that
+        #                           matters. Those three all resolve to a status for which
+        #                           ``passed`` is True, so a row reaching one of them while
+        #                           carrying findings renders green-or-yellow with no red row in
+        #                           the summary table -- while ``run_ash_scan`` sums the same
+        #                           ``actionable`` counts and fails the build. A report that
+        #                           contradicts the exit code is worse than either verdict.
+        #   excluded             -- the operator switched this scanner off.
+        #   dependencies_missing -- it could not run in this environment.
+        #   evaluated_nothing    -- it ran and had no input to evaluate. Separate from
+        #                           ``excluded`` on purpose: conflating the two is what made
+        #                           this reorder necessary in the first place.
+        #   otherwise            -- nothing above applies and there are no actionable findings.
+        if stats["error"]:
             status = "ERROR"
         elif stats["actionable"] > 0:
             status = "FAILED"
+        elif stats["excluded"]:
+            status = "SKIPPED"
+        elif stats["dependencies_missing"]:
+            status = "MISSING"
+        elif stats["evaluated_nothing"]:
+            status = "SKIPPED"
         else:
             scan_result: ScannerTargetStatusInfo | None = (
                 asharp_model.scanner_results.get(scanner_name, None)

--- a/automated_security_helper/models/scan_results_container.py
+++ b/automated_security_helper/models/scan_results_container.py
@@ -66,9 +66,28 @@ class ScanResultsContainer(BaseModel):
     # reports PASSED with zero findings, which reads exactly like a clean project. These two
     # counters are what let ``determine_status`` tell those apart.
     #
-    # Scanners that do not track per-target outcomes leave both at 0, which preserves their
-    # existing behavior: the guard only triggers once a scanner has said it attempted work.
-    targets_attempted: int = 0
+    # ``targets_attempted`` is deliberately tri-state, because two counters cannot carry three
+    # distinct facts:
+    #
+    #   None -- the scanner makes no claim about targets. It does not track per-target
+    #           outcomes, so nothing can be concluded from the count and status falls through
+    #           to the severity gate exactly as it always has. bandit, checkov, semgrep, grype,
+    #           syft, detect-secrets, opengrep, cfn-nag and npm-audit are all in this state, so
+    #           this is the case that must stay untouched.
+    #   0    -- the scanner tracks targets and attempted none. It ran, evaluated nothing, and
+    #           has no findings because it had no input -- not because the input was clean.
+    #   > 0  -- the scanner tracks targets and attempted some. ``targets_failed`` is then
+    #           meaningful relative to it.
+    #
+    # A plain ``int`` default of 0 would collapse the first two, which is the whole hazard
+    # here: treating "no claim" as "attempted zero" would flip every non-tracking scanner from
+    # PASSED to SKIPPED and turn an entire clean report yellow. That is a worse defect than the
+    # one this distinction exists to fix.
+    #
+    # ``targets_failed`` stays a plain int because it has no independent meaning: it is only
+    # ever read against ``targets_attempted``, and a failure count with no attempt count is a
+    # caller bug rather than a third state.
+    targets_attempted: int | None = None
     targets_failed: int = 0
 
     def add_metadata(self, key: str, value: Any) -> None:
@@ -90,8 +109,14 @@ class ScanResultsContainer(BaseModel):
             self.errors.append(error)
 
     def record_target_attempt(self, count: int = 1) -> None:
-        """Record that the scanner is about to process ``count`` more targets."""
-        self.targets_attempted += count
+        """Record that the scanner is about to process ``count`` more targets.
+
+        Calling this at all is the claim. A scanner that never calls it leaves
+        ``targets_attempted`` at None and is read as making no claim; the first call moves it
+        off None even when ``count`` is 0, which is how a scanner says "I looked, there was
+        nothing to look at" rather than staying silent.
+        """
+        self.targets_attempted = (self.targets_attempted or 0) + count
 
     def record_target_failure(self, target: Any, error: str) -> None:
         """Record that one target could not be scanned.
@@ -111,8 +136,20 @@ class ScanResultsContainer(BaseModel):
         Feeds SARIF ``executionSuccessful``. A report claiming success while carrying no
         results is worse than an absent report, because a consumer cannot tell the difference
         between a clean scan and one that never ran.
+
+        Stays True for a tracked-but-zero scan, and that is intentional. SARIF defines the
+        field as "specifies whether the tool's execution completed successfully" -- it is about
+        the run, not about the yield. A scanner that started, found no applicable input and
+        exited cleanly did complete successfully; reporting False would tell every consumer
+        that gates on ``executionSuccessful`` that the run broke, which would start failing
+        builds on repositories that simply contain no CloudFormation. "Nothing was evaluated"
+        is a different fact, and it belongs in ``status`` (SKIPPED), which is the field the
+        summary table renders and a human reads.
+
+        The falsy test covers both None (no claim) and 0 (tracked, attempted none). Comparing
+        with ``<= 0`` would raise TypeError on None.
         """
-        if self.targets_attempted <= 0:
+        if not self.targets_attempted:
             return True
         return self.targets_failed < self.targets_attempted
 
@@ -174,11 +211,12 @@ class ScanResultsContainer(BaseModel):
     # ---- Threshold evaluation ------------------------------------------
 
     def determine_status(self, threshold: str | None) -> ScannerStatus:
-        """Determine PASSED/FAILED status by comparing severity_counts to threshold.
+        """Determine status from per-target outcomes first, then severity_counts vs threshold.
 
-        Any finding at or above the configured severity threshold fails the
-        scanner. Does not mutate the container's current status — the caller
-        assigns the result.
+        Returns ERROR when a tracking scanner failed every target, SKIPPED when a tracking
+        scanner attempted none, and otherwise PASSED/FAILED from the severity gate: any finding
+        at or above the configured severity threshold fails the scanner. Does not mutate the
+        container's current status — the caller assigns the result.
 
         The gate itself lives in ``utils.severity_ladder``, shared with the
         junitxml reporter so the two cannot disagree about the same finding.
@@ -191,18 +229,48 @@ class ScanResultsContainer(BaseModel):
             severity_fails_threshold,
         )
 
-        # Checked BEFORE the severity gate, and this ordering is the whole point.
+        # Both per-target guards are checked BEFORE the severity gate, and that ordering is the
+        # whole point.
         #
         # Everything below reasons about finding counts, where zero means "nothing to
-        # report". For a scanner that failed on every target, zero means "nothing was
-        # examined" -- the same number carrying the opposite meaning. Deciding on findings
-        # first would return PASSED and discard that distinction permanently.
+        # report". For a scanner that failed on every target, or one that attempted none, zero
+        # means "nothing was examined" -- the same number carrying the opposite meaning.
+        # Deciding on findings first would return PASSED and discard that distinction
+        # permanently.
         #
         # ERROR rather than FAILED: FAILED means the scanner worked and found problems, which
         # a consumer may legitimately gate or waive on. This did not work, and there is
         # nothing to waive.
-        if self.targets_attempted > 0 and self.targets_failed >= self.targets_attempted:
+        # ``self.targets_attempted and ...`` rather than ``> 0 and ...``: the field is now
+        # tri-state, and comparing None with an int raises TypeError. Truthiness rejects both
+        # None and 0, which are exactly the two values that must not reach this comparison.
+        if self.targets_attempted and self.targets_failed >= self.targets_attempted:
             return ScannerStatus.ERROR
+
+        # Tracked, and attempted nothing. PASSED has to mean "evaluated and clean"; it must
+        # never mean "evaluated nothing", because those render identically -- green, no
+        # findings -- and an operator reads the first one off a report that shows the second.
+        #
+        # Ordered after the ERROR guard on purpose, and the order is observable rather than
+        # cosmetic. The two conditions overlap on a negative count: the guard above tests
+        # truthiness, so -1 is truthy and ``0 >= -1`` holds, and a miscounted scanner reports
+        # ERROR instead of reaching this line. That is the intended precedence -- ERROR is the
+        # louder and more actionable of the two, because "it tried and everything broke" tells
+        # an operator more than "it evaluated nothing", and a negative counter means something
+        # is genuinely wrong with the scanner rather than with its input.
+        #
+        # The overlap is also why this guard keeps ``<= 0`` instead of ``== 0``: the two are
+        # then defense in depth. Narrowing the ERROR guard to an explicit ``> 0`` later would
+        # send negatives here rather than into the severity gate, where they would report
+        # PASSED off a broken counter.
+        #
+        # ``is not None`` is the load-bearing half of this condition. Dropping it would fire on
+        # every scanner that does not track targets -- bandit, checkov, semgrep, grype, syft,
+        # detect-secrets, opengrep, cfn-nag, npm-audit -- and turn an entire clean report
+        # yellow.
+        #
+        if self.targets_attempted is not None and self.targets_attempted <= 0:
+            return ScannerStatus.SKIPPED
 
         counts = self.severity_counts
         counts_by_severity = (

--- a/automated_security_helper/models/scan_results_container.py
+++ b/automated_security_helper/models/scan_results_container.py
@@ -260,10 +260,20 @@ class ScanResultsContainer(BaseModel):
         # an operator more than "it evaluated nothing", and a negative counter means something
         # is genuinely wrong with the scanner rather than with its input.
         #
-        # The overlap is also why this guard keeps ``<= 0`` instead of ``== 0``: the two are
-        # then defense in depth. Narrowing the ERROR guard to an explicit ``> 0`` later would
-        # send negatives here rather than into the severity gate, where they would report
-        # PASSED off a broken counter.
+        # The overlap is also why this guard keeps ``<= 0`` instead of ``== 0``: narrowing the
+        # ERROR guard to an explicit ``> 0`` later would send negatives here, rather than past
+        # both guards and into the severity gate.
+        #
+        # That is worth less than an earlier version of this comment claimed. It said the ``<= 0``
+        # prevents "PASSED off a broken counter", and PASSED off a broken counter is in fact the
+        # outcome today, by the only route negatives actually travel. Counters reach this model
+        # through ``_target_count_attr`` in the executor, which rejects anything below zero and
+        # hands over None -- so a plugin exposing ``targets_attempted = -1`` arrives here as a
+        # no-claim scanner, reaches the severity gate, and reports PASSED no matter what these two
+        # guards say. That boundary now logs a warning naming the plugin and the value, which is
+        # where a broken counter is actually made visible; these guards are not what does it.
+        # A negative only gets in front of this line from a caller constructing the container
+        # directly, which today means tests and any future in-process producer.
         #
         # ``is not None`` is the load-bearing half of this condition. Dropping it would fire on
         # every scanner that does not track targets -- bandit, checkov, semgrep, grype, syft,

--- a/automated_security_helper/models/scan_results_container.py
+++ b/automated_security_helper/models/scan_results_container.py
@@ -241,6 +241,7 @@ class ScanResultsContainer(BaseModel):
         # ERROR rather than FAILED: FAILED means the scanner worked and found problems, which
         # a consumer may legitimately gate or waive on. This did not work, and there is
         # nothing to waive.
+        #
         # ``self.targets_attempted and ...`` rather than ``> 0 and ...``: the field is now
         # tri-state, and comparing None with an int raises TypeError. Truthiness rejects both
         # None and 0, which are exactly the two values that must not reach this comparison.
@@ -268,7 +269,6 @@ class ScanResultsContainer(BaseModel):
         # every scanner that does not track targets -- bandit, checkov, semgrep, grype, syft,
         # detect-secrets, opengrep, cfn-nag, npm-audit -- and turn an entire clean report
         # yellow.
-        #
         if self.targets_attempted is not None and self.targets_attempted <= 0:
             return ScannerStatus.SKIPPED
 

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -256,6 +256,15 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
             ):
                 scannable.append(pf.as_posix())
 
+        # Initialized here rather than just before the loop, because the empty-scan-set return
+        # below happens first. Leaving the attributes unset on that path made this scanner
+        # indistinguishable from one that does not track targets at all: the executor found no
+        # attribute, recorded no claim, and the zero-finding report resolved to PASSED -- green,
+        # with nothing examined. Setting them to 0 before any early exit is what turns that into
+        # SKIPPED.
+        self.targets_attempted = 0
+        self.targets_failed = 0
+
         if len(scannable) == 0:
             self._plugin_log(
                 f"No JSON/YAML files found in {target_type} directory to scan. Exiting.",
@@ -276,12 +285,10 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
 
         # Process each template file.
         #
-        # These counters replace a local `failed_files` list that was appended to on both
-        # failure paths and never read, so a run that failed on every template still produced
-        # an empty-but-successful report. They are attributes rather than locals precisely so
-        # the executor can read them and status computation can see them.
-        self.targets_attempted = 0
-        self.targets_failed = 0
+        # The counters set above replace a local `failed_files` list that was appended to on
+        # both failure paths and never read, so a run that failed on every template still
+        # produced an empty-but-successful report. They are attributes rather than locals
+        # precisely so the executor can read them and status computation can see them.
         target_rel_path = get_shortest_name(input=target)
 
         outdir = self.results_dir.joinpath(target_type)
@@ -311,6 +318,13 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
                     # Not counted as a failure: a non-CloudFormation file in the scan set is
                     # an expected skip, not a scanner malfunction. Counting it would make a
                     # repository of plain JSON report ERROR.
+                    #
+                    # Decrementing back to a running total of zero is not a silent success
+                    # either. When every file in the scan set lands here the count ends at 0,
+                    # which the container reads as "tracked, attempted none" and reports
+                    # SKIPPED. The wrapper also returns None when no nag pack is enabled and
+                    # when NodeJS is unavailable, so those two reach the same place: nothing was
+                    # evaluated, and the report says so instead of rendering green.
                     self.targets_attempted -= 1
                     ASH_LOGGER.debug(f"Not a CloudFormation file: {cfn_file}")
                     continue
@@ -347,6 +361,12 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
         # Every template failed. Say so loudly here as well as through the returned status:
         # this is the one line that distinguishes "your templates are compliant" from "cdk-nag
         # never evaluated a rule", and the two produce identical reports otherwise.
+        #
+        # The zero case is success here, and it feeds SARIF executionSuccessful below. That
+        # field is about whether the tool's run completed, not about whether it had anything to
+        # look at, so a scan with an empty template set is a successful run that produced no
+        # results. The "nothing was evaluated" signal is carried by the container's SKIPPED
+        # status instead, which is what the summary table shows a human.
         scan_succeeded = (
             self.targets_attempted <= 0 or self.targets_failed < self.targets_attempted
         )

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -182,6 +182,39 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
         """
         if global_ignore_paths is None:
             global_ignore_paths = []
+
+        # Per-call state, reset before anything else in the method can return.
+        #
+        # These are instance attributes on a plugin object that ScanPhase reuses:
+        # ``_scanner_tasks`` carries one task per scanner holding ``[source, converted]``, and
+        # ``ScannerExecutor._execute_scanner`` loops that list against the same instance, reading
+        # the counters off it after each call. So whatever a target leaves behind is what the
+        # next target starts with.
+        #
+        # Initializing them further down, next to the loop that increments them, reads naturally
+        # and was wrong in both directions. A target returning early inherited the previous
+        # target's totals -- an empty converted tree after a clean source pass reported PASSED
+        # over two attempts it never made, and after a failed source pass reported ERROR for a
+        # target where no file was ever opened. On the first call there was nothing to inherit,
+        # so the attributes stayed unset, which is how a scanner says "I do not track targets":
+        # the executor recorded no claim and the empty report resolved to PASSED, defeating the
+        # SKIPPED status outright.
+        #
+        # Top of the method rather than merely above the empty-target check, because there are
+        # three early returns above the old initialization point and the next one added would
+        # have inherited the same bug. Nothing between here and the first return can be
+        # meaningfully counted, so there is no ordering left to get wrong.
+        #
+        # The counters stay on the instance rather than moving to the per-call
+        # ``ScanResultsContainer``, which would remove this class of leak by construction. The
+        # container is built by the executor *around* the ``scan()`` call and is not passed in,
+        # and ``scan()``'s signature is the plugin contract every scanner -- including
+        # third-party ones -- implements. Threading the container through it is a breaking API
+        # change, and stashing it on ``self`` instead would be the same shared mutable state
+        # wearing a different name.
+        self.targets_attempted = 0
+        self.targets_failed = 0
+
         tool_component = ToolComponent(
             name="ash-cdk-nag-wrapper",
             fullName="awslabs/automated-security-helper",
@@ -256,15 +289,10 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
             ):
                 scannable.append(pf.as_posix())
 
-        # Initialized here rather than just before the loop, because the empty-scan-set return
-        # below happens first. Leaving the attributes unset on that path made this scanner
-        # indistinguishable from one that does not track targets at all: the executor found no
-        # attribute, recorded no claim, and the zero-finding report resolved to PASSED -- green,
-        # with nothing examined. Setting them to 0 before any early exit is what turns that into
-        # SKIPPED.
-        self.targets_attempted = 0
-        self.targets_failed = 0
-
+        # The counters are already at 0 here, set at the top of the method. Deliberately not
+        # re-initialized at this point: the empty-scan-set return just below is one of four
+        # places this method can leave, and an initialization sitting here covers only the ones
+        # underneath it.
         if len(scannable) == 0:
             self._plugin_log(
                 f"No JSON/YAML files found in {target_type} directory to scan. Exiting.",
@@ -285,10 +313,10 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
 
         # Process each template file.
         #
-        # The counters set above replace a local `failed_files` list that was appended to on
-        # both failure paths and never read, so a run that failed on every template still
-        # produced an empty-but-successful report. They are attributes rather than locals
-        # precisely so the executor can read them and status computation can see them.
+        # The counters set at the top of this method replace a local `failed_files` list that was
+        # appended to on both failure paths and never read, so a run that failed on every
+        # template still produced an empty-but-successful report. They are attributes rather than
+        # locals precisely so the executor can read them and status computation can see them.
         target_rel_path = get_shortest_name(input=target)
 
         outdir = self.results_dir.joinpath(target_type)

--- a/tests/unit/core/test_nothing_scanned_reaches_the_summary_table.py
+++ b/tests/unit/core/test_nothing_scanned_reaches_the_summary_table.py
@@ -1,0 +1,132 @@
+"""A SKIPPED container has to survive the trip to the summary table.
+
+The reviewer's ask was about what an operator sees: "display 'skipped' instead of green". A
+status set on ``ScanResultsContainer`` is several hops away from that. It is serialized into
+``additional_reports[scanner][target_type]``, read back by
+``ScannerStatisticsCalculator.get_scanner_status_info``, and only then turned into the string
+``get_unified_scanner_metrics`` hands the table. That chain recomputes status from findings on
+some routes, so a model-level assertion alone does not establish that anything changed on screen.
+
+These tests walk the real chain. They also carry the negative control -- a container that did
+scan cleanly must still arrive as PASSED -- because the failure mode being guarded against is a
+report where every row turned yellow.
+"""
+
+import pytest
+
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.core.unified_metrics import get_unified_scanner_metrics
+from automated_security_helper.models.asharp_model import AshAggregatedResults
+from automated_security_helper.models.scan_results_container import ScanResultsContainer
+
+
+def _model_with_container(container: ScanResultsContainer) -> AshAggregatedResults:
+    """Put a container into an AshAggregatedResults the way ScanResultProcessor does.
+
+    The dump keywords are copied from ``ScanResultProcessor.process_container`` verbatim,
+    ``exclude_none`` included. That flag is load-bearing: it is why a no-claim
+    ``targets_attempted`` never appears in a serialized report at all.
+    """
+    model = AshAggregatedResults()
+    model.additional_reports[container.scanner_name] = {
+        container.target_type: container.model_dump(
+            exclude_none=True,
+            exclude_unset=True,
+            by_alias=True,
+            mode="json",
+        )
+    }
+    return model
+
+
+def _status_in_table(container: ScanResultsContainer) -> str:
+    model = _model_with_container(container)
+    metrics = get_unified_scanner_metrics(model)
+    rows = [m for m in metrics if m.scanner_name == container.scanner_name]
+    assert rows, (
+        f"{container.scanner_name} produced no row in the summary table; "
+        f"got {[m.scanner_name for m in metrics]}"
+    )
+    return rows[0].status
+
+
+def _container(**kwargs) -> ScanResultsContainer:
+    kwargs.setdefault("scanner_name", "cdk-nag")
+    kwargs.setdefault("target_type", "source")
+    return ScanResultsContainer(**kwargs)
+
+
+def test_a_tracked_zero_scan_shows_as_skipped():
+    container = _container(targets_attempted=0, targets_failed=0)
+    container.status = container.determine_status("MEDIUM")
+    assert container.status == ScannerStatus.SKIPPED
+
+    assert _status_in_table(container) == "SKIPPED"
+
+
+def test_a_clean_scan_still_shows_as_passed():
+    # The negative control. If this ever reads SKIPPED, the change has turned every clean
+    # scanner yellow, which is the regression that matters more than the bug.
+    container = _container(targets_attempted=6, targets_failed=0)
+    container.status = container.determine_status("MEDIUM")
+    assert container.status == ScannerStatus.PASSED
+
+    assert _status_in_table(container) == "PASSED"
+
+
+def test_a_non_tracking_scanner_still_shows_as_passed():
+    container = _container(scanner_name="bandit")
+    container.status = container.determine_status("MEDIUM")
+
+    assert _status_in_table(container) == "PASSED"
+
+
+def test_a_total_failure_still_shows_as_error():
+    container = _container(targets_attempted=2, targets_failed=2)
+    container.status = container.determine_status("MEDIUM")
+    assert container.status == ScannerStatus.ERROR
+
+    assert _status_in_table(container) == "ERROR"
+
+
+@pytest.mark.parametrize("status", ["SKIPPED", "PASSED"])
+def test_skipped_and_passed_both_count_as_not_failing(status):
+    """Neither status may fail a build.
+
+    A scan that evaluated nothing has produced no evidence of a problem, so it must not start
+    failing pipelines that were green before -- that would make the fix worse than the bug for
+    every repository without CloudFormation. The distinction is meant to be visible, not fatal.
+    """
+    from automated_security_helper.core.unified_metrics import ScannerMetrics
+
+    assert ScannerMetrics(scanner_name="probe", status=status).passed is True
+
+
+@pytest.mark.parametrize(
+    "attempted,failed,expected_container_status",
+    [
+        (6, 0, ScannerStatus.PASSED),
+        (2, 2, ScannerStatus.ERROR),
+        (None, 0, ScannerStatus.PASSED),
+    ],
+)
+def test_the_table_never_invents_a_skipped_row(
+    attempted, failed, expected_container_status
+):
+    """Only a SKIPPED container produces a SKIPPED row.
+
+    The complement of the first test. That one shows the status reaches the table; this one
+    shows the table does not manufacture it from something else -- a clean scan, a total
+    failure and a non-tracking scanner must each keep their own status.
+
+    Deliberately not asserting that findings produce a FAILED row here. This fixture carries no
+    SARIF, and the table derives its actionable count from SARIF rather than from the
+    container's severity_counts, so such an assertion would be measuring the fixture. The
+    severity gate is covered where it lives, in
+    tests/unit/models/test_scan_results_container_nothing_scanned.py.
+    """
+    container = _container(targets_attempted=attempted, targets_failed=failed)
+    container.status = container.determine_status("MEDIUM")
+    assert container.status == expected_container_status
+
+    assert _status_in_table(container) != "SKIPPED"

--- a/tests/unit/core/test_nothing_scanned_reaches_the_summary_table.py
+++ b/tests/unit/core/test_nothing_scanned_reaches_the_summary_table.py
@@ -10,14 +10,43 @@ some routes, so a model-level assertion alone does not establish that anything c
 These tests walk the real chain. They also carry the negative control -- a container that did
 scan cleanly must still arrive as PASSED -- because the failure mode being guarded against is a
 report where every row turned yellow.
+
+The chain has a second hazard, and ``TestFindingsAreNeverReportedAsSkipped`` is the guard for
+it. Reaching the table as the string "SKIPPED" is not enough; it matters *which* field carried
+it there. ``excluded`` and the SKIPPED it produces both set ``ScannerMetrics.passed``, so a row
+that arrives via ``excluded`` claims the operator switched the scanner off, and any findings the
+scanner did produce render as skipped-and-passed while the exit code still fails the build off
+the same findings.
 """
 
 import pytest
 
+from automated_security_helper.config.ash_config import AshConfig
 from automated_security_helper.core.enums import ScannerStatus
-from automated_security_helper.core.unified_metrics import get_unified_scanner_metrics
+from automated_security_helper.core.unified_metrics import (
+    ScannerMetrics,
+    get_unified_scanner_metrics,
+)
 from automated_security_helper.models.asharp_model import AshAggregatedResults
 from automated_security_helper.models.scan_results_container import ScanResultsContainer
+from automated_security_helper.schemas.sarif_schema_model import (
+    Level,
+    Message,
+    Message1,
+    PropertyBag,
+    Result,
+    Run,
+    SarifReport,
+    Tool,
+    ToolComponent,
+)
+
+# ``AshAggregatedResults`` carries a forward reference to ``AshConfig`` that is only resolved by
+# an explicit rebuild. Done here at import rather than borrowed from whichever other test module
+# happened to run first: without it every test below raises PydanticUserError when this file is
+# run on its own, which makes a red run say nothing about the assertions in it.
+AshConfig.model_rebuild()
+AshAggregatedResults.model_rebuild()
 
 
 def _model_with_container(container: ScanResultsContainer) -> AshAggregatedResults:
@@ -39,15 +68,20 @@ def _model_with_container(container: ScanResultsContainer) -> AshAggregatedResul
     return model
 
 
-def _status_in_table(container: ScanResultsContainer) -> str:
-    model = _model_with_container(container)
+def _row_in_table(model: AshAggregatedResults, scanner_name: str) -> ScannerMetrics:
     metrics = get_unified_scanner_metrics(model)
-    rows = [m for m in metrics if m.scanner_name == container.scanner_name]
+    rows = [m for m in metrics if m.scanner_name == scanner_name]
     assert rows, (
-        f"{container.scanner_name} produced no row in the summary table; "
+        f"{scanner_name} produced no row in the summary table; "
         f"got {[m.scanner_name for m in metrics]}"
     )
-    return rows[0].status
+    return rows[0]
+
+
+def _status_in_table(container: ScanResultsContainer) -> str:
+    return _row_in_table(
+        _model_with_container(container), container.scanner_name
+    ).status
 
 
 def _container(**kwargs) -> ScanResultsContainer:
@@ -61,7 +95,20 @@ def test_a_tracked_zero_scan_shows_as_skipped():
     container.status = container.determine_status("MEDIUM")
     assert container.status == ScannerStatus.SKIPPED
 
-    assert _status_in_table(container) == "SKIPPED"
+    row = _row_in_table(_model_with_container(container), container.scanner_name)
+    assert row.status == "SKIPPED"
+
+    # Which field carried the status matters as much as the string, so this asserts the route
+    # and not just the destination. ``excluded`` means "the operator switched this scanner
+    # off", which is a different fact from "it ran and had nothing to evaluate", and reading
+    # the second as the first is what let real findings render as skipped-and-passed. Without
+    # this line the test is green through that defect rather than through the fix.
+    assert row.excluded is False, (
+        "the row must report SKIPPED because the scanner evaluated nothing, not because it "
+        "was excluded; deriving `excluded` from the status string masks findings on the "
+        "scanner's other target"
+    )
+    assert row.dependencies_missing is False
 
 
 def test_a_clean_scan_still_shows_as_passed():
@@ -130,3 +177,175 @@ def test_the_table_never_invents_a_skipped_row(
     assert container.status == expected_container_status
 
     assert _status_in_table(container) != "SKIPPED"
+
+
+def _dump(container: ScanResultsContainer) -> dict:
+    return container.model_dump(
+        exclude_none=True, exclude_unset=True, by_alias=True, mode="json"
+    )
+
+
+def _model_with_two_targets(
+    source_attempted: int | None, converted_attempted: int | None, critical: int = 0
+) -> AshAggregatedResults:
+    """A scanner reporting under both target types, with SARIF attributed to it.
+
+    Two targets is the production shape, not an exotic one: ``ScanPhase`` builds one task per
+    scanner carrying ``[source, converted]``, so every scanner writes two reports. The single
+    ``source`` fixture used by the tests above cannot express the case where one target
+    evaluated nothing and the other found something.
+
+    The SARIF matters too. The table derives ``actionable`` from SARIF rather than from the
+    container's ``severity_counts``, so a findings assertion without it would measure the
+    fixture.
+    """
+    model = AshAggregatedResults()
+    reports = {}
+    for target_type, attempted in (
+        ("source", source_attempted),
+        ("converted", converted_attempted),
+    ):
+        container = ScanResultsContainer(
+            scanner_name="cdk-nag",
+            target_type=target_type,
+            targets_attempted=attempted,
+        )
+        container.status = container.determine_status("MEDIUM")
+        reports[target_type] = _dump(container)
+    model.additional_reports["cdk-nag"] = reports
+
+    if critical:
+        model.sarif = SarifReport(
+            version="2.1.0",
+            runs=[
+                Run(
+                    tool=Tool(driver=ToolComponent(name="ASH", version="1.0")),
+                    results=[
+                        Result(
+                            ruleId=f"AwsSolutions-S{index}",
+                            level=Level.error,
+                            message=Message(root=Message1(text="Bucket is unsafe")),
+                            properties=PropertyBag(scanner_name="cdk-nag"),
+                        )
+                        for index in range(critical)
+                    ],
+                )
+            ],
+        )
+    return model
+
+
+class TestFindingsAreNeverReportedAsSkipped:
+    """A row carrying findings must render red, whatever its other target reported.
+
+    The reported shape: a repository whose tracked JSON and YAML are ``package.json``,
+    ``tsconfig.json`` and workflow files. cdk-nag evaluates none of them on the source pass, so
+    that target reports SKIPPED, while the converted pass has real templates and real findings.
+
+    ``passed`` is asserted alongside ``status`` because they are separate fields read by
+    separate consumers -- ``report_content_emitter`` hands both to the markdown, text and HTML
+    reporters -- and a row that says FAILED while ``passed`` is True is worse than either alone.
+    """
+
+    def test_a_skipped_source_target_does_not_hide_converted_findings(self):
+        model = _model_with_two_targets(
+            source_attempted=0, converted_attempted=2, critical=2
+        )
+        row = _row_in_table(model, "cdk-nag")
+
+        assert row.critical == 2, (
+            "fixture check: the findings must reach the row at all"
+        )
+        assert row.actionable == 2
+        assert row.status == "FAILED", (
+            "a scanner with actionable findings must never render as skipped; the source "
+            "target evaluated nothing, which says nothing about what the converted target "
+            "found"
+        )
+        assert row.passed is False
+        assert row.excluded is False
+
+    def test_an_excluded_scanner_carrying_findings_also_renders_red(self):
+        """The pre-existing half of the same defect, independent of target tracking.
+
+        ``for_excluded()`` has always set ``excluded`` honestly, and the excluded-before-
+        findings ordering meant such a row rendered SKIPPED and passed even with findings
+        attributed to it. Nothing in production reaches this state today -- an excluded scanner
+        never runs, so it produces no findings -- but the ordering that allows it is the same
+        ordering that produced the bug above, and pinning it here is what keeps a future
+        refactor from restoring one by way of the other.
+        """
+        model = AshAggregatedResults()
+        model.additional_reports["bandit"] = {
+            "None": _dump(ScanResultsContainer.for_excluded("bandit"))
+        }
+        model.sarif = SarifReport(
+            version="2.1.0",
+            runs=[
+                Run(
+                    tool=Tool(driver=ToolComponent(name="ASH", version="1.0")),
+                    results=[
+                        Result(
+                            ruleId="B101",
+                            level=Level.error,
+                            message=Message(root=Message1(text="assert used")),
+                            properties=PropertyBag(scanner_name="bandit"),
+                        )
+                    ],
+                )
+            ],
+        )
+
+        row = _row_in_table(model, "bandit")
+
+        assert row.actionable == 1, (
+            "fixture check: the finding must reach the row at all"
+        )
+        assert row.status == "FAILED"
+        assert row.passed is False
+        # The scanner really was excluded, and the row still says so. Only the status changed.
+        assert row.excluded is True
+
+    def test_both_targets_evaluating_nothing_still_reports_skipped(self):
+        """The positive control for the aggregate rule.
+
+        A repository with no CloudFormation anywhere leaves both targets at zero, and that is
+        the case the whole change exists to surface. Requiring *every* claim to be zero is what
+        keeps the test above from being satisfied by simply never reporting SKIPPED.
+        """
+        row = _row_in_table(
+            _model_with_two_targets(source_attempted=0, converted_attempted=0),
+            "cdk-nag",
+        )
+
+        assert row.status == "SKIPPED"
+        assert row.excluded is False
+
+    def test_one_target_evaluating_nothing_is_not_a_skipped_scan(self):
+        """Half-empty is not empty, even with no findings to show for the other half.
+
+        Separates the aggregate rule from the findings check above: here there is no SARIF at
+        all, so a row that read SKIPPED could not be blamed on findings precedence.
+        """
+        row = _row_in_table(
+            _model_with_two_targets(source_attempted=0, converted_attempted=3),
+            "cdk-nag",
+        )
+
+        assert row.status == "PASSED"
+        assert row.excluded is False
+
+    def test_two_non_tracking_targets_still_report_passed(self):
+        """The cross-scanner regression guard, at the table rather than the model.
+
+        Both reports omit the counter entirely, which is how every non-tracking scanner looks
+        after ``exclude_none``. If the aggregate rule read an absent claim as a zero claim,
+        every row in a clean report would turn yellow.
+        """
+        row = _row_in_table(
+            _model_with_two_targets(source_attempted=None, converted_attempted=None),
+            "cdk-nag",
+        )
+
+        assert row.status == "PASSED"
+        assert row.excluded is False

--- a/tests/unit/core/test_unified_metrics.py
+++ b/tests/unit/core/test_unified_metrics.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from automated_security_helper.core.unified_metrics import (
     ScannerMetrics,
     format_duration,
@@ -123,6 +125,7 @@ class TestUnifiedMetrics:
                     "excluded": False,
                     "dependencies_missing": False,
                     "error": False,
+                    "evaluated_nothing": False,
                 },
                 "scanner2": {
                     "suppressed": 0,
@@ -139,6 +142,7 @@ class TestUnifiedMetrics:
                     "excluded": True,
                     "dependencies_missing": False,
                     "error": False,
+                    "evaluated_nothing": False,
                 },
                 "scanner3": {
                     "suppressed": 0,
@@ -155,6 +159,7 @@ class TestUnifiedMetrics:
                     "excluded": False,
                     "dependencies_missing": True,
                     "error": False,
+                    "evaluated_nothing": False,
                 },
             }
 
@@ -224,6 +229,7 @@ class TestUnifiedMetrics:
                     "excluded": False,
                     "dependencies_missing": False,
                     "error": True,
+                    "evaluated_nothing": False,
                 },
             }
 
@@ -242,3 +248,69 @@ class TestUnifiedMetrics:
             assert error_metrics.duration is None
             assert error_metrics.total == 0
             assert error_metrics.actionable == 0
+
+    @pytest.mark.parametrize(
+        "flags,expected",
+        [
+            ({}, "PASSED"),
+            ({"error": True}, "ERROR"),
+            ({"actionable": 4}, "FAILED"),
+            ({"excluded": True}, "SKIPPED"),
+            ({"dependencies_missing": True}, "MISSING"),
+            ({"evaluated_nothing": True}, "SKIPPED"),
+            # Findings outrank every "did not run" flag. Each of those three resolves to a
+            # status whose ``passed`` is True, so a row reaching one of them while carrying
+            # findings leaves the summary table with no red row while the exit code -- computed
+            # from this same actionable count -- still fails the build.
+            ({"actionable": 4, "excluded": True}, "FAILED"),
+            ({"actionable": 4, "dependencies_missing": True}, "FAILED"),
+            ({"actionable": 4, "evaluated_nothing": True}, "FAILED"),
+            # An excluded scanner cannot also have evaluated nothing in production -- it never
+            # ran, so it wrote no per-target report -- but the branch order is pinned anyway so
+            # a refactor cannot quietly swap which of the two a row reports.
+            ({"excluded": True, "evaluated_nothing": True}, "SKIPPED"),
+        ],
+    )
+    def test_the_status_branch_table(self, flags, expected):
+        """The full precedence table of get_unified_scanner_metrics, one row per branch.
+
+        Written against the stats dict rather than a model so each branch is reachable
+        independently. The end-to-end proof that these flags are populated honestly from a real
+        container lives in tests/unit/core/test_nothing_scanned_reaches_the_summary_table.py;
+        this pins what the table does once they are.
+        """
+        from automated_security_helper.config.ash_config import AshConfig
+        from automated_security_helper.config.default_config import get_default_config
+
+        AshConfig.model_rebuild()
+        AshAggregatedResults.model_rebuild()
+
+        model = AshAggregatedResults()
+        model.ash_config = get_default_config()
+
+        stats = {
+            "suppressed": 0,
+            "critical": 0,
+            "high": 0,
+            "medium": 0,
+            "low": 0,
+            "info": 0,
+            "total": 0,
+            "actionable": 0,
+            "duration": 1.0,
+            "threshold": "MEDIUM",
+            "threshold_source": "global",
+            "excluded": False,
+            "dependencies_missing": False,
+            "error": False,
+            "evaluated_nothing": False,
+        }
+        stats.update(flags)
+
+        with patch(
+            "automated_security_helper.core.scanner_statistics_calculator.ScannerStatisticsCalculator.extract_scanner_statistics"
+        ) as mock_extract:
+            mock_extract.return_value = {"probe": stats}
+            metrics = get_unified_scanner_metrics(model)
+
+        assert metrics[0].status == expected

--- a/tests/unit/models/test_scan_results_container_failure_guard.py
+++ b/tests/unit/models/test_scan_results_container_failure_guard.py
@@ -49,10 +49,16 @@ class TestTotalFailureIsNotPassed:
         assert c.determine_status("MEDIUM") == ScannerStatus.PASSED
 
     def test_untracked_scanners_keep_existing_behavior(self):
-        # Scanners that do not report per-target outcomes leave both counters at 0. The guard
-        # must not fire for them, or every such scanner would regress to ERROR.
+        # Scanners that do not report per-target outcomes leave targets_attempted at None, the
+        # no-claim state. The guard must not fire for them, or every such scanner would regress
+        # to ERROR.
+        #
+        # This asserted ``== 0`` when the field was a plain int. The default moved to None so
+        # that "makes no claim" and "tracked, attempted none" stop sharing a value -- the second
+        # of those now reports SKIPPED, and reading the first as the second would flip every
+        # non-tracking scanner. See test_scan_results_container_nothing_scanned.py.
         c = _container()
-        assert c.targets_attempted == 0
+        assert c.targets_attempted is None
         assert c.determine_status("MEDIUM") == ScannerStatus.PASSED
 
     def test_failed_exceeding_attempted_still_errors(self):

--- a/tests/unit/models/test_scan_results_container_nothing_scanned.py
+++ b/tests/unit/models/test_scan_results_container_nothing_scanned.py
@@ -1,0 +1,251 @@
+"""A scanner that evaluated nothing must not report PASSED.
+
+PR #514 taught ``determine_status`` to tell "found nothing" from "failed on everything". This
+covers the third case it could not express: "evaluated nothing at all". A scanner with an empty
+input set produces zero findings and no failures, which the severity gate reads as a clean
+project and renders green.
+
+The hazard these tests exist to hold down is the fix, not the bug. ``targets_attempted``
+defaults to a state meaning "this scanner makes no claim about targets", because most scanners
+never touch the counters -- bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep,
+cfn-nag, npm-audit. Reading that state as "attempted zero" would flip every one of them from
+PASSED to SKIPPED and turn a whole clean report yellow, which is a worse defect than the one
+being fixed. ``TestNoClaimIsNotAZeroClaim`` is the guard against exactly that, and it is the
+test to run first if this file ever goes red.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.models.asharp_model import ScannerSeverityCount
+from automated_security_helper.models.scan_results_container import ScanResultsContainer
+
+
+def _container(**kwargs) -> ScanResultsContainer:
+    return ScanResultsContainer(scanner_name="probe-scanner", **kwargs)
+
+
+# Every builtin scanner that does not track per-target outcomes. Named individually rather than
+# discovered, so adding a scanner that tracks targets does not silently shrink the guard.
+NON_TRACKING_SCANNERS = (
+    "bandit",
+    "cfn-nag",
+    "checkov",
+    "detect-secrets",
+    "grype",
+    "npm-audit",
+    "opengrep",
+    "semgrep",
+    "syft",
+)
+
+
+class TestNoClaimIsNotAZeroClaim:
+    """The cross-scanner regression guard. Read the module docstring before changing these."""
+
+    def test_a_default_container_with_no_findings_is_passed(self):
+        # The single most important assertion in this file. A scanner that says nothing about
+        # targets and reports no findings has scanned cleanly, and must keep reporting PASSED.
+        c = _container()
+        assert c.targets_attempted is None, (
+            "the default must be the no-claim state; a default of 0 would assert that every "
+            "scanner tracked targets and attempted none"
+        )
+        assert c.determine_status("MEDIUM") == ScannerStatus.PASSED
+
+    @pytest.mark.parametrize("scanner_name", NON_TRACKING_SCANNERS)
+    def test_every_non_tracking_scanner_still_passes(self, scanner_name):
+        # One case per scanner that would regress, so a failure names the blast radius instead
+        # of reporting a single anonymous red test.
+        c = ScanResultsContainer(scanner_name=scanner_name)
+        assert c.determine_status("MEDIUM") == ScannerStatus.PASSED
+        assert c.determine_status(None) == ScannerStatus.PASSED
+
+    def test_a_no_claim_container_with_findings_still_fails(self):
+        # The severity gate must remain reachable. A guard that returned early for every
+        # no-claim container would suppress real failures.
+        c = _container(severity_counts=ScannerSeverityCount(high=1))
+        assert c.determine_status("HIGH") == ScannerStatus.FAILED
+
+    def test_no_claim_scan_succeeded_is_true(self):
+        assert _container().scan_succeeded is True
+
+    def test_a_no_claim_container_omits_the_counter_when_serialized(self):
+        # Reports are dumped with exclude_none, so the no-claim state stays absent from every
+        # non-tracking scanner's serialized result rather than appearing as a literal 0 that a
+        # downstream consumer could read as "attempted none".
+        dumped = _container().model_dump(exclude_none=True, mode="json")
+        assert "targets_attempted" not in dumped
+
+
+class TestTrackedAndAttemptedNothing:
+    def test_zero_attempts_is_skipped(self):
+        c = _container(targets_attempted=0)
+        assert c.determine_status("MEDIUM") == ScannerStatus.SKIPPED
+
+    def test_zero_attempts_is_skipped_with_no_findings(self):
+        # The reported shape: nothing evaluated, so nothing found. Before this change the
+        # severity gate saw zero findings and returned PASSED, which renders green and reads as
+        # "checked, clean".
+        c = _container(targets_attempted=0, targets_failed=0)
+        assert c.finding_count == 0
+        assert c.determine_status("MEDIUM") == ScannerStatus.SKIPPED
+
+    @pytest.mark.parametrize(
+        "threshold", [None, "", "ALL", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+    )
+    def test_zero_attempts_ignores_the_severity_threshold(self, threshold):
+        # The threshold answers "which findings are bad enough to fail". It has nothing to say
+        # about a scan that produced no findings because it read no input, so no setting of it
+        # may turn this back into PASSED.
+        assert _container(targets_attempted=0).determine_status(threshold) == (
+            ScannerStatus.SKIPPED
+        )
+
+    def test_recording_a_zero_attempt_moves_off_the_no_claim_state(self):
+        # How a scanner says "I looked and there was nothing to look at" through the API rather
+        # than by assigning the field. Calling the method at all is the claim.
+        c = _container()
+        c.record_target_attempt(count=0)
+        assert c.targets_attempted == 0
+        assert c.determine_status("MEDIUM") == ScannerStatus.SKIPPED
+
+    def test_a_negative_miscount_is_error_not_passed(self):
+        # A negative count is where the ERROR and SKIPPED guards overlap, and this pins which
+        # one wins. The ERROR guard tests truthiness, so -1 is truthy and ``0 >= -1`` holds --
+        # ERROR, before this branch is reached. That is the right precedence: a counter below
+        # zero means the scanner itself is miscounting, which is louder news than "there was
+        # nothing to scan".
+        #
+        # What matters either way is that it does not reach the severity gate, where zero
+        # findings off a broken counter would report PASSED.
+        assert _container(targets_attempted=-1).determine_status("MEDIUM") == (
+            ScannerStatus.ERROR
+        )
+
+    def test_a_negative_miscount_is_not_a_successful_scan(self):
+        # scan_succeeded agrees with the status above rather than contradicting it, so SARIF
+        # executionSuccessful and the rendered status cannot disagree about the same run.
+        assert _container(targets_attempted=-1).scan_succeeded is False
+
+    def test_zero_attempts_is_a_successful_execution(self):
+        # SARIF executionSuccessful is about whether the tool's run completed, not about what
+        # it yielded. A scanner with no applicable input ran fine; the "nothing evaluated"
+        # signal is carried by status instead. Flipping this to False would fail every consumer
+        # that gates on executionSuccessful, on any repository with no matching files.
+        assert _container(targets_attempted=0).scan_succeeded is True
+
+
+class TestTrackedWithAttempts:
+    """The existing PR #514 outcomes, unchanged. These are the negative controls."""
+
+    def test_all_targets_failed_is_still_error(self):
+        assert (
+            _container(targets_attempted=3, targets_failed=3).determine_status("MEDIUM")
+            == ScannerStatus.ERROR
+        )
+
+    def test_error_not_skipped_when_a_single_target_failed(self):
+        # ERROR and SKIPPED partition the tracked space on the sign of targets_attempted, so
+        # this pins that a failed attempt is never mistaken for an absent one.
+        c = _container(targets_attempted=1, targets_failed=1)
+        assert c.determine_status("MEDIUM") == ScannerStatus.ERROR
+
+    def test_attempts_with_no_failures_and_no_findings_is_passed(self):
+        # The case that must stay green: the scanner really did evaluate templates and they
+        # really were clean.
+        c = _container(targets_attempted=4, targets_failed=0)
+        assert c.determine_status("MEDIUM") == ScannerStatus.PASSED
+
+    def test_partial_failure_with_findings_still_reaches_the_severity_gate(self):
+        c = _container(
+            targets_attempted=3,
+            targets_failed=1,
+            severity_counts=ScannerSeverityCount(critical=1),
+        )
+        assert c.determine_status("CRITICAL") == ScannerStatus.FAILED
+
+
+class TestExecutorBoundaryPreservesTheTriState:
+    """The trap lives at this boundary, not in the model.
+
+    The executor copies the counters off arbitrary plugin objects. If that read answers 0 for a
+    plugin that has no counter, the model never sees the no-claim state and every non-tracking
+    scanner reports SKIPPED. The model tests above cannot catch that, because by then the damage
+    is already a 0 in the field.
+    """
+
+    def test_a_plugin_without_the_counter_makes_no_claim(self):
+        from automated_security_helper.core.phases.scanner_executor import (
+            _target_count_attr,
+        )
+
+        assert _target_count_attr(object(), "targets_attempted") is None
+
+    def test_a_mock_plugin_makes_no_claim(self):
+        from automated_security_helper.core.phases.scanner_executor import (
+            _target_count_attr,
+        )
+
+        # MagicMock auto-creates every attribute, so a plain getattr default never applies.
+        # Answering None keeps an unusable value out of the field instead of coercing it to a
+        # zero that means something specific and wrong.
+        assert _target_count_attr(MagicMock(), "targets_attempted") is None
+
+    @pytest.mark.parametrize("bad", [True, False, -3, "7", 2.0, None])
+    def test_an_unusable_counter_makes_no_claim(self, bad):
+        from automated_security_helper.core.phases.scanner_executor import (
+            _target_count_attr,
+        )
+
+        class Plugin:
+            targets_attempted = bad
+
+        assert _target_count_attr(Plugin(), "targets_attempted") is None
+
+    @pytest.mark.parametrize("value", [0, 1, 12])
+    def test_a_real_count_is_carried_through(self, value):
+        from automated_security_helper.core.phases.scanner_executor import (
+            _target_count_attr,
+        )
+
+        class Plugin:
+            targets_attempted = value
+
+        # Zero has to survive the read. It is the whole signal for a tracking scanner that
+        # evaluated nothing, and coercing it away would put the bug back.
+        assert _target_count_attr(Plugin(), "targets_attempted") == value
+
+    def test_the_boundary_and_the_model_compose_for_a_non_tracking_plugin(self):
+        # The two halves wired together, because each is correct in isolation and the defect
+        # only appears in the join.
+        from automated_security_helper.core.phases.scanner_executor import (
+            _non_negative_int_attr,
+            _target_count_attr,
+        )
+
+        plugin = object()
+        container = _container()
+        container.targets_attempted = _target_count_attr(plugin, "targets_attempted")
+        container.targets_failed = _non_negative_int_attr(plugin, "targets_failed")
+
+        assert container.determine_status("MEDIUM") == ScannerStatus.PASSED
+
+    def test_the_boundary_and_the_model_compose_for_a_tracking_plugin_at_zero(self):
+        from automated_security_helper.core.phases.scanner_executor import (
+            _non_negative_int_attr,
+            _target_count_attr,
+        )
+
+        class Plugin:
+            targets_attempted = 0
+            targets_failed = 0
+
+        plugin = Plugin()
+        container = _container()
+        container.targets_attempted = _target_count_attr(plugin, "targets_attempted")
+        container.targets_failed = _non_negative_int_attr(plugin, "targets_failed")
+
+        assert container.determine_status("MEDIUM") == ScannerStatus.SKIPPED

--- a/tests/unit/models/test_scan_results_container_nothing_scanned.py
+++ b/tests/unit/models/test_scan_results_container_nothing_scanned.py
@@ -249,3 +249,167 @@ class TestExecutorBoundaryPreservesTheTriState:
         container.targets_failed = _non_negative_int_attr(plugin, "targets_failed")
 
         assert container.determine_status("MEDIUM") == ScannerStatus.SKIPPED
+
+
+class TestABrokenCounterIsNotSilent:
+    """A negative counter is dropped at the boundary. It must not be dropped quietly.
+
+    This is the one place where reading each half separately gives the wrong answer about the
+    whole. ``TestTrackedAndAttemptedNothing.test_a_negative_miscount_is_error_not_passed`` shows
+    the model sends -1 to ERROR, and ``test_an_unusable_counter_makes_no_claim`` shows the
+    boundary answers None for -1. Both pass, and together they mean the model's ERROR guard never
+    sees a negative from a real plugin: the boundary has already turned it into "no claim", so a
+    plugin miscounting its targets reaches the severity gate and reports PASSED off a broken
+    counter. Neither half is wrong; the composition is, and only a test spanning both can say so.
+
+    The fix is to keep the coercion and make it audible rather than to let the negative through.
+    Returning it would have the model report ERROR -- "it tried and everything broke" -- which is
+    a claim nobody has evidence for: all that is known is that the plugin's accounting is wrong.
+    Its findings come from SARIF rather than from the counter and are still usable, so failing
+    the scan on an accounting bug would be a worse answer than a warning that names it. Raising
+    was rejected for the same reason, and because absorbing untrusted values at the boundary
+    instead of propagating them is the whole argument for ``_target_count_attr`` existing.
+    """
+
+    @staticmethod
+    def _read_with_logging(plugin, name="targets_attempted"):
+        """Read the counter, returning (value, warning messages).
+
+        ``ASH_LOGGER`` is patched rather than captured with caplog: it logs under the name "ash"
+        with propagate=False, so a caplog assertion here reads an empty list and would pass no
+        matter what the boundary did.
+        """
+        from unittest.mock import patch
+
+        from automated_security_helper.core.phases import scanner_executor
+
+        with patch.object(scanner_executor, "ASH_LOGGER") as logger:
+            value = scanner_executor._target_count_attr(plugin, name)
+
+        warnings = [
+            str(call.args[0]) if call.args else str(call)
+            for call in logger.warning.call_args_list
+        ]
+        return value, warnings
+
+    @pytest.mark.parametrize("negative", [-1, -3, -100])
+    def test_a_negative_counter_is_warned_about(self, negative):
+        class Plugin:
+            targets_attempted = negative
+
+        value, warnings = self._read_with_logging(Plugin())
+
+        assert value is None, "the negative must still not reach the field"
+        assert warnings, (
+            "dropping a negative counter must produce an operator-visible warning; otherwise a "
+            "scanner that miscounts its targets is indistinguishable from one that does not "
+            "track them, and reports PASSED"
+        )
+        joined = " ".join(warnings)
+        assert "targets_attempted" in joined, (
+            f"the warning must name the counter so it is actionable; got {warnings}"
+        )
+        assert str(negative) in joined, (
+            f"the warning must carry the offending value; got {warnings}"
+        )
+
+    def test_the_warning_names_the_plugin_it_came_from(self):
+        """A warning that does not say which scanner is broken is not actionable.
+
+        A run has a dozen scanners and the counters are read for each of them, so the message has
+        to identify the source or an operator cannot act on it.
+        """
+
+        class WidgetScanner:
+            targets_attempted = -2
+
+        _, warnings = self._read_with_logging(WidgetScanner())
+
+        assert any("WidgetScanner" in message for message in warnings), (
+            f"expected the plugin class name in the warning; got {warnings}"
+        )
+
+    @pytest.mark.parametrize(
+        "bad", [True, False, "7", 2.0, None, object(), MagicMock()]
+    )
+    def test_only_negatives_are_warned_about(self, bad):
+        """The negative control, and it is what stops this becoming log noise.
+
+        Every other unusable value is a scanner that simply does not track targets -- the normal
+        case for nine of the builtins and for the MagicMock every test suite passes in. Warning
+        about those would fire on every clean run and train operators to ignore the message,
+        which costs more than the silence it replaces. Only a negative is evidence of a counter
+        that was tracked and then miscounted.
+        """
+
+        class Plugin:
+            targets_attempted = bad
+
+        value, warnings = self._read_with_logging(Plugin())
+
+        assert value is None
+        assert warnings == [], (
+            f"a non-tracking or absent counter is not a defect and must stay quiet; got "
+            f"{warnings}"
+        )
+
+    def test_an_absent_counter_is_warned_about_for_neither_name(self):
+        for name in ("targets_attempted", "targets_failed"):
+            value, warnings = self._read_with_logging(object(), name=name)
+            assert value is None
+            assert warnings == [], f"{name}: {warnings}"
+
+    def test_a_negative_targets_failed_is_warned_about_too(self):
+        """``_non_negative_int_attr`` shares the coercion, so it shares the warning.
+
+        The two helpers deliberately have one rule about what counts as usable. A negative
+        failure count is the same kind of accounting bug and must not be quieter just because
+        this caller collapses None to 0.
+        """
+        from unittest.mock import patch
+
+        from automated_security_helper.core.phases import scanner_executor
+
+        class Plugin:
+            targets_failed = -5
+
+        with patch.object(scanner_executor, "ASH_LOGGER") as logger:
+            value = scanner_executor._non_negative_int_attr(Plugin(), "targets_failed")
+
+        assert value == 0
+        assert logger.warning.called, (
+            "a negative targets_failed must be reported as well"
+        )
+
+    def test_the_composed_negative_still_passes_and_says_why(self):
+        """The composition, end to end: what an operator gets for a miscounting plugin.
+
+        PASSED is the deliberate outcome, not a residual bug -- see the class docstring. What
+        changes is that it is no longer silent. This test is the one that fails if someone
+        removes the warning while leaving both halves individually correct, which is exactly how
+        the gap arose.
+        """
+        from unittest.mock import patch
+
+        from automated_security_helper.core.phases import scanner_executor
+
+        class Plugin:
+            targets_attempted = -1
+            targets_failed = 0
+
+        plugin = Plugin()
+        container = _container()
+        with patch.object(scanner_executor, "ASH_LOGGER") as logger:
+            container.targets_attempted = scanner_executor._target_count_attr(
+                plugin, "targets_attempted"
+            )
+            container.targets_failed = scanner_executor._non_negative_int_attr(
+                plugin, "targets_failed"
+            )
+
+        assert container.targets_attempted is None
+        assert container.determine_status("MEDIUM") == ScannerStatus.PASSED
+        assert logger.warning.called, (
+            "the status is PASSED, so the warning is the only signal that this scanner's "
+            "counters are broken; without it the run is indistinguishable from a clean one"
+        )

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_nothing_scanned.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_nothing_scanned.py
@@ -314,3 +314,166 @@ def test_a_scan_that_failed_every_template_still_errors(
     assert scanner.targets_attempted == 1
     assert scanner.targets_failed == 1
     assert _status_for(scanner) == ScannerStatus.ERROR
+
+
+# ---------------------------------------------------------------------------
+# The production shape: one plugin instance, two targets, two scan() calls
+# ---------------------------------------------------------------------------
+
+
+def _outcome(scanner_plugin):
+    """What the executor would record for the target that just finished."""
+    return (
+        scanner_plugin.targets_attempted,
+        scanner_plugin.targets_failed,
+        _status_for(scanner_plugin),
+    )
+
+
+class TestCountersDoNotLeakBetweenTargets:
+    """Every test above calls ``scan()`` once on a fresh fixture. Production never does.
+
+    ``ScanPhase`` appends one task per scanner carrying ``[source, converted]``, and
+    ``ScannerExecutor._execute_scanner`` loops that list against the *same* ``scanner_plugin``
+    object. So ``scan()`` runs twice on one instance, and the counters are instance attributes
+    that the executor reads after each call. Anything left over from the first target is read as
+    the second target's own claim.
+
+    The empty-or-absent-target return sits above the point where the counters are set, so a
+    target that returns there keeps whatever the previous target left behind. That is not an
+    exotic path: ``_pre_scan`` calls ``work_dir.mkdir(parents=True, exist_ok=True)`` during the
+    source pass, so by the time the converted pass runs the directory exists, and it is empty
+    for any project with nothing to convert.
+
+    The first leaked shape is precisely the defect this whole change exists to prevent -- a
+    PASSED that means "nothing was evaluated" -- except now backed by a positive attempt count
+    it did not earn, which is worse than the original because the count looks like evidence.
+
+    Only the empty-directory half of that branch is covered here. ``not target.exists()`` shares
+    the same ``if``, but it is unreachable two ways over: ``ScannerExecutor._execute_scanner``
+    drops targets whose path does not exist before calling ``scan()``, and a direct call with a
+    missing path raises earlier still, while building the SARIF skeleton above the check.
+    """
+
+    @pytest.fixture
+    def empty_target(self, tmp_path):
+        """A target directory that exists and is empty, like an unused work_dir."""
+        target = tmp_path / "empty-target"
+        target.mkdir()
+        return target
+
+    def test_a_clean_first_target_does_not_lend_its_attempts_to_an_empty_second(
+        self, scanner, cdk_available, wrapper_double, empty_target
+    ):
+        (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+        (scanner.context.work_dir / "queue.yaml").write_text(CFN_TEMPLATE)
+        wrapper_double.return_value = CdkNagWrapperResponse(
+            results={"AwsSolutions": []}, failure=None
+        )
+
+        scanner.scan(target=scanner.context.work_dir, target_type="converted")
+        assert _outcome(scanner) == (2, 0, ScannerStatus.PASSED)
+
+        scanner.scan(target=empty_target, target_type="converted")
+
+        assert _outcome(scanner) == (0, 0, ScannerStatus.SKIPPED), (
+            "the second target evaluated nothing and must say so; inheriting the first "
+            "target's attempt count reports PASSED off two attempts it never made"
+        )
+
+    def test_a_failed_first_target_does_not_lend_its_failures_to_an_empty_second(
+        self, scanner, cdk_available, wrapper_double, empty_target
+    ):
+        """The mirror image, and the one that invents a failure rather than hiding one.
+
+        A stale ``targets_failed`` makes the second target report ERROR -- "cdk-nag failed on
+        every template" -- for a target where cdk-nag never opened a file.
+        """
+        (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+        wrapper_double.return_value = CdkNagWrapperResponse(
+            results={}, failure="no validation report"
+        )
+
+        scanner.scan(target=scanner.context.work_dir, target_type="converted")
+        assert _outcome(scanner) == (1, 1, ScannerStatus.ERROR)
+
+        scanner.scan(target=empty_target, target_type="converted")
+
+        assert _outcome(scanner) == (0, 0, ScannerStatus.SKIPPED), (
+            "the second target evaluated nothing and must not inherit a failure; a false "
+            "ERROR names a broken scanner where nothing ran"
+        )
+
+    def test_the_real_source_then_converted_ordering_leaks_the_same_way(
+        self, scanner, cdk_available, wrapper_double
+    ):
+        """The same leak in the exact order ``ScanPhase`` builds the task list.
+
+        Stated separately from the two tests above so the defect cannot be dismissed as an
+        artifact of scanning the same target type twice. Source templates are evaluated, then the
+        converted pass finds an empty work_dir and returns early.
+        """
+        (scanner.context.source_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+        wrapper_double.return_value = CdkNagWrapperResponse(
+            results={"AwsSolutions": []}, failure=None
+        )
+
+        scanner.scan(target=scanner.context.source_dir, target_type="source")
+        source_outcome = _outcome(scanner)
+        assert source_outcome[0] == 1, (
+            f"fixture check: the source pass must evaluate the template; got {source_outcome}"
+        )
+
+        assert not any(scanner.context.work_dir.iterdir()), (
+            "fixture check: the converted target must be empty to reach the early return"
+        )
+        scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+        assert _outcome(scanner) == (0, 0, ScannerStatus.SKIPPED)
+
+    def test_an_empty_target_makes_a_claim_on_the_very_first_call(
+        self, scanner, cdk_available, wrapper_double, empty_target
+    ):
+        """The leak's other face: with nothing to inherit, the counters stay unset entirely.
+
+        Not a leak at all on a first call, but the same missing initialization, and it defeats
+        the guard rather than corrupting it. An unset attribute is how a scanner says "I do not
+        track targets", the executor records no claim, and the empty report resolves to PASSED --
+        the exact outcome the SKIPPED status exists to replace.
+
+        The route-1 tests above miss this because their work_dir holds ``notes.txt``, so the
+        directory is not empty and execution reaches the initialization further down. Only a
+        genuinely empty target returns above it.
+        """
+        wrapper_double.return_value = CdkNagWrapperResponse(
+            results={"AwsSolutions": []}, failure=None
+        )
+
+        scanner.scan(target=empty_target, target_type="converted")
+
+        assert scanner.targets_attempted == 0, (
+            "an empty target directory must record a tracked-zero claim; leaving the attribute "
+            "unset reads as 'does not track targets' and reports PASSED"
+        )
+        assert _outcome(scanner) == (0, 0, ScannerStatus.SKIPPED)
+
+    def test_a_second_target_that_does_scan_is_still_counted(
+        self, scanner, cdk_available, wrapper_double, empty_target
+    ):
+        """The negative control: resetting must not erase the second target's own work.
+
+        Without this, zeroing the counters unconditionally at the top of every call would pass
+        the tests above while destroying the counts for any target that really did scan.
+        """
+        wrapper_double.return_value = CdkNagWrapperResponse(
+            results={"AwsSolutions": []}, failure=None
+        )
+
+        scanner.scan(target=empty_target, target_type="converted")
+        assert _outcome(scanner) == (0, 0, ScannerStatus.SKIPPED)
+
+        (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+        (scanner.context.work_dir / "queue.yaml").write_text(CFN_TEMPLATE)
+        scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+        assert _outcome(scanner) == (2, 0, ScannerStatus.PASSED)

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_nothing_scanned.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_nothing_scanned.py
@@ -1,0 +1,316 @@
+"""cdk-nag must report SKIPPED, not PASSED, when it evaluated nothing.
+
+Three routes reach zero evaluated templates, and all three used to end the same way: an empty
+SARIF report, zero findings, PASSED, green.
+
+  1. The scan set holds no JSON or YAML file at all, so the scan body returns before the loop.
+  2. Files were found but every one turned out not to be a CloudFormation template, so the
+     per-file skip decremented the attempt count back to zero.
+  3. Every nag pack is disabled, so the wrapper registers no plugin and returns None for every
+     template -- which lands in the same skip branch as route 2.
+
+Route 3 is worth stating explicitly because it is the one the PR #514 reviewer named ("empty
+packs"), and because reading the scanner alone suggests it produces a validation report with no
+plugin reports and therefore an ERROR. It does not:
+``cdk_nag_wrapper.run_cdk_nag_against_cfn_template`` checks ``if not nag_packs`` before synthesis
+and returns None, so no report is written and no ``failure`` is set. It is a green case, and it
+is fixed by the same counter that fixes route 2.
+
+Asserted on the counters here and on the container's status in
+``tests/unit/models/test_scan_results_container_nothing_scanned.py``, because the scanner's job
+is to record what it attempted and the container's job is to turn that into a status.
+"""
+
+import pytest
+
+from automated_security_helper.base.plugin_context import PluginContext
+from automated_security_helper.config.default_config import get_default_config
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.models.scan_results_container import ScanResultsContainer
+from automated_security_helper.plugin_modules.ash_builtin.scanners import (
+    cdk_nag_scanner,
+)
+from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+    CdkNagPacks,
+    CdkNagScanner,
+    CdkNagScannerConfig,
+    CdkNagScannerConfigOptions,
+)
+from automated_security_helper.utils import cdk_nag_wrapper as wrapper_module
+from automated_security_helper.utils.cdk_nag_wrapper import CdkNagWrapperResponse
+
+CFN_TEMPLATE = """Resources:
+  MyDataBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      BucketName: placeholder-bucket
+"""
+
+
+@pytest.fixture
+def plugin_context(tmp_path):
+    context = PluginContext(
+        source_dir=tmp_path / "src",
+        output_dir=tmp_path / "out",
+        work_dir=tmp_path / "work",
+        config=get_default_config(),
+    )
+    context.source_dir.mkdir(parents=True)
+    context.output_dir.mkdir(parents=True)
+    context.work_dir.mkdir(parents=True)
+    return context
+
+
+@pytest.fixture
+def scanner(plugin_context):
+    return CdkNagScanner(context=plugin_context, config=CdkNagScannerConfig())
+
+
+@pytest.fixture
+def cdk_available(monkeypatch, tmp_path):
+    """Present the CDK dependencies and node without installing either."""
+    monkeypatch.setattr(cdk_nag_scanner, "_CDK_AVAILABLE", True)
+    fake_node = tmp_path / "bin" / "node"
+    fake_node.parent.mkdir(parents=True, exist_ok=True)
+    fake_node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    monkeypatch.setattr(cdk_nag_scanner, "find_executable", lambda name: str(fake_node))
+    return fake_node
+
+
+@pytest.fixture
+def wrapper_double(monkeypatch):
+    from unittest.mock import create_autospec
+
+    double = create_autospec(
+        wrapper_module.run_cdk_nag_against_cfn_template, spec_set=True
+    )
+    double.return_value = CdkNagWrapperResponse(results={})
+    monkeypatch.setattr(cdk_nag_scanner, "run_cdk_nag_against_cfn_template", double)
+    return double
+
+
+def _status_for(scanner_plugin) -> ScannerStatus:
+    """Run the two executor lines that copy the counters, then compute status.
+
+    Reproduces the join rather than the whole executor: the counters are read off the plugin
+    with the same helpers ScannerExecutor uses, so a change that flattens the tri-state at that
+    boundary fails here.
+    """
+    from automated_security_helper.core.phases.scanner_executor import (
+        _non_negative_int_attr,
+        _target_count_attr,
+    )
+
+    container = ScanResultsContainer(scanner_name="cdk-nag")
+    container.targets_attempted = _target_count_attr(
+        scanner_plugin, "targets_attempted"
+    )
+    container.targets_failed = _non_negative_int_attr(scanner_plugin, "targets_failed")
+    return container.determine_status("MEDIUM")
+
+
+# ---------------------------------------------------------------------------
+# Route 1: nothing in the scan set could be a CloudFormation template
+# ---------------------------------------------------------------------------
+
+
+def test_an_empty_scan_set_records_a_zero_attempt(
+    scanner, cdk_available, wrapper_double
+):
+    """The counters must exist on this path, and they did not before.
+
+    This branch returns before the loop. The counters were initialized just above the loop, so
+    on this path the attributes were never set at all -- and an absent attribute is how a
+    scanner says "I do not track targets", which is a different claim from "I tracked and
+    attempted none". The executor read no claim and the empty report resolved to PASSED.
+    """
+    (scanner.context.work_dir / "notes.txt").write_text("nothing here")
+    (scanner.context.work_dir / "main.py").write_text("print('hi')\n")
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 0, (
+        "the scanner must record that it tracked targets and attempted none; leaving the "
+        "attribute unset reads as 'does not track targets' and reports PASSED"
+    )
+    assert scanner.targets_failed == 0
+    wrapper_double.assert_not_called()
+
+
+def test_an_empty_scan_set_reports_skipped(scanner, cdk_available, wrapper_double):
+    (scanner.context.work_dir / "notes.txt").write_text("nothing here")
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert _status_for(scanner) == ScannerStatus.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# Route 2: every candidate file turned out not to be a CloudFormation template
+# ---------------------------------------------------------------------------
+
+
+def test_all_files_skipped_reports_skipped(scanner, cdk_available, wrapper_double):
+    """Ordinary JSON in the repository is not a clean CloudFormation scan."""
+    (scanner.context.work_dir / "package.json").write_text('{"name": "x"}\n')
+    (scanner.context.work_dir / "tsconfig.json").write_text("{}\n")
+    wrapper_double.return_value = None
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 0
+    assert scanner.targets_failed == 0
+    assert _status_for(scanner) == ScannerStatus.SKIPPED
+
+
+def test_one_real_template_among_skipped_files_is_not_skipped(
+    scanner, cdk_available, wrapper_double, monkeypatch
+):
+    """The negative control for route 2, and the reason the count is not a boolean.
+
+    A single evaluated template means the scan produced real information. Reporting SKIPPED here
+    would hide a genuine result behind a status that says nothing was checked.
+    """
+    (scanner.context.work_dir / "package.json").write_text('{"name": "x"}\n')
+    (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+
+    def _by_name(template_path, **kwargs):
+        if template_path.name == "bucket.yaml":
+            return CdkNagWrapperResponse(results={"AwsSolutions": []}, failure=None)
+        return None
+
+    wrapper_double.side_effect = _by_name
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 1
+    assert scanner.targets_failed == 0
+    assert _status_for(scanner) == ScannerStatus.PASSED
+
+
+# ---------------------------------------------------------------------------
+# Route 3: every nag pack disabled -- the case the reviewer named
+# ---------------------------------------------------------------------------
+
+
+def test_the_wrapper_asks_for_no_packs_when_all_are_disabled(
+    scanner, cdk_available, wrapper_double, plugin_context
+):
+    """Pins the input side: a config with every pack off produces an empty pack list.
+
+    Without this, the next test would prove only that a mocked None yields SKIPPED, and the
+    claim that disabling every pack reaches that branch would rest on reading the config code.
+    """
+    scanner.config = CdkNagScannerConfig(
+        options=CdkNagScannerConfigOptions(
+            nag_packs=CdkNagPacks(
+                AwsSolutionsChecks=False,
+                HIPAASecurityChecks=False,
+                NIST80053R4Checks=False,
+                NIST80053R5Checks=False,
+                PCIDSS321Checks=False,
+            )
+        )
+    )
+    (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+    wrapper_double.return_value = None
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert wrapper_double.call_args_list, "the wrapper was never called"
+    for call in wrapper_double.call_args_list:
+        assert call.kwargs["nag_packs"] == [], (
+            f"expected no packs to be requested; got {call.kwargs['nag_packs']}"
+        )
+
+
+def test_the_wrapper_returns_none_when_no_pack_is_registered():
+    """Pins the wrapper side: an empty pack list is None, not a report with no plugin reports.
+
+    Checked against the source rather than by calling the wrapper, because a call needs cdk-nag
+    and NodeJS and this is a unit test. The reading matters: if this branch instead synthesized
+    and wrote a report, ``_violations_from_validation_report`` would return a ``failure``, the
+    scanner would count a failed target, and every-pack-disabled would already report ERROR
+    rather than green. It returns None, so it does not.
+    """
+    import inspect
+
+    source = inspect.getsource(wrapper_module.run_cdk_nag_against_cfn_template)
+    guard = source.split("if not nag_packs:", 1)
+    assert len(guard) == 2, (
+        "run_cdk_nag_against_cfn_template no longer guards on an empty pack list; the "
+        "every-pack-disabled route may now take a different path"
+    )
+    after_guard = guard[1]
+    assert "return None" in after_guard.split("app.synth()", 1)[0], (
+        "the empty-pack guard must return None before synthesis; if it now synthesizes, this "
+        "route produces a validation report and needs its own handling"
+    )
+
+
+def test_every_pack_disabled_reports_skipped(scanner, cdk_available, wrapper_double):
+    """The reviewer's case, end to end through the scanner.
+
+    Every template returns None because no pack was registered, the attempt count returns to
+    zero, and the status says nothing was evaluated instead of rendering green.
+    """
+    scanner.config = CdkNagScannerConfig(
+        options=CdkNagScannerConfigOptions(
+            nag_packs=CdkNagPacks(
+                AwsSolutionsChecks=False,
+                HIPAASecurityChecks=False,
+                NIST80053R4Checks=False,
+                NIST80053R5Checks=False,
+                PCIDSS321Checks=False,
+            )
+        )
+    )
+    (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+    (scanner.context.work_dir / "queue.yaml").write_text(CFN_TEMPLATE)
+    wrapper_double.return_value = None
+
+    report = scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 0
+    assert _status_for(scanner) == ScannerStatus.SKIPPED
+    # The run itself completed; it simply had no rule to apply. executionSuccessful describes
+    # the run, and the "nothing evaluated" fact is carried by the status above.
+    assert report.runs[0].invocations[0].executionSuccessful is True
+
+
+# ---------------------------------------------------------------------------
+# A scan that did work is untouched
+# ---------------------------------------------------------------------------
+
+
+def test_a_real_scan_with_findings_still_fails(scanner, cdk_available, wrapper_double):
+    from tests.unit.plugin_modules.ash_builtin.test_cdk_nag_scanner_behavior import (
+        nag_result,
+    )
+
+    (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+    wrapper_double.return_value = CdkNagWrapperResponse(
+        results={"AwsSolutions": [nag_result()]}, failure=None
+    )
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 1
+    assert scanner.targets_failed == 0
+    assert _status_for(scanner) != ScannerStatus.SKIPPED
+
+
+def test_a_scan_that_failed_every_template_still_errors(
+    scanner, cdk_available, wrapper_double
+):
+    """SKIPPED must not swallow the ERROR case PR #514 added."""
+    (scanner.context.work_dir / "bucket.yaml").write_text(CFN_TEMPLATE)
+    wrapper_double.return_value = CdkNagWrapperResponse(
+        results={}, failure="no validation report"
+    )
+
+    scanner.scan(target=scanner.context.work_dir, target_type="converted")
+
+    assert scanner.targets_attempted == 1
+    assert scanner.targets_failed == 1
+    assert _status_for(scanner) == ScannerStatus.ERROR


### PR DESCRIPTION
# A scanner that evaluated nothing now reports SKIPPED instead of PASSED

Follow-up to the cdk-nag per-target failure work. That change taught the container to tell "found nothing" from "failed on everything". This handles the third case it could not express, which the reviewer of that PR asked for:

> Empty packs handling needs to be improved at a future date to display 'skipped' instead of green.

## The problem

`ScanResultsContainer.determine_status()` returns ERROR when a scanner attempted targets and failed all of them, then falls through to a severity gate that returns PASSED on zero findings. A scanner that attempted **zero** targets therefore reported PASSED with no findings — green, and indistinguishable from a clean project, when nothing had been examined.

cdk-nag reaches zero on three routes:

1. **No JSON or YAML file in the scan set.** The scan body returns before the loop.
2. **Files found, but none is a CloudFormation template.** The per-file skip decrements the attempt count back to zero.
3. **Every nag pack disabled.** `run_cdk_nag_against_cfn_template` checks `if not nag_packs` before synthesis and returns `None`, so every template lands in the same skip branch as route 2.

Route 3 is the case the reviewer named. It is worth stating explicitly because reading the scanner alone suggests it produces a validation report with no plugin reports, which would set `failure`, count a failed target, and already yield ERROR. It does not — the wrapper returns before synthesis, no report is written, and no `failure` is set. It was a green case, and the same counter that fixes route 2 fixes it.

Route 1 had a second problem: it returned before the counters were initialized at all, so the attributes were never set. An absent attribute is how a scanner says "I do not track targets" — a different claim from "I tracked and attempted none".

## The design: three states, not two

`targets_attempted` becomes `int | None`:

| value | meaning | status |
|---|---|---|
| `None` | the scanner makes no claim about targets | unchanged — falls through to the severity gate |
| `0` | the scanner tracked targets and attempted none | **SKIPPED** |
| `> 0` | the scanner tracked and attempted some | unchanged — existing ERROR / FAILED / PASSED |

Two counters cannot carry three facts. `targets_failed` stays a plain `int`, because it has no independent meaning: it is only ever read against `targets_attempted`, so "no claim" and "zero failures" lead to the same decision.

### The trap this avoids

Most scanners never touch these counters — bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag, npm-audit. A naive `if targets_attempted == 0: return SKIPPED` against the old `int = 0` default would have flipped **every one of them** from PASSED to SKIPPED and turned an entire clean report yellow. That is a larger defect than the one being fixed.

It is worse than cosmetic. The guard sits above the severity gate, so a spurious zero would let "attempted nothing" outrank real findings — one of the mutation runs below demonstrates exactly that.

### The trap lives at the executor boundary, not in the model

`ScannerExecutor` copies the counters off arbitrary plugin objects. A read that answers `0` for an absent attribute flattens the tri-state before the model ever sees it, and no model-level test can catch that. So the coercion is now explicit about it:

- `_target_count_attr(obj, name) -> int | None` answers `None` for an absent attribute *and* for a present-but-unusable one (a `MagicMock`, a bool, a negative, a non-int). Both mean "this scanner has told us nothing".
- `_non_negative_int_attr` is now expressed as `_target_count_attr(...) or 0`, for `targets_failed`. One coercion rule serves both callers, so they cannot drift apart on what counts as usable.

### Guard ordering

The SKIPPED guard sits after the ERROR guard, and the order is observable rather than cosmetic. The two overlap on a negative count: the ERROR guard tests truthiness, so `-1` is truthy and `0 >= -1` holds, and a miscounting scanner reports ERROR without reaching the SKIPPED branch. That is the intended precedence — a counter below zero means the scanner itself is broken, which is louder news than "there was nothing to scan". The SKIPPED guard still uses `<= 0` rather than `== 0` so the two are defense in depth: narrowing the ERROR guard later would send negatives to SKIPPED rather than into the severity gate, where zero findings off a broken counter would read as PASSED.

I originally wrote a comment claiming the two guards were mutually exclusive. A test disproved it, which is why the comment now says what actually happens.

### SARIF `executionSuccessful` stays True

The SARIF schema defines it as "specifies whether the tool's execution completed successfully" — the run, not the yield. A scanner that started, found no applicable input and exited cleanly did complete successfully. Reporting False would tell every consumer that gates on `executionSuccessful` that the run broke, and would start failing builds on repositories that simply contain no CloudFormation. "Nothing was evaluated" is a different fact and it belongs in `status`, which is the field the summary table renders and a human reads. Both are commented at the source.

SKIPPED also does not fail a build: `ScannerMetrics.passed` already treats it as non-failing, and the exit code is unchanged (measured below).

## Verification

### The cross-scanner regression is the gate

`TestNoClaimIsNotAZeroClaim` is the guard, with one case per scanner that would have regressed so a failure names the blast radius instead of reporting one anonymous red test. `test_nothing_scanned_reaches_the_summary_table.py` walks the real display chain — container to `additional_reports` to `ScannerStatisticsCalculator` to `get_unified_scanner_metrics` — because a status set on the model is several hops from what an operator sees, and that chain recomputes status from findings on some routes.

### Mutation proofs

Neither branch has only been seen to pass.

**Mutation 1 — make the SKIPPED branch unreachable** (`if False and ...`): **15 tests failed**, including `test_zero_attempts_is_skipped`, all seven threshold parametrizations, `test_an_empty_scan_set_reports_skipped`, `test_all_files_skipped_reports_skipped`, `test_every_pack_disabled_reports_skipped`, `test_a_tracked_zero_scan_shows_as_skipped`, and the composed boundary test.

**Mutation 2 — flatten the tri-state** (model default `None` to `0`, and `getattr(obj, name, None)` to `getattr(obj, name, 0)`, i.e. reintroduce the trap): **16 tests failed** — the default-container test, all nine non-tracking scanner cases, both executor-boundary tests, the display-path test, the serialization test, and the existing untracked-scanner test from the previous PR. `test_a_no_claim_container_with_findings_still_fails` also failed, which is the finding-masking consequence: with the trap in place a spurious zero suppressed a real HIGH finding.

### Test suite

Baseline on `main` (`06263f00`): `5944 passed, 22 skipped, 3 xfailed`
This branch: `6005 passed, 22 skipped, 3 xfailed`

Plus 61, nothing lost, skips and xfails unchanged. Coverage 93.17% against an 80% gate.

### Live scans

Real `--mode precommit` runs with the `cdk` extra installed and NodeJS v22 present, same fixtures on both revisions:

| fixture | `main` before | this branch |
|---|---|---|
| Python file only, no JSON or YAML | cdk-nag **PASSED** (green) | cdk-nag **SKIPPED** |
| Python file plus a plain `package.json`, no CloudFormation | cdk-nag **PASSED** (green) | cdk-nag **SKIPPED** |
| Python file plus a real S3 bucket template | cdk-nag FAILED, 2 critical | cdk-nag FAILED, 2 critical |

Every other scanner reported identically on both revisions in all three runs — bandit, checkov, detect-secrets and npm-audit PASSED; cfn-nag, grype and syft MISSING (tools absent here); opengrep and semgrep SKIPPED (disabled in precommit mode). The cross-scanner regression does not occur on a real run.

Process exit code for the newly-SKIPPED fixture: `0` on both revisions.

Lint and format checked with the ruff version this repo pins in `.pre-commit-config.yaml` (0.11.8) rather than the newer one in the local venv, which disagrees with the repo baseline on 161 files. All seven changed files pass `ruff check` and `ruff format --check`. One pre-existing `F401` in `cdk_nag_scanner.py` (an unused `ScannerError` import, present on `main`) is left alone as unrelated.

## Deliberately not changed

**A third early return in cdk-nag.** `scan()` also returns early when the target directory is empty or absent, before the counters. That was left as no-claim on purpose rather than for convenience: it fires routinely for the `converted` target on repositories with nothing to convert, and the per-target containers collapse into one displayed status through a path I did not trace end to end. Making it SKIPPED risks flipping cdk-nag to SKIPPED on scans that did evaluate templates from `source` — the same class of over-broad regression as the trap above. Worth its own change with its own measurement.

## Open question for the reviewer

`run_cdk_nag_against_cfn_template` returns `None` for three different reasons: the file is not a CloudFormation template, no nag pack is registered, and **cdk-nag or NodeJS is unavailable**. All three now land on SKIPPED when they apply to every template.

For the first two that is right. For the third, SKIPPED is strictly better than the green it replaces, but MISSING would be more precise — the scanner did not run because a dependency was absent, which is what MISSING means everywhere else in ASH. Distinguishing it means giving the wrapper a reason alongside the `None`, which is a larger interface change than this fix. Happy to do it here or in a follow-up, whichever you prefer.
