### PR TITLE
ci(deps): make every monitored requirement measurable so grouping admits it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,31 +1,32 @@
-# Every catch-all "minor" group below deliberately omits `update-types`. That is not an
-# oversight, and restoring the filter reintroduces a measured bug.
+# Two facts about grouping that this file depends on, and that cost a wrong fix to learn.
 #
-# What was observed. On 2026-09-08 the first run after the `uv` switch opened one grouped pull
-# request and three ungrouped ones inside the same 36 seconds. The grouped one, #537 on branch
-# dependabot/uv/engine-minor-b50b6cf414, carried three updates and described each as a version
-# bump: "Updates `importlib-metadata` from 9.0.0 to 9.0.1". The three that escaped -- #538
-# mkdocstrings[python], #539 pydantic[email], #540 types-boto3[...] -- were each described as
-# "Updates the requirements on [pydantic[email]] to permit the latest version", with no
-# from/to version pair anywhere in the body. #537 and #538 were eight seconds apart, so
-# grouping was plainly switched on and working; the question was only which updates it admits.
+# 1. A group that declares `update-types` admits an update only if Dependabot computed a
+#    semantic-version level for it. An update with no level matches no such group, and the
+#    documented fallback then applies: "Any outdated dependencies that do not match a rule are
+#    updated in individual pull requests."
 #
-# Why the second kind escaped. A group that declares `update-types` can only admit an update
-# whose semantic-version level Dependabot managed to compute. A requirement-permit update has
-# no from/to pair, so there is no level to compare, it satisfies no `update-types` list, and
-# the documented fallback takes over: "Any outdated dependencies that do not match a rule are
-# updated in individual pull requests." A group with no `update-types` has no level for an
-# update to fail -- the documentation says such a group "will include updates for all semantic
-# versions (SemVer)". Note this mechanism is not stated anywhere in the documentation; it was
-# read out of Dependabot's own grouping code and confirmed against the run above.
+# 2. Dependabot could not compute a level for a requirement written with extras. On 2026-09-08
+#    one run raised the floor on six dependencies in this project. The three written bare --
+#    importlib-metadata, typer, ruff -- were each described as "Updates `importlib-metadata`
+#    from 9.0.0 to 9.0.1" and batched into a single grouped pull request. The three written with
+#    extras -- mkdocstrings[python], pydantic[email], types-boto3[...] -- were each described as
+#    "Updates the requirements on [pydantic[email]] to permit the latest version", carried no
+#    from/to version pair anywhere, and each arrived in a pull request of its own. Six for six,
+#    one run, the same floor-raising operation on both sides.
 #
-# Why this does not collapse majors into the minor pull requests. Within one ecosystem entry
-# Dependabot walks groups in declaration order and refuses to put a dependency into a later
-# group once an earlier group has claimed it. Every `*-major-upgrade` group is declared ahead
-# of its matching minor group and still carries `update-types: ["major"]`, so a genuine major
-# is claimed there first and never reaches the untyped group; a minor, a patch, or an untyped
-# requirement bump is refused by the major group and falls through to it. The separation
-# depends on that ordering, so do not reorder the groups and do not add `update-types` back.
+# Note what the discriminator is not, because both wrong answers look convincing. It is not
+# "requirement changes carry no level": all six were requirement changes and three of them had a
+# level. It is not a pattern-matching failure either; Dependabot matches group patterns by
+# escaping every character except `*`, so `"*"` does match a bracketed name. Extras is what is
+# left. The mechanism behind it is not documented anywhere and is not proven here -- only the
+# correlation is, and it is exact.
+#
+# So the fix lives upstream of this file rather than in it. No requirement in either project is
+# written with extras any more; each former extra is declared as its own bare requirement, so
+# every monitored dependency has a name Dependabot can resolve a version for. That is what lets
+# the groups below keep `update-types`, and they must keep it: it is the only thing holding a
+# major out of a minor pull request. Reintroduce a bracketed requirement and expect it to escape
+# its group and arrive alone.
 #
 # Cooldown, recorded here so the next reader is not misled. Dependabot applies a default
 # cooldown of three days to version updates even when `cooldown` is absent, and that default
@@ -33,12 +34,11 @@
 # soak that already existed rather than creating one, and deleting `cooldown` would not make
 # updates arrive immediately.
 #
-# Security updates are intentionally left ungrouped. `applies-to` defaults to
-# `version-updates`, so every group here batches version updates only and security advisories
-# keep arriving one per advisory. Two reasons not to add security groups: batching them lets a
-# single failing check hold up every fix in the batch, which is the opposite of what an
-# advisory needs; and `cooldown` does not apply to security updates at all, so a security
-# group could not inherit the soak the rest of this file is built around.
+# Security updates are deliberately left ungrouped. `applies-to` defaults to `version-updates`,
+# so every group here batches version updates only and advisories keep arriving one at a time.
+# Batching them would let a single failing check hold up every fix in the batch, and `cooldown`
+# does not apply to security updates at all, so a security group could not inherit the soak the
+# rest of this file is built around.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -56,10 +56,13 @@ updates:
         patterns:
           - "*"
 
