### PR TITLE
fix(transpiler): drop the dead transpile entry point and fix the docs it broke

### DIFF
--- a/ash-agent-plugins/README.md
+++ b/ash-agent-plugins/README.md
@@ -50,13 +50,25 @@ Each backend is a class that subclasses `BaseBackend` and declares its layout vi
 ```
 agentic-coding/
 ├── transpiler/                         # The build tool
-│   ├── pyproject.toml                  # Declares jinja2, pydantic, pyyaml deps
-│   ├── transpile.py                    # ~700 lines — orchestrator + section emitters
-│   ├── schema.py                       # Pydantic models that validate configs.yaml
-│   ├── configs.yaml                    # Per-platform layout descriptions (15 entries)
+│   ├── pyproject.toml                  # Deps + the agentic-plugins, refresh-schemas, generate-models entry points
+│   ├── validate.py                     # Output validation, invoked by `check`
+│   ├── transpiler/                     # The package
+│   │   ├── cli.py                      # Click CLI — the commands listed under Development workflow
+│   │   ├── core.py                     # BaseBackend, Manifest, output-anchor resolution
+│   │   ├── orchestrator.py             # build / release / drift across backends
+│   │   ├── emitters.py                 # Section emitters + the run_section_emitters dispatch
+│   │   ├── registry.py                 # BackendRegistry + @register_backend
+│   │   ├── formats.py                  # Format descriptors (see `agentic-plugins formats`)
+│   │   ├── backends/<name>/            # One sub-package per backend — the class and its class vars
+│   │   └── ...                         # jinja_renderer, manifest_builders, mcp_builders, install_scripts, packagers, cli_tools
+│   ├── tools/                          # refresh-schemas + generate-models
+│   ├── schemas/                        # Vendored external JSON Schemas + the schemas.json index
+│   ├── generated_models/               # Pydantic models generated from those schemas (committed)
+│   ├── tests/
 │   ├── _base/                          # SOURCE OF TRUTH — humans only edit here
 │   │   ├── manifest.json               # Plugin metadata: name, description, etc.
 │   │   ├── skill.md                    # Main skill body (no frontmatter)
+│   │   ├── cli_versions.json           # Platform CLI version pins, used by smoke-test
 │   │   ├── references/
 │   │   │   ├── tool-reference.md
 │   │   │   └── troubleshooting.md
@@ -70,21 +82,25 @@ agentic-coding/
 │
 └── plugins/                            # GENERATED — committed for browse-by-platform
     ├── AGENTS.md                       # Universal repo-root instruction file
-    ├── claude/, codex/, kiro/,         # 14 directory-style plugins
+    ├── claude/, codex/, kiro/,         # 14 directory-style platform plugins
     ├── copilot/, opencode/, cursor/,
     ├── windsurf/, cline/, roo/,
     ├── continue/, gemini/, goose/,
     ├── amazonq/, aider/
-    └── mcpb/                           # MCPB archive (manifest.json + ash.mcpb ZIP)
+    ├── mcpb/                           # MCPB archive (manifest.json + ash.mcpb ZIP)
+    └── generic-skill/                  # Standalone agentskills.io release (row 16 above)
 ```
+
+The seventeenth backend, `skills-root`, writes outside this tree — to `skills/`
+at the repository root, per row 17 above.
 
 ## How transpilation works
 
-The transpiler reads `_base/` content and `configs.yaml` layout descriptions, then dispatches each platform through a generic `render_platform()` function. Each section in a platform's config (`plugin_manifest`, `mcp`, `skill`, `commands`, `agents`, `instruction_file`, `rules_dir`, `custom_modes`, `config_file`, `marketplace`, `extension_manifest`, `mcpb_bundle`) is handled by a corresponding emitter.
+The transpiler reads `_base/` content and each backend's class vars, then dispatches through `emitters.run_section_emitters`. Every section a backend declares (`PLUGIN_MANIFEST`, `MCP`, `SKILL`, `COMMANDS`, `AGENTS`, `INSTRUCTION_FILE`, `RULES_DIR`, `CUSTOM_MODES`, `CONFIG_FILE`, `MARKETPLACE`, `EXTENSION_MANIFEST`, `MCPB_BUNDLE`) is handled by a corresponding `emit_*` function; sections it leaves unset are skipped.
 
