### PR TITLE
fix(test): stop a leaked stdout log handler from failing the scan-set silence test

### DIFF
--- a/tests/unit/utils/test_get_scan_set_coverage.py
+++ b/tests/unit/utils/test_get_scan_set_coverage.py
@@ -9,7 +9,7 @@ The POSIX-rooted paths that do appear (``/subdir/a.log``) are ignore-spec match
 keys, not filesystem paths -- ``igittigitt`` matches them as pattern text and
 never opens them, so they carry no Windows ``is_absolute()``/``as_uri()`` hazard.
 
-Two things about this file are worth knowing before changing it.
+Three things about this file are worth knowing before changing it.
 
 Five tests are skipped on Windows, across two distinct defects in the code under
 test. Neither is flakiness, and both reasons are spelled out in the constants
@@ -39,8 +39,18 @@ anchored at. For the two nested-marker cases that agreement is the only reason
 they pass, because the same relative path under a real source root does not
 match -- measured, not assumed. The root-level cases compile to a base of ``/``
 and do generalize, since every absolute POSIX path is under ``/``.
+
+One test takes the ``ash_records_stay_off_stdout`` fixture and the others do not.
+``test_scan_set_is_silent_by_default`` is the only one here that asserts on
+captured stdout being *empty*, and ``ASH_LOGGER`` is a process-global whose
+handlers any earlier test in the same worker may have replaced with one that
+writes to stdout. The fixture's docstring has the mechanism; the short version is
+that the assertion measures ``scan_set`` only once that handler list is pinned.
+The other two stdout tests assert that a substring is present, which extra output
+cannot break, so they are left alone.
 """
 
+import logging
 import os
 import re
 import subprocess
@@ -105,6 +115,89 @@ POSIX_ANCHORED_REWRITE = (
     "emits a corrupted '${SOURCE_DIR}gitignore'. The fix is to derive the marker "
     "from the real scan root, the same change DRIVE_ANCHORED_RULES needs."
 )
+
+
+@pytest.fixture
+def ash_records_stay_off_stdout(caplog):
+    """Give ``ASH_LOGGER`` pytest's capture handlers and nothing else, for one test.
+
+    Why this exists. ``get_scan_set`` writes through the module-global
+    ``ASH_LOGGER``, which is ``logging.getLogger("ash")`` -- one object for the
+    whole process. ``utils.log.get_logger`` defaults its ``name`` to ``"ash"``, so
+    every call reconfigures that same object: it clears the handler list, raises
+    the level to TRACE, and -- when ``show_progress`` is False -- attaches a
+    ``RichHandler`` whose ``Console`` was built with no explicit ``file`` and
+    ``stderr=False``. rich resolves ``sys.stdout`` at emit time rather than at
+    construction, so that handler writes into whichever capture fixture is active
+    in *any later test in the same worker process*, and nothing removes it.
+
+    Nine production call sites reconfigure that global logger: five in
+    ``cli/config.py``, one each in ``cli/dependencies.py``, ``cli/plugin.py`` and
+    ``cli/report.py``, and ``run_ash_scan._setup_logger``. Eight pass
+    ``show_progress=False`` outright and ``_setup_logger`` does so whenever
+    progress is off, so all nine attach the stdout handler. Two further
+    ``get_logger`` calls in ``cli/config.py`` pass an explicit ``name=`` and build
+    child loggers instead, so they are not contaminators. Any test that drives one
+    of the nine through ``CliRunner`` leaks the handler. The earliest in collection
+    order is
+    ``tests/unit/cli/test_config_commands.py::TestConfigInit::test_init_creates_config_file``,
+    and running just that test and the silence test below in one process
+    reproduces the failure: two INFO records from ``report_ignore_file_exclusions``
+    land on stdout.
+
+    Whether the leak is *visible* turns on two further process-globals this test
+    cannot see. ``cli/mcp/__init__.py`` sets ``ASH_LOG_TO_STDERR=1`` and never
+    restores it, after which every later ``get_logger`` builds a stderr Console
+    and the leaked handler is harmless; and ``cli/main.py``'s
+    ``reset_logging_config`` clears the handler list outright. Both happen to sit
+    between the contaminator and this test in serial collection order, which is
+    why the suite is green with ``-n0`` and green in most CI cells. Under xdist's
+    ``--dist load`` the worker packing decides which of the adder, the
+    stderr-flipper and the remover share a process with this test, so one commit
+    passed seventeen of eighteen matrix cells and failed the eighteenth.
+
+    What this fixture deliberately does not do. It does not reset logging for the
+    suite. A blanket autouse reset would also silence the next test that depends
+    on ambient handler state, and would paper over both leaks named above -- which
+    are worth keeping visible, because ASH's default logger writing to stdout is a
+    real product behavior and not an accident.
+
+    Rejected alternative: weakening the assertion to ``"one.py" not in out``. That
+    drops the only check that ``scan_set`` prints *nothing* when ``print_results``
+    is False, which is the entire contract of that flag, and it would still be
+    order-dependent -- the leaked handler renders the scan root's path, and a
+    tmp_path can contain any substring pytest chooses.
+
+    Known limitation. The pin covers the ``ash`` logger's handler list, level and
+    propagate flag. It does not stop a test from writing to ``sys.stdout``
+    directly, which is what the assertion is there to catch.
+    """
+    logger = gss.ASH_LOGGER
+    saved_handlers = logger.handlers
+    saved_propagate = logger.propagate
+
+    # Keep pytest's own capture handlers -- one feeds ``caplog.records``, the other
+    # the "Captured log call" report section -- and drop every other handler. Their
+    # class is read off ``caplog.handler`` so this needs no private pytest import.
+    capture_handlers = [
+        handler
+        for handler in saved_handlers
+        if isinstance(handler, type(caplog.handler))
+    ]
+    if caplog.handler not in capture_handlers:
+        capture_handlers.append(caplog.handler)
+
+    logger.handlers = capture_handlers
+    logger.propagate = False
+    # The leaked level is the third uncontrolled input: a WARNING left behind by an
+    # earlier test would drop the INFO records the positive control asserts on.
+    # set_level restores the level itself at teardown.
+    caplog.set_level(logging.INFO, logger=logger.name)
+    try:
+        yield caplog
+    finally:
+        logger.handlers = saved_handlers
+        logger.propagate = saved_propagate
 
 
 # ---------------------------------------------------------------------------
@@ -646,12 +739,30 @@ def test_scan_set_prints_each_selected_file_when_asked(tmp_path, capsys):
     assert "two.py" in out
 
 
-def test_scan_set_is_silent_by_default(tmp_path, capsys):
+def test_scan_set_is_silent_by_default(tmp_path, capsys, ash_records_stay_off_stdout):
+    """``print_results=False`` prints nothing, and the exclusion report still logs.
+
+    Both halves are asserted, because an empty stdout only means something if the
+    code that would have written to it ran. ``report_ignore_file_exclusions`` logs
+    at INFO unconditionally -- deliberately, so that a scan set which shrank after
+    an upgrade cannot shrink silently -- so its records are the positive control
+    for the emptiness above them.
+
+    That INFO record reaches stdout in a real ASH run, because ``get_logger``
+    builds its Console with ``stderr=False`` by default; ``ASH_LOG_TO_STDERR`` is
+    the switch that moves it. So "silent" here is a claim about ``print_results``,
+    not about the logger, and the fixture pins the logger so the claim can only be
+    read the one way.
+    """
     (tmp_path / "one.py").write_text("o = 1\n")
 
     scan_set(source=str(tmp_path))
 
     assert capsys.readouterr().out == ""
+    assert any(
+        "ASH_INCLUSIONS excluded 0 files from the scan set" in record.getMessage()
+        for record in ash_records_stay_off_stdout.records
+    )
 
 
 def test_scan_set_applies_a_filter_pattern_to_the_result(tmp_path):


### PR DESCRIPTION
## What was wrong

`tests/unit/utils/test_get_scan_set_coverage.py::test_scan_set_is_silent_by_default`
asserts `capsys.readouterr().out == ""`. On a pull-request branch it failed in the
`unit-test (macos-latest, py3.11)` cell under xdist worker `[gw3]`, having captured two
`INFO` records emitted from `automated_security_helper/utils/get_scan_set.py`. The other
17 of 18 matrix cells passed on the identical commit, including `ubuntu-latest, py3.11`
and the three other `macos-latest` Python versions. A second, unrelated branch hit the
same test with the same symptom earlier the same day: red in run 1, green in run 2 on
identical code, green in isolation, green with `tests/unit/utils/` run serially.

`pytest-randomly` is not installed, so order within a worker is stable. The variable is
xdist `--dist load` worker packing.

## Reproducing invocation

Deterministic, no xdist needed:

```
uv run pytest \
  "tests/unit/cli/test_config_commands.py::TestConfigInit::test_init_creates_config_file" \
  "tests/unit/utils/test_get_scan_set_coverage.py::test_scan_set_is_silent_by_default" \
  -o addopts="" -o log_cli=False -q
```

Before this change that fails with:

```
E  AssertionError: assert '[09/09/26 15... scan set  \n' == ''
E  + [09/09/26 15:16:01] INFO  No ignore files were found under
E  +                           /tmp/.../test_scan_set_is_silent_by_def0, so no ignore
E  +                           rules removed anything from the scan set.
E  +                     INFO  ASH_INCLUSIONS excluded 0 files from the scan set
```

The packing dependence is visible directly. Over the same two whole files, before this
change:

| invocation | result |
| --- | --- |
| `-n 2 --dist loadfile` | 80 passed |
| `-n 2 --dist load` | 1 failed, 79 passed |

`loadfile` keeps the two files in separate workers, so the leak never reaches the test;
`load` interleaves them into one worker and it does.

## Mechanism

`utils/get_scan_set.py` writes through the module-global `ASH_LOGGER`, which is
`logging.getLogger("ash")` — one object per process.

`utils/log.py::get_logger` defaults its `name` to `"ash"`, so every call reconfigures that
same object. It clears the handler list, raises the level to `TRACE`, and — when
`show_progress` is False — attaches a `RichHandler` whose `Console` was built with no
explicit `file` and `stderr=False`. rich resolves `sys.stdout` at emit time rather than at
construction, so that handler writes into whichever capture fixture is active in **any
later test in the same worker process**. Nothing removes it.

Nine production call sites reconfigure the global logger that way: five in
`cli/config.py`, one each in `cli/dependencies.py`, `cli/plugin.py` and `cli/report.py`,
and `interactions/run_ash_scan.py::_setup_logger`. Eight pass `show_progress=False`
outright and `_setup_logger` does so whenever progress is off. Two further `get_logger`
calls in `cli/config.py` pass an explicit `name=` and build child loggers, so they are not
contaminators. Any test driving one of the nine through `typer.testing.CliRunner` leaks
the handler; the earliest in collection order is
`tests/unit/cli/test_config_commands.py::TestConfigInit::test_init_creates_config_file`,
which is the one used above.

Two further pieces of process-global state decide whether the leak is *visible*, which is
why the serial suite is green and why the failure looked like a platform bug:

- `cli/mcp/__init__.py` sets `os.environ["ASH_LOG_TO_STDERR"] = "1"` and never restores
  it. After any MCP-path test has run in that worker, every later `get_logger` builds a
  stderr `Console` and the leaked handler is harmless. Measured: over all of
  `tests/unit/cli`, every leaked handler carries `stderr=True`.
- `cli/main.py::reset_logging_config` clears the handler list outright, and
  `tests/unit/cli/test_main_coverage.py::TestResetLoggingConfig::test_removes_handlers_from_root_logger`
  calls it.

Both happen to sit between the contaminator and this test in serial collection order.
Under `--dist load` the packing decides which of the adder, the stderr-flipper and the
remover land in the same process as the test, and in what order — so the outcome flips per
matrix cell on identical code.

`tests/conftest.py::_keep_live_logging_off_the_ash_logger` is prior scar tissue from the
same defect family; its docstring already records that "any test that clears the `ash`
logger's handlers permanently detaches the session-scoped handler for the rest of that
worker process" and that this produced a commit green on 4-worker runners and red on
3-worker ones. That fixture is session-scoped, so it cannot undo a per-test mutation.

## The fix, and why not the alternatives

The test now pins the one input it has no business reading. A new fixture,
`ash_records_stay_off_stdout`, gives `ASH_LOGGER` pytest's own capture handlers and
nothing else for the duration of the test, plus a fixed level and `propagate` flag, and
restores all three afterwards. Pytest's handlers are kept — one feeds `caplog.records`,
the other the "Captured log call" report section — by matching on `type(caplog.handler)`,
so no private pytest import is needed and failure diagnostics are preserved.

The assertion is unchanged: still `assert capsys.readouterr().out == ""`. A positive
control is added alongside it, asserting that the exclusion report was in fact logged, so
that an empty stdout cannot pass vacuously. Mutating the expected message to a string the
module never emits makes the test fail, so the control is live.

Rejected alternatives:

- **Restore the logger in each contaminating test.** This is not one test. It is nine
  production call sites and every current and future test that reaches one of them through
  `CliRunner`, which in practice means a directory-wide autouse reset that grows silently
  as CLI tests are added. It would also paper over the two leaks named above, and those
  are worth keeping visible — ASH's default logger writing to stdout is deliberate product
  behavior, not an accident.
- **Change the production logging.** `report_ignore_file_exclusions` logs at `INFO`
  unconditionally on purpose; its own docstring argues that a security scanner which
  quietly scans less after an upgrade is the worst outcome available, so the reduction must
  be reported. Moving it to stderr would contradict `get_logger`'s explicit
  `ASH_LOG_TO_STDERR` switch, whose whole point is that CLI logs belong on stdout and only
  the MCP path opts out.
- **Loosen the assertion to `"one.py" not in out`.** That drops the only coverage of
  `print_results=False`, which is the entire contract of the flag and the difference from
  the sibling test `test_scan_set_prints_each_selected_file_when_asked`. It would also
  still be order-dependent, since the leaked handler renders the scan root's path and a
  `tmp_path` can contain any substring pytest chooses.

## Proof, both directions

With the fix:

| invocation | result |
| --- | --- |
| reproducing pair, serial | 2 passed |
| reproducing pair, `-n 1 --dist load` | 2 passed |
| both whole files, `-n 2 --dist load` | 80 passed |
| both whole files, `-n 2 --dist loadfile` | 80 passed |
| `tests/unit/cli tests/unit/utils`, `-n 3 --dist load` | 1948 passed, 14 skipped |
| target test alone | 1 passed |
| whole target file | 62 passed |

With the fix reverted and nothing else changed:

| invocation | result |
| --- | --- |
| reproducing pair, serial | **1 failed**, 1 passed |
| reproducing pair, `-n 1 --dist load` | **1 failed**, 1 passed |
| both whole files, `-n 2 --dist load` | **1 failed**, 79 passed |
| both whole files, `-n 2 --dist loadfile` | 80 passed (packing hides it) |

Full suite, exactly as CI runs it (`uv sync --extra cdk` then `uv run pytest`), on
Python 3.13:

| | passed | failed | skipped | xfailed | exit |
| --- | --- | --- | --- | --- | --- |
| base (`3eac29d`) | 6039 | 0 | 117 | 3 | 0 |
| with this change | 6039 | 0 | 117 | 3 | 0 |

Counts are identical on both sides — the skip count does not move, no test was added,
removed, skipped or xfailed, and the 117 skips are the pre-existing
`--run-integration`/`--run-slow`/Windows-marker set. The base suite passes here because
this host's worker count happens to produce benign packing; that is the flake, and it is
why the deterministic pair-level proof above is the load-bearing evidence rather than a
full-suite run.

`ruff format` and `ruff check` are clean on the changed file. `cz check` passes on the
title.

## Latent instances found, and left alone

Six other assertions in the suite have the same shape — exact equality against empty
captured output:

- `tests/unit/cli/mcp/test_stdout_jsonrpc_safety.py` lines 124, 137, 147, 191
- `tests/unit/interactions/test_run_ash_scan_workspace_coverage.py` line 612

All six were paired with the contaminator and measured: all pass. The MCP cases exit
through paths that write with `typer.secho(..., err=True)` rather than through
`ASH_LOGGER`, and `mcp_command` sets `ASH_LOG_TO_STDERR` on the way; the workspace case
runs `_print_workspace_summary` with `quiet=True`, which emits no `INFO` record. They are
the same shape but not currently reachable, so they are reported rather than changed —
the fix here is a fixture and a docstring, not a one-line edit that could be applied to
them mechanically. If any of those code paths later starts logging through `ASH_LOGGER`,
they become live and the same fixture applies.

The other two `capsys` tests in the changed file,
`test_scan_set_prints_each_selected_file_when_asked` and
`test_main_scans_the_requested_source_and_returns_zero`, assert that a substring is
present. Extra output cannot break those, so they are untouched.

## Why this matters beyond the one test

This test is currently red on the `ASH - Unified CI` required check for two other open
pull requests, both of which add tests elsewhere and so shift the xdist packing. Landing
this unblocks them without either of them having to carry an unrelated test change.