-  # Both docker entries had no groups at all, so every base-image change arrived as its own
-  # pull request. Same two-group shape as the Python entries and for the same reason: a base
-  # image crossing a major boundary is the case a human should look at on its own, everything
-  # else can travel together.
+  # This entry had no groups, so every base image change arrived on its own. Same two-group
+  # shape as the Python entries below: a major on its own, everything else together.
+  #
+  # `base-image-major-upgrade` is close to unreachable in practice rather than load-bearing. The
+  # Dockerfile pins ARG BASE_IMAGE to a CPython 3.12 slim tag, and CPython does not publish a
+  # 4.x tag, so nothing is expected to match it. It is kept because it costs nothing and because
+  # the base image is editable, not because it is doing work today.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -76,33 +79,21 @@ updates:
           - "*"
         update-types:
           - "major"
-      # No `update-types`, for the reason given in the header.
       base-image:
         patterns:
           - "*"
-
-  # Separate entry because `directory` scopes an ecosystem entry to one location, so the entry
-  # above does not see this Dockerfile. Group names differ from the ones above on purpose: a
-  # pull request titled "bump the base-image group" would otherwise not say which image moved.
-  - package-ecosystem: "docker"
-    directory: "/automated_security_helper/assets"
-    schedule:
-      interval: "daily"
-    cooldown:
-      default-days: 7
-    commit-message:
-      prefix: "build"
-    labels:
-      - "dependencies"
-    groups:
-      asset-image-major-upgrade:
-        patterns:
-          - "*"
         update-types:
-          - "major"
-      asset-image:
-        patterns:
-          - "*"
+          - "minor"
+          - "patch"
+
+  # There is deliberately no docker entry for automated_security_helper/assets. One was here and
+  # was removed after checking what that directory contains: a Gemfile and Gemfile.lock, six Ruby
+  # rule files, a YAML rule set, a README and a shell script. No Dockerfile, and no other
+  # container manifest. The repository's only Dockerfile is the root one above, so the entry was
+  # monitoring nothing.
+  #
+  # Its Gemfile is not monitored by anything in this file either. Adding a `bundler` entry for it
+  # is a real gap but a separate decision, deliberately not taken here.
 
   # Python dependencies, split so a scanner upgrade is never mistaken for an engine upgrade
   # and a major is never mistaken for a routine bump.
@@ -150,30 +141,32 @@ updates:
     groups:
       # A major bump of a scanner or its engine is the case that needs a human reading the
       # upstream changelog before merge, so it gets its own PR with a name that says so.
+      #
+      # The trailing `*` on each scanner name is deliberate and is not cosmetic. A bare
+      # `cdk-nag` stops matching the moment anyone writes `cdk-nag[something]`, and the
+      # dependency would then fall through to the engine groups and be filed as an engine
+      # change. Extras are the known failure mode in this file, so these patterns are written
+      # to survive one being added.
       scanner-major-upgrade:
         patterns:
-          - "cdk-nag"
-          - "aws-cdk-lib"
-          - "constructs"
-          - "detect-secrets"
-          - "cfn-flip"
+          - "cdk-nag*"
+          - "aws-cdk-lib*"
+          - "constructs*"
+          - "detect-secrets*"
+          - "cfn-flip*"
         update-types:
           - "major"
 
-      # No `update-types`, and it has to stay absent here too -- not only on the engine group.
-      # An exact package name outranks the engine groups' wildcard when Dependabot decides
-      # which group is the better home for a dependency, so these five are offered to the
-      # scanner groups and to nothing else. If this group filtered on level, an untyped
-      # requirement bump for cdk-nag or aws-cdk-lib would be refused by both scanner groups and
-      # never reach `engine-minor` either, and would end up in a pull request of its own filed
-      # as neither a scanner change nor an engine change.
       scanner-minor:
         patterns:
-          - "cdk-nag"
-          - "aws-cdk-lib"
-          - "constructs"
-          - "detect-secrets"
-          - "cfn-flip"
+          - "cdk-nag*"
+          - "aws-cdk-lib*"
+          - "constructs*"
+          - "detect-secrets*"
+          - "cfn-flip*"
+        update-types:
+          - "minor"
+          - "patch"
 
       engine-major-upgrade:
         patterns:
@@ -181,11 +174,12 @@ updates:
         update-types:
           - "major"
 
-      # No `update-types`. This is the group that has to be able to catch an update whose
-      # semver level Dependabot could not compute, which is what #538, #539 and #540 were.
       engine-minor:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   # The transpiler is a separate uv project with its own pyproject.toml and uv.lock, and
   # nothing above covers it: `directory` scopes an ecosystem entry to one manifest, so the
@@ -214,10 +208,9 @@ updates:
           - "*"
         update-types:
           - "major"
-      # No `update-types`, same reason as `engine-minor`. This entry already produced a working
-      # grouped pull request (#536, transpiler-minor, three updates), so the filter is not
-      # blocking everything here -- it would only drop an untyped requirement bump, and this
-      # project has the same `increase-if-necessary` strategy that produced them at the root.
       transpiler-minor:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,44 @@