-**Adding a new platform** is typically just a `configs.yaml` entry plus possibly one Jinja template if the layout has a genuinely new shape. No new Python render function is needed unless the platform requires output formats outside the existing dispatcher (JSON manifests, YAML configs, MCPB archives, install scripts).
+**Adding a new platform** is typically just a backend class declaring those class vars, plus possibly one Jinja template if the layout has a genuinely new shape. No new emitter is needed unless the platform requires an output shape outside the existing dispatch (JSON manifests, YAML configs, MCPB archives, install scripts).
 
-**Each Jinja template stays under 20 lines.** The single `skill.md.j2` template handles all frontmatter+body files (skills, commands, agents) by parameterizing over `frontmatter_fields`. Per-platform templates exist only where a platform's shape is genuinely different (Roo `.roomodes`, Continue YAML mcpServers, Goose YAML extensions, instruction files like POWER.md / GEMINI.md / .goosehints / CONVENTIONS.md / copilot-instructions.md, Aider config).
+**Jinja templates stay small** — 24 of the 26 are under 20 lines. The single `skill.md.j2` template handles all frontmatter+body files (skills, commands, agents) by parameterizing over `frontmatter_fields`, which is why it is the longest at 34. Per-platform templates exist only where a platform's shape is genuinely different (Roo `.roomodes`, Continue YAML mcpServers, Goose YAML extensions, instruction files like POWER.md / GEMINI.md / .goosehints / CONVENTIONS.md / copilot-instructions.md, Aider config).
 
 ## Development workflow
 
@@ -124,17 +140,20 @@ CI runs `agentic-plugins check` on every push and pull request that touches the 
 
 The transpiler validates every generated file against its platform's spec via three tiers:
 