+# Every catch-all "minor" group below deliberately omits `update-types`. That is not an
+# oversight, and restoring the filter reintroduces a measured bug.
+#
+# What was observed. On 2026-09-08 the first run after the `uv` switch opened one grouped pull
+# request and three ungrouped ones inside the same 36 seconds. The grouped one, #537 on branch
+# dependabot/uv/engine-minor-b50b6cf414, carried three updates and described each as a version
+# bump: "Updates `importlib-metadata` from 9.0.0 to 9.0.1". The three that escaped -- #538
+# mkdocstrings[python], #539 pydantic[email], #540 types-boto3[...] -- were each described as
+# "Updates the requirements on [pydantic[email]] to permit the latest version", with no
+# from/to version pair anywhere in the body. #537 and #538 were eight seconds apart, so
+# grouping was plainly switched on and working; the question was only which updates it admits.
+#
+# Why the second kind escaped. A group that declares `update-types` can only admit an update
+# whose semantic-version level Dependabot managed to compute. A requirement-permit update has
+# no from/to pair, so there is no level to compare, it satisfies no `update-types` list, and
+# the documented fallback takes over: "Any outdated dependencies that do not match a rule are
+# updated in individual pull requests." A group with no `update-types` has no level for an
+# update to fail -- the documentation says such a group "will include updates for all semantic
+# versions (SemVer)". Note this mechanism is not stated anywhere in the documentation; it was
+# read out of Dependabot's own grouping code and confirmed against the run above.
+#
+# Why this does not collapse majors into the minor pull requests. Within one ecosystem entry
+# Dependabot walks groups in declaration order and refuses to put a dependency into a later
+# group once an earlier group has claimed it. Every `*-major-upgrade` group is declared ahead
+# of its matching minor group and still carries `update-types: ["major"]`, so a genuine major
+# is claimed there first and never reaches the untyped group; a minor, a patch, or an untyped
+# requirement bump is refused by the major group and falls through to it. The separation
+# depends on that ordering, so do not reorder the groups and do not add `update-types` back.
+#
+# Cooldown, recorded here so the next reader is not misled. Dependabot applies a default
+# cooldown of three days to version updates even when `cooldown` is absent, and that default
+# does not apply to security updates. The seven-day `default-days` below therefore lengthens a
+# soak that already existed rather than creating one, and deleting `cooldown` would not make
+# updates arrive immediately.
+#
+# Security updates are intentionally left ungrouped. `applies-to` defaults to
+# `version-updates`, so every group here batches version updates only and security advisories
+# keep arriving one per advisory. Two reasons not to add security groups: batching them lets a
+# single failing check hold up every fix in the batch, which is the opposite of what an
+# advisory needs; and `cooldown` does not apply to security updates at all, so a security
+# group could not inherit the soak the rest of this file is built around.
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -15,6 +56,10 @@ updates:
         patterns:
           - "*"
 
+  # Both docker entries had no groups at all, so every base-image change arrived as its own
+  # pull request. Same two-group shape as the Python entries and for the same reason: a base
+  # image crossing a major boundary is the case a human should look at on its own, everything
+  # else can travel together.
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
@@ -25,7 +70,20 @@ updates:
       prefix: "build"
     labels:
       - "dependencies"
+    groups:
+      base-image-major-upgrade:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      # No `update-types`, for the reason given in the header.
+      base-image:
+        patterns:
+          - "*"
 
+  # Separate entry because `directory` scopes an ecosystem entry to one location, so the entry
+  # above does not see this Dockerfile. Group names differ from the ones above on purpose: a
+  # pull request titled "bump the base-image group" would otherwise not say which image moved.
   - package-ecosystem: "docker"
     directory: "/automated_security_helper/assets"
     schedule:
@@ -36,6 +94,15 @@ updates:
       prefix: "build"
     labels:
       - "dependencies"
+    groups:
+      asset-image-major-upgrade:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+      asset-image:
+        patterns:
+          - "*"
 
   # Python dependencies, split so a scanner upgrade is never mistaken for an engine upgrade
   # and a major is never mistaken for a routine bump.
@@ -93,6 +160,13 @@ updates:
         update-types:
           - "major"
 
+      # No `update-types`, and it has to stay absent here too -- not only on the engine group.
+      # An exact package name outranks the engine groups' wildcard when Dependabot decides
+      # which group is the better home for a dependency, so these five are offered to the
+      # scanner groups and to nothing else. If this group filtered on level, an untyped
+      # requirement bump for cdk-nag or aws-cdk-lib would be refused by both scanner groups and
+      # never reach `engine-minor` either, and would end up in a pull request of its own filed
+      # as neither a scanner change nor an engine change.
       scanner-minor:
         patterns:
           - "cdk-nag"
@@ -100,9 +174,6 @@ updates:
           - "constructs"
           - "detect-secrets"
           - "cfn-flip"
-        update-types:
-          - "minor"
-          - "patch"
 
       engine-major-upgrade:
         patterns:
@@ -110,12 +181,11 @@ updates:
         update-types:
           - "major"
 
+      # No `update-types`. This is the group that has to be able to catch an update whose
+      # semver level Dependabot could not compute, which is what #538, #539 and #540 were.
       engine-minor:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"
 
   # The transpiler is a separate uv project with its own pyproject.toml and uv.lock, and
   # nothing above covers it: `directory` scopes an ecosystem entry to one manifest, so the
@@ -144,9 +214,10 @@ updates:
           - "*"
         update-types:
           - "major"
+      # No `update-types`, same reason as `engine-minor`. This entry already produced a working
+      # grouped pull request (#536, transpiler-minor, three updates), so the filter is not
+      # blocking everything here -- it would only drop an untyped requirement bump, and this
+      # project has the same `increase-if-necessary` strategy that produced them at the root.
       transpiler-minor:
         patterns:
           - "*"
-        update-types:
-          - "minor"
-          - "patch"

--- a/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
+++ b/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
@@ -8,7 +8,14 @@ license = { text = "Apache-2.0" }
 authors = [{ name = "AWS Labs", url = "https://github.com/awslabs/automated-security-helper" }]
 dependencies = [
     "jinja2>=3.1",
-    "pydantic[email]>=2.0",
+    # Was "pydantic[email]". Split into two bare requirements because Dependabot could not
+    # compute a semver level for a name carrying extras, so bumps escaped their group and
+    # arrived one per pull request. Verified against PyPI: pydantic 2.13.5 declares
+    # 'email-validator>=2.0.0; extra == "email"' and nothing else under that extra. Left
+    # unbounded to match the other requirements in this list; the transpiler entry in
+    # .github/dependabot.yml has a major-upgrade group that catches a major either way.
+    "pydantic>=2.0",
+    "email-validator>=2.0",
     "pyyaml>=6.0",
     "jsonschema>=4.0",
     "python-frontmatter>=1.1",
@@ -25,7 +32,13 @@ generate-models = "tools.generate_models:main"
 # Refresh-time tooling — only needed when running refresh-schemas or generate-models.
 # CI normally just runs `transpile --check` against vendored schemas + models.
 refresh = [
-    "datamodel-code-generator[http]>=0.64",
+    # Was "datamodel-code-generator[http]". Unbundled for the same reason as pydantic above --
+    # an extras-bearing name is one Dependabot cannot compute a semver level for, so it escapes
+    # its group. Verified against the resolved 0.74.0 as well as the current release: the `http`
+    # extra declares 'httpx>=0.24.1' and nothing else. The floor here mirrors the extra exactly
+    # rather than being rounded up, so this is a faithful substitution.
+    "datamodel-code-generator>=0.64",
+    "httpx>=0.24.1",
 ]
 # Test-time tooling.
 test = [

--- a/ash-agent-plugins/agentic-coding/transpiler/uv.lock
+++ b/ash-agent-plugins/agentic-coding/transpiler/uv.lock
@@ -12,16 +12,18 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "email-validator" },
     { name = "jinja2" },
     { name = "jsonschema" },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic" },
     { name = "python-frontmatter" },
     { name = "pyyaml" },
 ]
 
 [package.optional-dependencies]
 refresh = [
-    { name = "datamodel-code-generator", extra = ["http"] },
+    { name = "datamodel-code-generator" },
+    { name = "httpx" },
 ]
 test = [
     { name = "pytest" },
@@ -30,10 +32,12 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1" },
-    { name = "datamodel-code-generator", extras = ["http"], marker = "extra == 'refresh'", specifier = ">=0.64" },
+    { name = "datamodel-code-generator", marker = "extra == 'refresh'", specifier = ">=0.64" },
+    { name = "email-validator", specifier = ">=2.0" },
+    { name = "httpx", marker = "extra == 'refresh'", specifier = ">=0.24.1" },
     { name = "jinja2", specifier = ">=3.1" },
     { name = "jsonschema", specifier = ">=4.0" },
-    { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
+    { name = "pydantic", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.0" },
     { name = "python-frontmatter", specifier = ">=1.1" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -164,11 +168,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/57/e8/8a46c8de96ec5c3b891172bf5db4bcf4797e75c31aa03d540d528e61ccd8/datamodel_code_generator-0.74.0.tar.gz", hash = "sha256:db0998d920e774f48442ca2702b901049be60c35ccb547086c574b1d261f1444", size = 2055535, upload-time = "2026-08-17T17:06:40.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/81/5b79e507f1fab62ac953d3343708a345d8e74cbe862ca2f61ccc90c2c600/datamodel_code_generator-0.74.0-py3-none-any.whl", hash = "sha256:5e7d0b41d25077ac54f23775904573fc8b608bdabc7fc762885204322f596190", size = 592333, upload-time = "2026-08-17T17:06:38.185Z" },
-]
-
-[package.optional-dependencies]
-http = [
-    { name = "httpx" },
 ]
 
 [[package]]
@@ -459,11 +458,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,15 @@ dependencies = [
  "GitPython>=3.1.61,<4.0.0",  # floor is advisory-driven: GHSA-wvpp-8hx9-p66j and others affect <= 3.1.57
  "gitdb>=4.0,<5.0.0",
  "pyrsistent>=0.20,<1.0.0",
- "pydantic[email]>=2.13,<2.14",
+ # Was "pydantic[email]". Split into two bare requirements because Dependabot could not compute
+ # a semver level for a name carrying extras, so every bump of it escaped its group and arrived
+ # as its own pull request. `pydantic[email]` is exactly pydantic plus email-validator: pydantic
+ # 2.13.5 declares 'email-validator>=2.0.0; extra == "email"' and nothing else under that extra.
+ # Unbundled rather than pinned: this list is published to PyPI, so an exact pin here would
+ # force a resolution conflict on any consumer that also depends on pydantic. Two bare names
+ # cost consumers nothing and keep the automatic patch adoption that the floors here exist for.
+ "pydantic>=2.13,<2.14",
+ "email-validator>=2.0,<3.0.0",
  "typer>=0.27,<0.28",
  "rich>=15.0,<16",
  "igittigitt>=2.2,<3.0.0",
@@ -83,10 +91,45 @@ dev = [
  "mkdocs>=1.6,<2.0.0",
  "mkdocs-material>=9.7.7,<10.0.0",  # floor is advisory-driven: GHSA-xvg9-69gf-fjrf affects >= 7.2.0, < 9.7.7
  "pymdown-extensions>=11.0.2,<12.0.0",  # floor is advisory-driven: GHSA-gm37-52c6-37mw affects <= 11.0.0
- "mkdocstrings[python]>=1.0,<2.0.0",
+ # Was "mkdocstrings[python]". Unbundled for the same reason as pydantic above. mkdocstrings
+ # 1.0.6 declares 'mkdocstrings-python>=1.16.2; extra == "python"' and nothing else under that
+ # extra. Unbundled rather than pinned even though this group is not published: an exact pin
+ # would reverse the deliberate move to major.minor floors, turning every upstream patch back
+ # into its own pull request. The <3.0.0 cap is this file's convention, not the extra's, which
+ # is unbounded -- a future major then arrives as a major instead of silently.
+ "mkdocstrings>=1.0,<2.0.0",
+ "mkdocstrings-python>=2.0,<3.0.0",
  "mkdocs-autorefs>=1.4,<2.0.0",
  "pytest-asyncio>=1.4,<2.0.0",
- "types-boto3[essential, logs, s3, securityhub, securitylake, sts]>=1.43,<2.0.0",
+ # Was "types-boto3[essential, logs, s3, securityhub, securitylake, sts]". Unbundled for the same
+ # reason as the two above, and the expansion is verified rather than guessed: in types-boto3
+ # 1.43.86 the `essential` extra declares dynamodb, cloudformation, ec2, lambda, rds, s3 and sqs;
+ # `logs`, `s3`, `securityhub`, `securitylake` and `sts` declare one each. The union of the six
+ # extras is the eleven names below -- s3 appears in both `essential` and `s3`. botocore-stubs
+ # and types-s3transfer are unconditional requirements of types-boto3 itself, so they still
+ # arrive without being named here.
+ #
+ # Pinning was rejected here specifically. types-boto3 published seven releases in the fortnight
+ # before this change, so an exact pin would propose a pull request most days. These eleven
+ # instead batch into one grouped pull request, so naming them does not multiply PR volume.
+ #
+ # One deliberate difference from the extra: it constrained each satellite to the parent's minor
+ # (>=1.43.0,<1.44.0), and these carry the parent's own >=1.43,<2.0.0 instead. That allows a
+ # satellite to move a minor ahead of the parent. For type stubs that is a staleness question
+ # rather than a runtime one, and it avoids having to widen twelve lines in lockstep every time
+ # the ecosystem's minor rolls over.
+ "types-boto3>=1.43,<2.0.0",
+ "types-boto3-cloudformation>=1.43,<2.0.0",
+ "types-boto3-dynamodb>=1.43,<2.0.0",
+ "types-boto3-ec2>=1.43,<2.0.0",
+ "types-boto3-lambda>=1.43,<2.0.0",
+ "types-boto3-logs>=1.43,<2.0.0",
+ "types-boto3-rds>=1.43,<2.0.0",
+ "types-boto3-s3>=1.43,<2.0.0",
+ "types-boto3-securityhub>=1.43,<2.0.0",
+ "types-boto3-securitylake>=1.43,<2.0.0",
+ "types-boto3-sqs>=1.43,<2.0.0",
+ "types-boto3-sts>=1.43,<2.0.0",
  "mkdocs-awesome-nav>=3.3,<4.0.0",
  "mkdocs-mermaid2-plugin>=1.2,<2.0.0",
  "pytest-xdist>=3.8,<4.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -138,6 +138,7 @@ dependencies = [
     { name = "defusedxml" },
     { name = "detect-secrets" },
     { name = "docker" },
+    { name = "email-validator" },
     { name = "gitdb" },
     { name = "gitpython" },
     { name = "igittigitt" },
@@ -146,7 +147,7 @@ dependencies = [
     { name = "jsonschema" },
     { name = "junitparser" },
     { name = "mcp" },
-    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic" },
     { name = "pyrsistent" },
     { name = "python-multipart" },
     { name = "requests" },
@@ -177,7 +178,8 @@ dev = [
     { name = "mkdocs-awesome-nav" },
     { name = "mkdocs-material" },
     { name = "mkdocs-mermaid2-plugin" },
-    { name = "mkdocstrings", extra = ["python"] },
+    { name = "mkdocstrings" },
+    { name = "mkdocstrings-python" },
     { name = "mypy" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
@@ -187,7 +189,18 @@ dev = [
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "toml" },
-    { name = "types-boto3", extra = ["essential", "logs", "s3", "securityhub", "securitylake", "sts"] },
+    { name = "types-boto3" },
+    { name = "types-boto3-cloudformation" },
+    { name = "types-boto3-dynamodb" },
+    { name = "types-boto3-ec2" },
+    { name = "types-boto3-lambda" },
+    { name = "types-boto3-logs" },
+    { name = "types-boto3-rds" },
+    { name = "types-boto3-s3" },
+    { name = "types-boto3-securityhub" },
+    { name = "types-boto3-securitylake" },
+    { name = "types-boto3-sqs" },
+    { name = "types-boto3-sts" },
     { name = "types-pyyaml" },
 ]
 
@@ -204,6 +217,7 @@ requires-dist = [
     { name = "defusedxml", specifier = ">=0.7,<0.8" },
     { name = "detect-secrets", specifier = ">=1.5,<2" },
     { name = "docker", specifier = ">=7.2,<8.0.0" },
+    { name = "email-validator", specifier = ">=2.0,<3.0.0" },
     { name = "gitdb", specifier = ">=4.0,<5.0.0" },
     { name = "gitpython", specifier = ">=3.1.61,<4.0.0" },
     { name = "igittigitt", specifier = ">=2.2,<3.0.0" },
@@ -212,7 +226,7 @@ requires-dist = [
     { name = "jsonschema", specifier = ">=4.26,<5.0.0" },
     { name = "junitparser", specifier = ">=5.0,<6" },
     { name = "mcp", specifier = ">=2.1,<3" },
-    { name = "pydantic", extras = ["email"], specifier = ">=2.13,<2.14" },
+    { name = "pydantic", specifier = ">=2.13,<2.14" },
     { name = "pyrsistent", specifier = ">=0.20,<1.0.0" },
     { name = "python-multipart", specifier = ">=0.0.32,<0.1" },
     { name = "requests", specifier = ">=2.34,<3.0.0" },
@@ -237,7 +251,8 @@ dev = [
     { name = "mkdocs-awesome-nav", specifier = ">=3.3,<4.0.0" },
     { name = "mkdocs-material", specifier = ">=9.7.7,<10.0.0" },
     { name = "mkdocs-mermaid2-plugin", specifier = ">=1.2,<2.0.0" },
-    { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0,<2.0.0" },
+    { name = "mkdocstrings", specifier = ">=1.0,<2.0.0" },
+    { name = "mkdocstrings-python", specifier = ">=2.0,<3.0.0" },
     { name = "mypy", specifier = ">=2.3,<3.0.0" },
     { name = "pymdown-extensions", specifier = ">=11.0.2,<12.0.0" },
     { name = "pytest", specifier = ">=9.1,<10.0.0" },
@@ -247,7 +262,18 @@ dev = [
     { name = "pytest-xdist", specifier = ">=3.8,<4.0.0" },
     { name = "ruff", specifier = ">=0.16,<1.0.0" },
     { name = "toml", specifier = ">=0.10" },
-    { name = "types-boto3", extras = ["essential", "logs", "s3", "securityhub", "securitylake", "sts"], specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-cloudformation", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-dynamodb", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-ec2", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-lambda", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-logs", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-rds", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-s3", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-securityhub", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-securitylake", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-sqs", specifier = ">=1.43,<2.0.0" },
+    { name = "types-boto3-sts", specifier = ">=1.43,<2.0.0" },
     { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
@@ -1785,11 +1811,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/5b/4c1902e8bdd5c4db63284e9d101dece4038d4025d6d88850ffe0a1578980/mkdocstrings-1.0.6-py3-none-any.whl", hash = "sha256:2703708697487d1b6d6d7b412e176fa436edf120c1bf81dc9e126b12d00893c7", size = 35787, upload-time = "2026-07-11T19:38:04.417Z" },
 ]
 
-[package.optional-dependencies]
-python = [
-    { name = "mkdocstrings-python" },
-]
-
 [[package]]
 name = "mkdocstrings-python"
 version = "2.0.3"
@@ -2062,11 +2083,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
-]
-
-[package.optional-dependencies]
-email = [
-    { name = "email-validator" },
 ]
 
 [[package]]
@@ -2982,32 +2998,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/dc/aad14124346930439a846b0563afb854dd5c4343f8f03a140b26985b103f/types_boto3-1.43.81.tar.gz", hash = "sha256:7ca466d08b9aa422e29369fa520157244a266801a7aada31e2f8beac78678923", size = 104923, upload-time = "2026-08-26T22:11:18.434Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/76/4661d5c9c14d5055b1dd76d8c58fbef145302a9a65b499f71e49c4abccb2/types_boto3-1.43.81-py3-none-any.whl", hash = "sha256:69ad51c06c43ed2c0bef142cef97d407c2ac07771987b02f244ee92bc520fbd8", size = 71418, upload-time = "2026-08-26T22:11:15.477Z" },
-]
-
-[package.optional-dependencies]
-essential = [
-    { name = "types-boto3-cloudformation" },
-    { name = "types-boto3-dynamodb" },
-    { name = "types-boto3-ec2" },
-    { name = "types-boto3-lambda" },
-    { name = "types-boto3-rds" },
-    { name = "types-boto3-s3" },
-    { name = "types-boto3-sqs" },
-]
-logs = [
-    { name = "types-boto3-logs" },
-]
-s3 = [
-    { name = "types-boto3-s3" },
-]
-securityhub = [
-    { name = "types-boto3-securityhub" },
-]
-securitylake = [
-    { name = "types-boto3-securitylake" },
-]
-sts = [
-    { name = "types-boto3-sts" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this fixes

Grouping in `.github/dependabot.yml` is not inert. It groups some updates and drops others, and
the ones it drops arrive one pull request per dependency. The dropped ones all had something in
common, and it was not what the first attempt on this branch assumed.

The first run after the `uv` ecosystem switch, on 2026-09-08, produced both behaviors in one
minute:

| Pull request | Created | Branch | Grouped? |
| --- | --- | --- | --- |
| #536 | 21:51:35Z | `dependabot/uv/ash-agent-plugins/agentic-coding/transpiler/transpiler-minor-3c6b61444e` | yes |
| #537 | 21:56:11Z | `dependabot/uv/engine-minor-b50b6cf414` | yes |
| #538 | 21:56:19Z | `dependabot/uv/mkdocstrings-python--gte-1.0.6-and-lt-2.0.0` | no |
| #539 | 21:56:36Z | `dependabot/uv/pydantic-email--gte-2.13.5-and-lt-2.14` | no |
| #540 | 21:56:47Z | `dependabot/uv/types-boto3-essentiallogss3securityhubsecuritylakests--gte-1.43.86-and-lt-2.0.0` | no |

#536 and #537 take their branch names from a group identifier. #538, #539 and #540 take theirs
from the dependency. #537 and #538 were eight seconds apart, so nothing about schedule, ecosystem
or cooldown separates them.

## The diagnosis this branch started with, and why it was wrong

The first commit here removed `update-types` from the three minor groups, on the theory that
these were "requirement-permit" updates carrying no semantic-version level, and so matching no
group that filters on level.

That theory does not survive the run it cited. #537, the pull request offered as proof that
grouping worked, was **itself a requirement-floor change**:

```
- "importlib-metadata>=9.0,<10.0.0",      + "importlib-metadata>=9.0.1,<10.0.0",
- "typer>=0.27,<0.28",                    + "typer>=0.27.2,<0.28",
- "ruff>=0.16,<1.0.0",                    + "ruff>=0.16.5,<1.0.0",
```

All six updates that day raised a floor. Three got a computed level and grouped; three got none
and did not. So "requirement change implies no level" cannot be the discriminator.

That first commit was also a regression, which is the more important reason it is reverted here.
If a level is uncomputable for a given dependency whatever the magnitude, a major is uncomputable
too. A `pydantic[email]` 3.0.0 would fail `engine-major-upgrade` (`update-types: ["major"]`) and
the now-untyped `engine-minor` would claim it, landing a major of the core data-model dependency
inside a pull request titled "bump the engine-minor group". That is precisely what the
major/minor split exists to prevent.

## The discriminator that does survive

Extras in the name, six for six, with a clean control on both sides of the same run:

| Requirement | Written with extras | Reported as | Grouped |
| --- | --- | --- | --- |
| `importlib-metadata` | no | "from 9.0.0 to 9.0.1" | yes |
| `typer` | no | "from 0.27.1 to 0.27.2" | yes |
| `ruff` | no | "from 0.16.4 to 0.16.5" | yes |
| `mkdocstrings[python]` | yes | "to permit the latest version" | no |
| `pydantic[email]` | yes | "to permit the latest version" | no |
| `types-boto3[...]` | yes | "to permit the latest version" | no |

Two candidate mechanisms are ruled out. It is not pattern matching: Dependabot matches group
patterns by escaping every character except `*`, so `"*"` does match a bracketed name. It is not
"the resolved version did not move" either: #538's lockfile shows no `version =` change, but
#539's does move pydantic 2.13.4 to 2.13.5 and it still reported no from/to pair.

**Stated as a correlation, not a proven mechanism.** Why extras defeats level computation is not
documented anywhere, and this change does not claim to have proven it. What is established is
that extras is the only property separating the two sets, across six samples in one run
performing the same operation.

## What changed

The fix is upstream of `dependabot.yml`: no requirement in either project is written with extras
any more, so every monitored dependency has a name Dependabot can resolve a version for. Each
expansion was read from PyPI `requires_dist` rather than assumed:

| Was | Now | Verified from |
| --- | --- | --- |
| `pydantic[email]` | `pydantic` + `email-validator` | pydantic 2.13.5: `email-validator>=2.0.0; extra == "email"` |
| `mkdocstrings[python]` | `mkdocstrings` + `mkdocstrings-python` | mkdocstrings 1.0.6: `mkdocstrings-python>=1.16.2; extra == "python"` |
| `types-boto3[essential, logs, s3, securityhub, securitylake, sts]` | `types-boto3` + 11 satellites | types-boto3 1.43.86: `essential` names dynamodb, cloudformation, ec2, lambda, rds, s3, sqs; the other five name one each (s3 appears twice) |
| `datamodel-code-generator[http]` | `datamodel-code-generator` + `httpx` | 0.74.0 and current: `httpx>=0.24.1; extra == "http"` |

The last of those is a fourth site in the transpiler's `refresh` extra that was not in the
original list; it has the same defect and is fixed the same way.

**Unbundled rather than pinned, in every case.** `pydantic` sits in `[project] dependencies` and
this package publishes to PyPI, so an exact pin there would force a resolution conflict on any
consumer that also depends on pydantic. For the three that are not published runtime
dependencies, a pin would reverse the deliberate move to major.minor floors and turn every
upstream patch back into its own pull request, and `types-boto3` alone published seven releases
in the preceding fortnight. A pin also would not have worked: it leaves the extras in the name,
which is the property that caused the problem in the first place.

One deliberate difference from the extras it replaces: the `types-boto3` extras constrained each
satellite to the parent's minor (`>=1.43.0,<1.44.0`), and the unbundled requirements carry the
parent's own `>=1.43,<2.0.0`. That allows a satellite to move a minor ahead of the parent, which
for type stubs is a staleness question rather than a runtime one, and it avoids widening twelve
lines in lockstep every time the ecosystem's minor rolls over.

With every name measurable, the typed groups are correct as originally designed, so
`update-types: ["minor", "patch"]` is restored on `scanner-minor`, `engine-minor` and
`transpiler-minor`, and the `*-major-upgrade` groups are untouched. Majors stay isolated.

## Review findings fixed alongside

**A docker entry monitored a directory with no Dockerfile.** `automated_security_helper/assets`
holds a `Gemfile` and `Gemfile.lock`, six Ruby rule files, a YAML rule set, a README and a shell
script. No Dockerfile, and no other container manifest; the repository's only Dockerfile is at the
root. The whole entry is removed rather than just its groups, because a groups-less entry pointed
at nothing is the same dead config with less to read. Its `Gemfile` is monitored by nothing here
either. That is a real gap, recorded in a comment, and deliberately not opened in this change.

**A comment contradicted the documented rule and the rest of the file.** A claim that an exact
package name "outranks" a wildcard, and that the five scanner packages are "offered to the scanner
groups and to nothing else", is gone. Specificity ranking does exist in Dependabot's source, but
it is absent from the documented behavior, it contradicted the two other comments in this file
that state the first-match rule correctly, and "and to nothing else" was the sentence most likely
to license reordering the groups that the same file forbids reordering.

**Scanner patterns are now resilient to the failure mode this pull request is about.** `cdk-nag`,
`aws-cdk-lib`, `constructs`, `detect-secrets` and `cfn-flip` gain a trailing `*`. A bare name
stops matching the moment someone writes `cdk-nag[something]`, and the dependency would then fall
through to the engine groups and be filed as an engine change, losing the split.

**`base-image-major-upgrade` is kept but no longer oversold.** The Dockerfile pins
`ARG BASE_IMAGE` to a CPython 3.12 slim tag and CPython does not publish a 4.x tag, so nothing is
expected to match it. It is kept because the base image is editable and it costs nothing, not
because it is doing work today.

## Verification

Relocking is a **no-op at the lockfile level**, which is the bar the unbundling had to clear:

- Root: 169 packages before, 169 after, **identical** name/version set.
- Transpiler: 42 packages before, 42 after, **identical** name/version set.
- No `version =` line changed in either lock. The only lockfile movement is `requires-dist`
  metadata losing its `extras = [...]` markers and gaining the bare names.
- `uv lock --check` clean in both projects.

The dependency was not silently dropped, which is the failure mode for an unbundling:
`email_validator` 2.3.0 imports from the built environment, and `pydantic.EmailStr` still
**rejects** an invalid address, so the validator is live rather than absent. All eleven
`types-boto3-*` satellites and `mkdocstrings-python` resolve to the versions they held before.

Tests, with no test file touched:

- Root suite: **6039 passed, 117 skipped, 3 xfailed, 0 failed**. Coverage 93.18% against the 80%
  gate.
- Transpiler suite: **26 passed, 0 failed**, run the way its workflow runs it.

Config: parses, and validates with 0 errors against `https://json.schemastore.org/dependabot-2.0.json`.
No group has an empty `patterns`.

## Still open, deliberately not fixed here

`versioning-strategy: increase-if-necessary` is documented as "Leave the version requirement
unchanged if it already allows the new release", with the resolved version still updated. The
observed behavior disagrees. #538 raised `mkdocstrings[python]` from `>=1.0,<2.0.0` to
`>=1.0.6,<2.0.0` even though the existing range already admitted 1.0.6. `versioning-strategy` is
not changed in this pull request; whether this is a Dependabot behavior or a misreading of the
option deserves its own investigation.

## How to tell whether this worked

**This cannot be verified locally.** No local tool executes Dependabot's grouping. Everything
verified above is either a lockfile property, a test result, or a schema check. Whether grouping
now admits these updates is observable only from the next Dependabot run.

The specific test: `pydantic`, `email-validator`, `mkdocstrings`, `mkdocstrings-python` and the
`types-boto3` family are now bare names, so their next bump should appear **inside** a grouped
pull request on a branch named after a group identifier, such as
`dependabot/uv/engine-minor-<hash>`. If any of them still arrives alone on a
`dependabot/uv/<package>--gte-<version>-and-lt-<version>` branch, the extras correlation is not
the cause and the diagnosis needs reopening a second time.