-1. **External JSON Schemas** — `mcpb/manifest.json` validates against the official [MCPB Draft 07 schema](https://github.com/modelcontextprotocol/mcpb), and `opencode/opencode.json` validates against the [OpenCode Draft 2020-12 schema](https://opencode.ai/config.json). Both schemas are vendored at `agentic-coding/transpiler/schemas/`.
-2. **Structural sanity** — every generated `.json` parses as JSON, every `.yaml`/`.yml` parses as YAML, every markdown file with `---` frontmatter has parseable YAML, and every path declared in `configs.yaml` exists in the output tree.
+1. **External JSON Schemas** — `mcpb/manifest.json` validates against the official [MCPB Draft 07 schema](https://github.com/modelcontextprotocol/mcpb), `opencode/opencode.json` against the [OpenCode Draft 2020-12 schema](https://opencode.ai/config.json), and `amazonq/agent.json` against the [Amazon Q agent-v1 Draft 07 schema](https://github.com/aws/amazon-q-developer-cli/blob/main/docs/agent-format.md). All are vendored at `agentic-coding/transpiler/schemas/`; `validate.EXTERNAL_SCHEMAS` is the list.
+2. **Structural sanity** — every generated `.json` parses as JSON, every `.yaml`/`.yml` parses as YAML, every markdown file with `---` frontmatter has parseable YAML, and every path a backend declares exists in the output tree.
 3. **Known platform constraints** — Claude plugin name kebab-case, Roo customMode slug regex, Windsurf `trigger` enum, Copilot 4000-char `copilot-instructions.md` cap, Windsurf 12000-byte rule cap, MCPB archive integrity (must contain `manifest.json` at root, manifest must validate against the MCPB schema).
 
 To refresh the cached external schemas after upstream changes:
 
 ```bash
-bash agentic-coding/transpiler/schemas/refresh.sh
+uv run --project agentic-coding/transpiler refresh-schemas
 git diff agentic-coding/transpiler/schemas/   # review what changed
 uv run --project agentic-coding/transpiler agentic-plugins check  # confirm we still validate
 ```
+
+If a refreshed schema changes shape, regenerate the committed Pydantic models
+too: `uv run --project agentic-coding/transpiler --extra refresh generate-models`.
 
 You can run validation independently of drift detection:
 

--- a/ash-agent-plugins/agentic-coding/transpiler/README.md
+++ b/ash-agent-plugins/agentic-coding/transpiler/README.md
@@ -1,23 +1,36 @@
 # Transpiler
 
-Single-source-of-truth → 14 platform plugin packages. See the [repo root README](../README.md) for the full picture.
+Single source of truth (`_base/`) → one plugin package per registered backend.
+See the [directory README](../../README.md) for the platform table and the
+architecture.
 
 ## Run
 
 ```sh
-# From the repo root:
-uv run --project transpiler transpiler/transpile.py            # regenerate all outputs
-uv run --project transpiler transpiler/transpile.py --check    # exit 1 if outputs differ
+# From the ash-agent-plugins/ directory:
+uv run --project agentic-coding/transpiler agentic-plugins build   # regenerate all outputs
+uv run --project agentic-coding/transpiler agentic-plugins check   # exit 1 on drift or validation failure
 ```
+
+`build` and `check` report how many backends they covered rather than assuming a
+number; `agentic-plugins formats` lists them with the format each one emits.
+`agentic-plugins --help` covers the rest (`setup`, `release`, `smoke-test`,
+`cli-tools`, `matrix`).
 
 ## Develop
 
 ```sh
-cd transpiler
-uv sync                          # create .venv, install jinja2
-uv run python transpile.py
+uv sync --project agentic-coding/transpiler --extra test
+uv run --project agentic-coding/transpiler --extra test pytest agentic-coding/transpiler/tests/
 ```
+
+Add a platform by writing a backend module under
+`agentic-coding/transpiler/transpiler/backends/<name>/`; `@register_backend`
+picks it up on import.
 
 ## Dependencies
 
-Only `jinja2`. Stdlib otherwise. Python 3.11+.
+`jinja2`, `pydantic`, `pyyaml`, `jsonschema`, `python-frontmatter`, `click`.
+Stdlib otherwise. Python 3.11+. The `refresh` extra adds
+`datamodel-code-generator`, needed only by `refresh-schemas` and
+`generate-models`; the `test` extra adds `pytest`.

--- a/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
+++ b/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "agentic-plugin-transpiler"
 version = "0.1.0"
-description = "Transpile a single _base/ source-of-truth into plugin packages for 14 AI coding agent platforms (Claude Code, Codex CLI, Kiro, GitHub Copilot, OpenCode, Cursor, Windsurf, Cline, Roo Code, Continue.dev, Gemini CLI, Goose, Amazon Q, Aider)."
+description = "Transpile a single _base/ source-of-truth into plugin packages for AI coding agent platforms, plus standalone agentskills.io skill releases. `agentic-plugins formats` lists the registered backends and the formats they emit."
 readme = "README.md"
 requires-python = ">=3.11"
 license = { text = "Apache-2.0" }

--- a/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
+++ b/ash-agent-plugins/agentic-coding/transpiler/pyproject.toml
@@ -17,13 +17,12 @@ dependencies = [
 
 [project.scripts]
 agentic-plugins = "transpiler.cli:main"
-transpile = "transpiler.cli:transpile_compat"
 refresh-schemas = "tools.refresh_schemas:main"
 generate-models = "tools.generate_models:main"
 
 [project.optional-dependencies]
 # Refresh-time tooling — only needed when running refresh-schemas or generate-models.
-# CI normally just runs `transpile --check` against vendored schemas + models.
+# CI normally just runs `agentic-plugins check` against vendored schemas + models.
 refresh = [
     "datamodel-code-generator[http]>=0.64",
 ]

--- a/ash-agent-plugins/agentic-coding/transpiler/tests/test_console_scripts.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tests/test_console_scripts.py
@@ -1,0 +1,61 @@
+"""Every console script in `[project.scripts]` must resolve to a callable.
+
+A `[project.scripts]` entry is a string. Nothing at build or install time checks
+that the module it names is importable or that the attribute after the colon
+exists -- the wrapper is generated either way, and the import only happens when
+a user runs the command. A stale entry therefore installs cleanly, passes CI,
+and fails with ImportError for whoever follows the documentation.
+
+This project shipped exactly that: `transpile = "transpiler.cli:transpile_compat"`
+outlived the shim it pointed at, and four other places told users to run it.
+Importing each target here is the cheapest check that would have caught it, and
+it covers entry points added later without anyone remembering to test them.
+"""
+from __future__ import annotations
+
+import importlib
+import tomllib
+from pathlib import Path
+
+import pytest
+
+PYPROJECT = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
+def _declared_scripts() -> dict[str, str]:
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh).get("project", {}).get("scripts", {})
+
+
+def test_pyproject_declares_console_scripts():
+    """Positive control: without it, an empty table would make the parametrized
+    test below collect nothing and report success."""
+    assert _declared_scripts(), f"no [project.scripts] table found in {PYPROJECT}"
+
+
+@pytest.mark.parametrize(("script", "target"), sorted(_declared_scripts().items()))
+def test_declared_console_script_resolves_to_a_callable(script: str, target: str):
+    module_path, sep, attr_path = target.partition(":")
+    assert sep and attr_path, (
+        f"console script {script} = {target!r} names no attribute; an entry point "
+        "must be 'module:callable'"
+    )
+
+    module = importlib.import_module(module_path)
+
+    # PEP 621 allows a dotted attribute (`module:Class.method`), so walk it.
+    obj = module
+    walked = module_path
+    for part in attr_path.split("."):
+        assert hasattr(obj, part), (
+            f"console script {script} = {target!r} does not resolve: {walked} "
+            f"defines no {part!r}. Running `{script}` would raise ImportError in "
+            "the generated wrapper."
+        )
+        obj = getattr(obj, part)
+        walked = f"{walked}.{part}"
+
+    assert callable(obj), (
+        f"console script {script} = {target!r} resolves to {obj!r}, which is not "
+        f"callable, so `{script}` would fail at invocation"
+    )

--- a/ash-agent-plugins/agentic-coding/transpiler/tests/test_console_scripts.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tests/test_console_scripts.py
@@ -11,6 +11,7 @@ outlived the shim it pointed at, and four other places told users to run it.
 Importing each target here is the cheapest check that would have caught it, and
 it covers entry points added later without anyone remembering to test them.
 """
+
 from __future__ import annotations
 
 import importlib

--- a/ash-agent-plugins/agentic-coding/transpiler/tools/generate_models.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tools/generate_models.py
@@ -90,7 +90,7 @@ def main() -> int:
     if failures:
         print(f"FAILED: {len(failures)} schema(s): {failures}")
         return 1
-    print("Done. Run `uv run --project agentic-coding/transpiler transpile --check` to confirm validation still passes.")
+    print("Done. Run `uv run --project agentic-coding/transpiler agentic-plugins check` to confirm validation still passes.")
     return 0
 
 

--- a/ash-agent-plugins/agentic-coding/transpiler/tools/refresh_schemas.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/tools/refresh_schemas.py
@@ -14,7 +14,7 @@ Direct entries require curl. Zod-converted entries require Node >=18 and git.
 Both pre-conditions are checked at startup; missing tools fail with an
 actionable error message.
 
-After refresh, run `uv run --project agentic-coding/transpiler transpile --check`
+After refresh, run `uv run --project agentic-coding/transpiler agentic-plugins check`
 to confirm the new schemas still validate the generated outputs.
 """
 from __future__ import annotations
@@ -129,7 +129,7 @@ def main() -> int:
         return 1
     print("All schemas refreshed. Review the diff and re-run --check:")
     print("  git diff agentic-coding/transpiler/schemas/")
-    print("  uv run --project agentic-coding/transpiler transpile --check")
+    print("  uv run --project agentic-coding/transpiler agentic-plugins check")
     return 0
 
 

--- a/ash-agent-plugins/agentic-coding/transpiler/transpiler/registry.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/transpiler/registry.py
@@ -1,7 +1,9 @@
 """Backend registration + discovery.
 
 @register_backend on a class adds it to BackendRegistry. Importing
-transpiler.backends triggers all 15 platform modules, populating the registry.
+transpiler.backends triggers every backend module, populating the registry.
+`BackendRegistry.names()` is the authoritative list; nothing should restate its
+length, since a stated count goes stale the next time a backend is added.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## What this fixes

Three defects in `ash-agent-plugins/agentic-coding/transpiler`: a console script that points at a function that does not exist, a package description that undercounts its own backends, and a README architecture section describing files that were deleted.

Base: `3eac29d8309668a79b1363ccd634e93cd6ed17ba`.

---

## Defect 1 — `transpile` has never worked

`pyproject.toml` declared:

```toml
transpile = "transpiler.cli:transpile_compat"
```

`transpiler.cli` defines no `transpile_compat`. Its 14 module-level names are `_all_or_one`, `cli`, `setup`, `build`, `release`, `check`, `_label`, `smoke_test`, `formats_cmd`, `cli_tools_cmd`, `matrix_cmd`, `_register_backend_groups`, `_backend_to_platform_config`, `main`. Confirmed at runtime:

```
$ python -c "import transpiler.cli; print(hasattr(transpiler.cli,'transpile_compat'))"
False
```

### Why it has never worked

The shim existed only on the branch that introduced the transpiler. One commit there added both the pyproject entry and `def transpile_compat()`; a later commit on the same branch, titled *"refactor: backend sub-packages, drop compat shim, fix --check + DA gaps"*, deleted the function and left the entry point behind. The branch was squashed before landing, so the flattened commit shipped the entry with no function. At that commit, `transpile_compat` appears exactly once in the tree — the pyproject line. There is no landed state in which `transpile` resolves; running it raises `ImportError` inside the wrapper that pip generates.

### The five sites

| Site | What it said |
|---|---|
| `transpiler/pyproject.toml:20` | the dead entry point |
| `transpiler/pyproject.toml:26` | "CI normally just runs `transpile --check` ..." |
| `tools/generate_models.py:93` | `print("Done. Run ... transpile --check ...")` on success |
| `tools/refresh_schemas.py:17` | module docstring |
| `tools/refresh_schemas.py:132` | printed instruction on success |

Two of them print right after a successful refresh, so the first thing a user saw after `refresh-schemas` or `generate-models` succeeded was an instruction to run a command that cannot start.

### The working command, and evidence

The deleted shim's own docstring recorded the mapping: `transpile --check` → `agentic-plugins check`, `transpile --drift-only` → `agentic-plugins check --drift-only`, bare `transpile` → `agentic-plugins build`. That is corroborated by `ash-agent-plugins/.pre-commit-config.yaml`, which already invokes `agentic-plugins build` and `agentic-plugins check`, and by the root drift workflow, which runs `agentic-plugins check`.

Run, not assumed:

```
$ uv run --project ash-agent-plugins/agentic-coding/transpiler agentic-plugins check
OK: AGENTS.md + 17 platform outputs match _base/ source.
OK: validation passed for 17 platforms + AGENTS.md.
$ echo $?
0
```

### Chose (a), remove — not (b), add a shim

- The script has never resolved in any landed state, so nothing can depend on it.
- The shim was deliberately deleted, in a commit that says so in its subject, and its own docstring called it temporary: *"Exists so existing pre-commit hooks and CI invocations don't break during the transition."* Re-adding it reverses a decision the maintainers already made.
- Nothing in the repository invokes it. `git grep` over the whole tree — including the generated platform trees, the install scripts, both CI workflows, and both pre-commit configs — found the name only at the five sites above. After this change the only remaining mention is the new test's docstring, which explains the history.

(b) would create a working command that never shipped, rather than restore one.

---

## Defect 1b — a test that makes it categorical

`[project.scripts]` is a string. Nothing at build or install time checks that the module imports or that the attribute exists; the wrapper is generated either way and the import happens only when a user runs the command. So a stale entry installs cleanly and keeps CI green.

`tests/test_console_scripts.py` imports every declared target and walks the attribute path (dotted attributes included, per PEP 621). It carries a positive control asserting the scripts table is non-empty — without it, deleting the table would leave the parametrized test collecting nothing and reporting success.

**Proof it fails.** With the broken entry re-added:

```
FAILED tests/test_console_scripts.py::test_declared_console_script_resolves_to_a_callable[transpile-transpiler.cli:transpile_compat]
AssertionError: console script transpile = 'transpiler.cli:transpile_compat' does not resolve:
transpiler.cli defines no 'transpile_compat'. Running `transpile` would raise ImportError
in the generated wrapper.
```

The other three scripts passed in that same run, so the failure is specific rather than a collection error. `pyproject.toml` was then restored byte-for-byte (verified with `diff` against a pre-break copy) and the suite returns 30 passed.

---

## Defect 2 — the description restated a count that had already gone stale

The description claimed "14 AI coding agent platforms" and enumerated them. **The registry has 17 backends:**

```
$ agentic-plugins check
OK: validation passed for 17 platforms + AGENTS.md.
```

`BackendRegistry.names()` → `aider, amazonq, claude, cline, codex, continue, copilot, cursor, gemini, generic-skill, goose, kiro, mcpb, opencode, roo, skills-root, windsurf`

The 14 it enumerated are real named platforms. The three it omitted are not platforms in the same sense, which is why "just change 14 to 17" would have been the wrong fix:

- **`mcpb`** — an Anthropic MCP Bundle archive. A package format (`FORMAT.name == "mcpb-bundle"`), consumed by Claude Desktop.
- **`generic-skill`** and **`skills-root`** — both carry `is_format_only_release = True` and emit the same platform-agnostic agentskills.io `SKILL.md`. They differ only in where it lands: inside the plugin tree, and at the repository root so `npx skills add owner/repo` resolves.

The number was not the whole defect. A description that states a count must be edited whenever a backend lands, and this one had already drifted three ways against one registry: pyproject said 14, `registry.py`'s docstring said "all 15 platform modules", and the transpiler README said "14 platform plugin packages". So the count **and** the enumeration are gone, replaced by a pointer to `agentic-plugins formats`, which derives the list from the registry at runtime. `registry.py` now records why it does not restate the length.

`ash-agent-plugins/README.md` is deliberately unchanged here: its "15 platforms plus two skill releases, 17 outputs in total, which is the number `agentic-plugins check` reports" already reconciles, counting MCPB/Claude Desktop as a platform.

The transpiler's own README also documented `transpiler/transpile.py`, a file that does not exist, claimed "Only `jinja2`" against six declared runtime dependencies, and linked `../README.md`, a path with no file at it. Every command it now lists was executed from the directory it names.

---

## Defect 3 — verified, and it was wrong

`ash-agent-plugins/README.md` does have an Architecture section. Checking each structural claim against the tree:

**False, and fixed.** Three of the four files the directory tree listed under `transpiler/` are gone — `transpile.py`, `schema.py`, `configs.yaml` — so the tree contradicted the prose four lines above it, which already said backends are classes under `transpiler/backends/<name>/`. The tree also omitted `plugins/generic-skill/` and the repository-root `skills/` tree. The claims that depended on the deleted files were wrong too:

- "dispatches each platform through a generic `render_platform()` function" — no such function exists anywhere in the tree; the dispatch is `emitters.run_section_emitters`.
- "Adding a new platform is typically just a `configs.yaml` entry."
- "every path declared in `configs.yaml` exists in the output tree."
- "Each Jinja template stays under 20 lines" — 24 of 26 are. `skill.md.j2` is 34 and `aider/CONVENTIONS.md.j2` is 21.
- `bash agentic-coding/transpiler/schemas/refresh.sh` — no such script; the entry point is `refresh-schemas`, which is how `refresh_schemas.py`'s own docstring documents it.
- Tier-1 validation named two vendored schemas and said "Both". `validate.EXTERNAL_SCHEMAS` has three, including Amazon Q's `agent.json`.

**Accurate, and left alone.** The 17-row platform table (every folder exists, including the repository-root `skills/` tree), the reconciled count in the opening paragraph, the `BaseBackend` class-var list (all 12 section vars plus `PHASES` verified present; `CLI_GROUP` is correctly described as per-backend opt-in rather than a base default), both CI workflow paths (`.github/workflows/ash-agent-plugins-drift.yml` and `ash-agent-plugins/.github/workflows/validate.yml` both exist), the five lifecycle commands, the `check` flags, the MCPB determinism note, and the AGENTS.md adoption list.

---

## Verification

| Check | Result |
|---|---|
| `pytest` (transpiler suite) | **30 passed**, 0 failed, 0 skipped — 26 on main plus 4 new |
| `agentic-plugins check` (drift + validation) | **exit 0** — 17 outputs match `_base/`, unchanged from main |
| `agentic-plugins build` | exit 0, then `git status` clean, so output is byte-identical |
| `ruff check` on every changed file | **passes**, identical to the `origin/main` baseline for those files |
| `ruff format --check` on the new test | **passes** |
| `cz check` on the PR title and all 5 commit subjects | all valid |
| `transpiler/uv.lock` | **unchanged** — no dependency edits were needed |

No test was weakened, skipped, or deleted; the only test change is an addition.

`ruff` is worth one note. It fails repo-wide on this subtree independently of this PR: 5 pre-existing `F401` errors in `backends/aider/__init__.py`, `emitters.py`, and `orchestrator.py`, and 40 of 43 Python files unformatted — this directory has never been through `ruff format`. The root pre-commit config carries the ruff hooks, this directory's own does not, and neither drift workflow runs them. Baselining `origin/main` copies of the three Python files this PR edits shows they were already in the "would reformat" set, so nothing regressed. Reformatting the subtree is its own change and is not smuggled in here.

Not touched, by request: `.github/**`, the root `pyproject.toml`, and `transpiler/_base/**`.

## Left for a follow-up

`transpiler/validate.py` still points users at `configs.yaml` in seven user-facing error hints ("Edit transpiler/_base/ or configs.yaml ..."). Same root cause as Defect 3 — a file deleted in the class-per-backend refactor — but it is a distinct surface in a file outside this change's scope, and folding it in would blur three otherwise focused commits.
