### PR TITLE
fix(scanners): probe a uv tool's version once, not once per project

### DIFF
--- a/automated_security_helper/base/uv_tool_mixin.py
+++ b/automated_security_helper/base/uv_tool_mixin.py
@@ -33,6 +33,30 @@ class UVToolMixin:
     # Version detection
     # ------------------------------------------------------------------
 
+    def _uv_from_spec(self) -> Optional[str]:
+        """The ``--from`` spec this plugin's scan will run under.
+
+        Mirrors the construction in ``UVToolRunner.run_tool``, which builds the
+        spec from ``self.command`` plus this plugin's extras and version
+        constraint. Returns ``None`` when the scan passes no ``--from`` at all,
+        so the probe matches that too.
+
+        Why the probe needs this: ``uv tool run bandit`` and
+        ``uv tool run --from 'bandit[sarif,toml]>=1.7.0,<2.0.0' bandit`` resolve
+        to different environments. stevedore's entry-point cache is keyed on
+        ``sys.executable`` and ``sys.prefix``, so those two invocations warm two
+        different cache files -- and a probe that warms the wrong one leaves the
+        scan's file cold for N concurrent scanners to race, which is the whole
+        problem serializing the probe was meant to remove. Measured directly:
+        one workspace scan produced five distinct bandit environments.
+        """
+        extras = self._get_tool_package_extras()
+        constraint = self._get_tool_version_constraint()
+        if not extras and not constraint:
+            return None
+        base = f"{self.command}[{','.join(extras)}]" if extras else self.command
+        return f"{base}{constraint}" if constraint else base
+
     def _get_uv_tool_version(
         self, tool_name: str, package_name: Optional[str] = None
     ) -> Optional[str]:
@@ -40,10 +64,15 @@ class UVToolMixin:
 
         Args:
             tool_name: Name of the tool to get version for
+            package_name: ``--from`` spec to probe under. When omitted, defaults
+                to :meth:`_uv_from_spec` so the probe shares an environment --
+                and therefore an entry-point cache file -- with the scan.
 
         Returns:
             Version string if detected, None if version cannot be determined or UV is not available
         """
+        if package_name is None:
+            package_name = self._uv_from_spec()
         if not self.use_uv_tool:
             self._plugin_log(
                 f"UV tool execution is disabled for {tool_name}",
@@ -595,8 +624,14 @@ class UVToolMixin:
 
                 clear_find_executable_cache()
 
+                # Second argument is the ``--from`` spec, a string. This passed
+                # ``package_extras`` (a list) until now, which raised TypeError
+                # inside the probe and was swallowed by the broad except below,
+                # so the version silently read as unknown. After memoization it
+                # was worse: the failure was cached under the key
+                # "bandit::['sarif', 'toml']" and served to later callers.
                 post_install_version = runner.get_installed_tool_version(
-                    self.command, package_extras
+                    self.command, self._uv_from_spec()
                 )
 
                 self._plugin_log(

--- a/automated_security_helper/utils/uv_tool_runner.py
+++ b/automated_security_helper/utils/uv_tool_runner.py
@@ -93,7 +93,11 @@ class UVToolRunner:
         return tool_name in installed_tools
 
     def get_tool_version(
-        self, tool_name: str, package_name: Optional[str] = None
+        self,
+        tool_name: str,
+        package_name: Optional[str] = None,
+        *,
+        refresh: bool = False,
     ) -> Optional[str]:
         """Get version of a UV tool.
 
@@ -109,6 +113,22 @@ class UVToolRunner:
         first-imports can leave behind a cache that parses but holds a
         wrong-arity entry, which breaks the tool for every later process on the
         machine. One probe means one writer.
+
+        ``package_name`` is the ``--from`` specification. Passing the SAME spec
+        the scan will use matters: ``uv tool run bandit`` and
+        ``uv tool run --from 'bandit[sarif,toml]>=1.7.0,<2.0.0' bandit`` resolve
+        to different environments, and stevedore's digest is over
+        ``sys.executable`` and ``sys.prefix``, so they warm different cache
+        files. A probe that warms the wrong file leaves the scan's file cold for
+        N concurrent scanners. Callers should pass the scan's spec;
+        ``UVToolMixin._get_uv_tool_version`` does this by default.
+
+        Failures are memoized too, deliberately -- caching only successes would
+        reopen the concurrent-probe window on exactly the path where a slow cold
+        start makes it most likely. Because that means one transient failure is
+        then served process-wide, ``refresh=True`` forces a re-probe and
+        overwrites the memo; ``validate_cached_tool`` uses it so a probe that
+        merely timed out cannot permanently declare a working tool broken.
         """
         if not self.is_uv_available():
             return None
@@ -116,11 +136,11 @@ class UVToolRunner:
         cache_key = f"{tool_name}::{package_name or ''}"
 
         with _uv_tool_runner_cache_lock:
-            if cache_key in _uv_tool_version_cache:
+            if not refresh and cache_key in _uv_tool_version_cache:
                 return _uv_tool_version_cache[cache_key]
             # Bind to a local and keep it alive until after the acquire below;
             # the registry holds locks weakly. See _get_or_create_probe_lock.
-            probe_lock = _get_or_create_probe_lock(cache_key)
+            probe_lock = _get_or_create_probe_lock(f"version::{cache_key}")
 
         # Held across the subprocess so a second thread on this key waits for
         # the first probe rather than starting its own. The coarse cache lock is
@@ -128,7 +148,7 @@ class UVToolRunner:
         # in parallel.
         with probe_lock:
             with _uv_tool_runner_cache_lock:
-                if cache_key in _uv_tool_version_cache:
+                if not refresh and cache_key in _uv_tool_version_cache:
                     return _uv_tool_version_cache[cache_key]
 
             version: Optional[str] = None
@@ -150,7 +170,7 @@ class UVToolRunner:
                     command,
                     capture_output=True,
                     text=True,
-                    timeout=15,
+                    timeout=_UV_TOOL_VERSION_PROBE_TIMEOUT,
                     check=False,
                     encoding="utf-8",
                     errors="replace",
@@ -595,7 +615,11 @@ class UVToolRunner:
 
         try:
             # Try to get version to validate functionality
-            version = self.get_tool_version(tool_name, package_name)
+            # refresh=True: this is the caller that decides whether a tool is
+            # broken, so it must not inherit a memoized failure. A probe that
+            # merely timed out would otherwise make every later caller report
+            # is_functional=False for a tool that works.
+            version = self.get_tool_version(tool_name, package_name, refresh=True)
             if version:
                 validation_result["is_functional"] = True
                 validation_result["version"] = version
@@ -659,7 +683,7 @@ _executable_cache: Dict[str, Optional[str]] = {}
 # populates that cache and every other reads it. See #542.
 _uv_tool_version_cache: Dict[str, Optional[str]] = {}
 
-# Coarse lock guarding the three module-level cache dicts above. This lock
+# Coarse lock guarding the four module-level cache dicts above. This lock
 # is only held across in-memory reads/writes; it is NOT held across the
 # subprocess probe. See `_get_or_create_probe_lock` below for the per-key
 # lock used to dedupe concurrent probes for the same `(tool, fallback)`
@@ -687,18 +711,37 @@ _uv_tool_probe_locks: "_weakref.WeakValueDictionary[str, threading.Lock]" = (
 # scanners with no progress reporting (DA r4 #5).
 _UV_VERSION_PROBE_TIMEOUT = 5
 
+# Timeout for ``UVToolRunner.get_tool_version``. Higher than the constant above
+# on purpose, and the two are not merged. That probe resolves a bare tool name;
+# this one resolves a full ``--from`` spec with extras and a version constraint,
+# which on a cold uv cache means materializing an environment.
+#
+# Kept at its historical 15s rather than lowered now that the probe is
+# serialized. It is true that this is now the whole workspace's stall budget
+# instead of one project's -- but it is one 15s worst case for the workspace
+# where it used to be N of them, so serializing already improved the bound.
+# Lowering it would trade that for a higher rate of memoized failures, and a
+# memoized failure is now served process-wide (see ``refresh``), which costs the
+# tool version in every project's report.
+_UV_TOOL_VERSION_PROBE_TIMEOUT = 15
+
 
 def _get_or_create_probe_lock(cache_key: str) -> threading.Lock:
     """Return the per-key probe lock for ``cache_key``, creating it if needed.
 
+    ``cache_key`` must be namespaced by caller (``version::``, ``command::``).
+    Two callers building the same string share a lock, and these are plain
+    non-reentrant ``threading.Lock``, so an accidental collision between two
+    probes that can call into each other is a deadlock rather than a slowdown.
+
     STRONG-REF CONTRACT: ``_uv_tool_probe_locks`` holds its values weakly, so
-    the caller MUST bind the returned lock to a local and keep that local alive
-    until after it has acquired the lock. Acquiring on a temporary (for example
-    ``with _get_or_create_probe_lock(k):`` is fine, but re-calling this helper
-    to acquire a second time is not) risks the lock being collected between the
-    dict write here and a later acquire, at which point a concurrent thread on
-    the same key would create a *different* lock and the per-key serialization
-    would silently stop working.
+    the caller must keep a reference to the returned lock alive until it has
+    acquired it -- binding it to a local, as both callers here do, is enough. If
+    the only reference were dropped before the acquire, a concurrent thread on
+    the same key could create a *different* lock object and the per-key
+    serialization would silently stop working. This contract is asserted by
+    inspection, not by a test: a test written in the obvious way holds a strong
+    reference itself and so cannot fail.
 
     Must be called with ``_uv_tool_runner_cache_lock`` held, so that two
     threads racing on the same key agree on one lock object.
@@ -710,15 +753,48 @@ def _get_or_create_probe_lock(cache_key: str) -> threading.Lock:
     return probe_lock
 
 
-def invalidate_tool_version_cache(tool_name: str) -> None:
-    """Forget memoized ``--version`` answers for ``tool_name``.
+def _requirement_base_name(spec: str) -> str:
+    """The bare package name at the front of a requirement spec.
 
-    Call after installing or upgrading a tool. Keys are ``tool::package``, so
-    every package spelling for this tool is dropped.
+    ``bandit[sarif,toml]>=1.7.0,<2.0.0`` -> ``bandit``. Used so an invalidation
+    naming a package still matches memo keys whose ``--from`` segment carries
+    extras and a version constraint.
     """
-    prefix = f"{tool_name}::"
+    for index, char in enumerate(spec):
+        if char in "[]<>=!~;, ":
+            return spec[:index].strip()
+    return spec.strip()
+
+
+def invalidate_tool_version_cache(name: str) -> None:
+    """Forget memoized ``--version`` answers for a tool, by either of its names.
+
+    Matching on a single spelling is not enough. A memo key is
+    ``"<command>::<from-spec>"``, but the name reaching
+    ``install_tool_with_version`` is ``uv_tool_package_name or command``
+    (``UVToolMixin._install_uv_tool``), so the installer often knows the tool by
+    its *package* name while the probe keyed on its *command* name. For
+    JupyterConverter those differ -- command ``jupyter-nbconvert``, package
+    ``nbconvert`` -- so a prefix match on the package name cleared nothing and
+    the pre-install ``None`` survived the install it was supposed to be
+    invalidated by.
+
+    So compare against both segments of the key, and against the bare package
+    name of each, since the ``--from`` segment carries extras and constraints.
+    """
     with _uv_tool_runner_cache_lock:
-        for key in [k for k in _uv_tool_version_cache if k.startswith(prefix)]:
+        doomed = []
+        for key in _uv_tool_version_cache:
+            command_segment, _, from_segment = key.partition("::")
+            candidates = {
+                command_segment,
+                from_segment,
+                _requirement_base_name(command_segment),
+                _requirement_base_name(from_segment),
+            }
+            if name in candidates or _requirement_base_name(name) in candidates:
+                doomed.append(key)
+        for key in doomed:
             del _uv_tool_version_cache[key]
 
 
@@ -790,21 +866,13 @@ def get_uv_tool_command(
         if cache_key in _uv_command_cache:
             return _uv_command_cache[cache_key]
         # Get-or-create the per-key probe lock under the coarse lock so two
-        # threads racing here see the same lock object.
-        #
-        # STRONG-REF CONTRACT (DA r6 #6): the local `probe_lock` variable
-        # MUST stay in scope until after the `with probe_lock:` acquire
-        # below. The WeakValueDictionary holds the lock by weak reference;
-        # without a stack-frame strong reference, GC could collect the
-        # lock between the dict-write here and the acquire below, and a
-        # concurrent thread on the same cache key would create a NEW
-        # lock — defeating the per-key serialization. Do NOT refactor
-        # this block to return the lock from a helper without giving the
-        # caller a strong ref before the acquire.
-        probe_lock = _uv_tool_probe_locks.get(cache_key)
-        if probe_lock is None:
-            probe_lock = threading.Lock()
-            _uv_tool_probe_locks[cache_key] = probe_lock
+        # threads racing here see the same lock object. STRONG-REF CONTRACT
+        # (DA r6 #6): `probe_lock` must stay in scope until after the acquire
+        # below -- see _get_or_create_probe_lock. The `command::` prefix keeps
+        # these keys disjoint from get_tool_version's; without it,
+        # get_tool_version("bandit", "bandit") and get_uv_tool_command("bandit")
+        # both produce "bandit::bandit" and share a non-reentrant lock.
+        probe_lock = _get_or_create_probe_lock(f"command::{cache_key}")
 
     # Per-key lock: serialize probes for THIS cache key without blocking
     # probes for other cache keys. The coarse cache lock is NOT held here,

--- a/automated_security_helper/utils/uv_tool_runner.py
+++ b/automated_security_helper/utils/uv_tool_runner.py
@@ -95,42 +95,77 @@ class UVToolRunner:
     def get_tool_version(
         self, tool_name: str, package_name: Optional[str] = None
     ) -> Optional[str]:
-        """Get version of a UV tool."""
+        """Get version of a UV tool.
+
+        Memoized and serialized per ``(tool_name, package_name)``: concurrent
+        callers asking about the same tool produce exactly ONE
+        ``uv tool run <tool> --version`` subprocess, and every later caller
+        reads the remembered answer.
+
+        Probing once is load-bearing, not just faster. See the comment on
+        ``_uv_tool_version_cache``: the probe imports the tool, a stevedore-based
+        tool builds a shared per-user entry-point cache on first import, and
+        stevedore writes that cache non-atomically and unlocked. N concurrent
+        first-imports can leave behind a cache that parses but holds a
+        wrong-arity entry, which breaks the tool for every later process on the
+        machine. One probe means one writer.
+        """
         if not self.is_uv_available():
             return None
 
-        try:
-            command = [self.uv_executable, "tool", "run"]
+        cache_key = f"{tool_name}::{package_name or ''}"
 
-            # Build command with --from parameter if extras specified
-            if package_name:
-                # Build the --from specification
-                command.extend(
-                    [
-                        "--from",
-                        package_name,
-                    ]
+        with _uv_tool_runner_cache_lock:
+            if cache_key in _uv_tool_version_cache:
+                return _uv_tool_version_cache[cache_key]
+            # Bind to a local and keep it alive until after the acquire below;
+            # the registry holds locks weakly. See _get_or_create_probe_lock.
+            probe_lock = _get_or_create_probe_lock(cache_key)
+
+        # Held across the subprocess so a second thread on this key waits for
+        # the first probe rather than starting its own. The coarse cache lock is
+        # deliberately NOT held here, so probes for *different* tools still run
+        # in parallel.
+        with probe_lock:
+            with _uv_tool_runner_cache_lock:
+                if cache_key in _uv_tool_version_cache:
+                    return _uv_tool_version_cache[cache_key]
+
+            version: Optional[str] = None
+            try:
+                command = [self.uv_executable, "tool", "run"]
+
+                # Build command with --from parameter if extras specified
+                if package_name:
+                    # Build the --from specification
+                    command.extend(
+                        [
+                            "--from",
+                            package_name,
+                        ]
+                    )
+
+                command.extend([tool_name, "--version"])
+                result = subprocess.run(  # nosec B603 — list args, validated uv executable path
+                    command,
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    check=False,
+                    encoding="utf-8",
+                    errors="replace",
                 )
 
-            command.extend([tool_name, "--version"])
-            result = subprocess.run(  # nosec B603 — list args, validated uv executable path
-                command,
-                capture_output=True,
-                text=True,
-                timeout=15,
-                check=False,
-                encoding="utf-8",
-                errors="replace",
-            )
+                if result.returncode == 0 and result.stdout.strip():
+                    version_line = result.stdout.strip().split("\n")[0]
+                    version = version_line.strip()
 
-            if result.returncode == 0 and result.stdout.strip():
-                version_line = result.stdout.strip().split("\n")[0]
-                return version_line.strip()
+            except Exception:  # nosec B110 — version check failure is non-critical
+                version = None
 
-        except Exception:  # nosec B110 — version check failure is non-critical
-            pass
-
-        return None
+            with _uv_tool_runner_cache_lock:
+                _uv_tool_version_cache[cache_key] = version
+            return version
 
     def get_installed_tool_version(
         self, tool_name: str, package_name: Optional[str] = None
@@ -254,6 +289,12 @@ class UVToolRunner:
             # Stop progress monitoring
             if progress_thread:
                 progress_thread = None
+
+            # Installing is exactly the event that makes a remembered version
+            # wrong, so drop this tool's memoized probe result. Without this, a
+            # caller that probed before installing (converters re-read
+            # tool_version afterwards) would keep seeing the pre-install answer.
+            invalidate_tool_version_cache(tool_name)
 
             return True
         except subprocess.TimeoutExpired as e:
@@ -599,6 +640,25 @@ _uv_command_cache: Dict[str, Optional[List[str]]] = {}
 _uv_executable_cache: Dict[str, Optional[str]] = {}
 _executable_cache: Dict[str, Optional[str]] = {}
 
+# ``uv tool run <tool> --version`` results, keyed by ``tool::package``.
+#
+# Memoizing this is not only a speed-up. The probe *runs the tool*, and a tool
+# that loads plugins through ``stevedore`` populates a per-user entry-point
+# cache at ``$XDG_CACHE_HOME/python-entrypoints/<digest>`` on first import.
+# stevedore writes that file with a plain truncating ``open(path, 'w')`` and no
+# lock, and the JSON it writes orders groups by iterating a *set*, so two
+# processes emit byte streams of the SAME length but DIFFERENT content. Two
+# concurrent first-imports therefore interleave at the 8 KiB buffer flush
+# boundary and can leave a file that still parses as JSON but holds an entry
+# whose tuple arity is not 3 -- at which point every later reader of that cache
+# dies in ``stevedore/_cache.py`` with ``TypeError: EntryPoint.__init__()``.
+#
+# ASH constructs one scanner per project, and each construction probed the
+# version, so an N-project workspace scan fired N concurrent cold-start
+# imports of the same tool. Probing once per key means exactly one process ever
+# populates that cache and every other reads it. See #542.
+_uv_tool_version_cache: Dict[str, Optional[str]] = {}
+
 # Coarse lock guarding the three module-level cache dicts above. This lock
 # is only held across in-memory reads/writes; it is NOT held across the
 # subprocess probe. See `_get_or_create_probe_lock` below for the per-key
@@ -628,12 +688,47 @@ _uv_tool_probe_locks: "_weakref.WeakValueDictionary[str, threading.Lock]" = (
 _UV_VERSION_PROBE_TIMEOUT = 5
 
 
+def _get_or_create_probe_lock(cache_key: str) -> threading.Lock:
+    """Return the per-key probe lock for ``cache_key``, creating it if needed.
+
+    STRONG-REF CONTRACT: ``_uv_tool_probe_locks`` holds its values weakly, so
+    the caller MUST bind the returned lock to a local and keep that local alive
+    until after it has acquired the lock. Acquiring on a temporary (for example
+    ``with _get_or_create_probe_lock(k):`` is fine, but re-calling this helper
+    to acquire a second time is not) risks the lock being collected between the
+    dict write here and a later acquire, at which point a concurrent thread on
+    the same key would create a *different* lock and the per-key serialization
+    would silently stop working.
+
+    Must be called with ``_uv_tool_runner_cache_lock`` held, so that two
+    threads racing on the same key agree on one lock object.
+    """
+    probe_lock = _uv_tool_probe_locks.get(cache_key)
+    if probe_lock is None:
+        probe_lock = threading.Lock()
+        _uv_tool_probe_locks[cache_key] = probe_lock
+    return probe_lock
+
+
+def invalidate_tool_version_cache(tool_name: str) -> None:
+    """Forget memoized ``--version`` answers for ``tool_name``.
+
+    Call after installing or upgrading a tool. Keys are ``tool::package``, so
+    every package spelling for this tool is dropped.
+    """
+    prefix = f"{tool_name}::"
+    with _uv_tool_runner_cache_lock:
+        for key in [k for k in _uv_tool_version_cache if k.startswith(prefix)]:
+            del _uv_tool_version_cache[key]
+
+
 def _reset_uv_tool_runner_caches() -> None:
     """Reset module-level caches (mainly for testing)."""
     with _uv_tool_runner_cache_lock:
         _uv_command_cache.clear()
         _uv_executable_cache.clear()
         _executable_cache.clear()
+        _uv_tool_version_cache.clear()
 
 
 def find_uv_or_none() -> Optional[str]:

--- a/scripts/verify_multi_project_attribution.py
+++ b/scripts/verify_multi_project_attribution.py
@@ -458,10 +458,31 @@ class GateOutcome:
     projects: Tuple[ProjectOutcome, ...] = ()
     runs: Tuple[RunEvidence, ...] = ()
     scanner_statuses: Dict[str, str] = field(default_factory=dict)
+    #: Violations that explain other violations. A scanner reporting ERROR
+    #: produced no findings, so every downstream "rule X is missing from project
+    #: Y" and "two thresholds saw equal counts" follows from it rather than being
+    #: an independent defect. Reporting one dead scanner as ten problems sends
+    #: the reader chasing nine symptoms. Kept as a subset of ``violations`` so
+    #: ``passed`` and the exit status are unchanged.
+    root_violations: List[str] = field(default_factory=list)
 
     @property
     def passed(self) -> bool:
         return not self.violations
+
+    @property
+    def consequential_violations(self) -> List[str]:
+        """Violations that are not themselves a named root cause."""
+        roots = set(self.root_violations)
+        return [v for v in self.violations if v not in roots]
+
+    @property
+    def errored_scanners(self) -> List[str]:
+        return sorted(
+            name
+            for name, status in self.scanner_statuses.items()
+            if status == STATUS_ERROR
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1458,7 +1479,12 @@ def evaluate_results(
     # marker, the attribution checks below cannot fail and say nothing about it.
     outcome.violations.extend(check_the_fixture_can_discriminate())
     outcome.violations.extend(check_every_project_ran(projects))
-    outcome.violations.extend(check_no_scanner_errors(statuses))
+    scanner_errors = check_no_scanner_errors(statuses)
+    outcome.violations.extend(scanner_errors)
+    # A dead scanner explains the marker-rule, suppression and threshold
+    # violations below, so name it as the root cause rather than letting it sit
+    # first in a flat list of ten.
+    outcome.root_violations.extend(scanner_errors)
     outcome.violations.extend(check_one_run_per_project(projects, runs))
     outcome.violations.extend(check_findings_are_attributed_to_their_own_project(runs))
     outcome.violations.extend(check_each_project_shows_only_its_own_marker_rule(runs))
@@ -1696,6 +1722,52 @@ def _print_block(title: str, body: Any) -> None:
     print(sanitize_for_console(text))
 
 
+def find_scanner_error_logs(output_dir: Path, scanner: str) -> List[Path]:
+    """Every stderr log a scanner wrote, across projects and target types.
+
+    ASH sends each scanner's stderr to
+    ``projects/<project>/scanners/<scanner>/<target>/<Name>Scanner.stderr.log``.
+    When a scanner dies at import, that file holds the whole traceback while the
+    aggregated results hold only ``status: ERROR``. The gate used to print
+    neither, so the one artifact naming the cause went unread and every failure
+    of this kind cost a round trip into the uploaded evidence.
+    """
+    scanner_dir = output_dir / "projects"
+    if not scanner_dir.is_dir():
+        return []
+    return sorted(scanner_dir.glob(f"*/scanners/{scanner}/*/*.stderr.log"))
+
+
+def print_scanner_error_evidence(output_dir: Path, scanners: Sequence[str]) -> None:
+    """Print, in full, the stderr of each scanner that reported ERROR.
+
+    Deliberately not tail-truncated: the useful frames of an import-time
+    traceback are the *last* ones, but the deepest frame is what names the
+    failing library, and a tail cut mid-frame is what makes these reports
+    unactionable. Identical logs are collapsed, since a workspace scan runs the
+    same tool once per project and typically fails the same way in each.
+    """
+    for scanner in scanners:
+        logs = find_scanner_error_logs(output_dir, scanner)
+        if not logs:
+            print(
+                f"--- scanner '{scanner}' reported ERROR but wrote no stderr log "
+                f"under {output_dir / 'projects'} ---"
+            )
+            continue
+        by_content: Dict[str, List[Path]] = {}
+        for log in logs:
+            try:
+                body = log.read_text(encoding="utf-8", errors="replace")
+            except OSError as err:  # pragma: no cover - unreadable evidence
+                body = f"<could not read {log}: {err}>"
+            by_content.setdefault(body, []).append(log)
+        for body, paths in by_content.items():
+            shown = ", ".join(str(p.relative_to(output_dir)) for p in paths)
+            suffix = f" (identical in {len(paths)} projects)" if len(paths) > 1 else ""
+            _print_block(f"scanner '{scanner}' stderr{suffix}: {shown}", body)
+
+
 def _configure_stdout_for_utf8() -> None:
     for stream in (sys.stdout, sys.stderr):
         reconfigure = getattr(stream, "reconfigure", None)
@@ -1824,10 +1896,35 @@ def main(argv: Iterable[str] | None = None) -> int:
             succeeded = True
             return 0
 
-        print(f"FAIL: {len(outcome.violations)} problem(s) found")
-        for violation in outcome.violations:
-            print(f"  - {violation}")
+        roots = outcome.root_violations
+        downstream = outcome.consequential_violations
+        if roots:
+            print(
+                f"FAIL: {len(outcome.violations)} problem(s) found -- "
+                f"{len(roots)} root cause, {len(downstream)} likely consequence(s)"
+            )
+            print()
+            print("ROOT CAUSE:")
+            for violation in roots:
+                print(f"  - {violation}")
+            if downstream:
+                print()
+                print(
+                    "DOWNSTREAM of the above -- a scanner that reported ERROR "
+                    "produced no findings, so these should clear once the root "
+                    "cause is fixed, and are not evidence of separate defects:"
+                )
+                for violation in downstream:
+                    print(f"  - {violation}")
+        else:
+            print(f"FAIL: {len(outcome.violations)} problem(s) found")
+            for violation in outcome.violations:
+                print(f"  - {violation}")
         print()
+        # The scanner's own stderr log names the cause; the aggregated results
+        # only say ERROR. Print it before the scan's console output, which is
+        # tail-truncated and much noisier.
+        print_scanner_error_evidence(output_dir, outcome.errored_scanners)
         _print_block("scan stdout (tail)", _tail(completed.stdout))
         _print_block("scan stderr (tail)", _tail(completed.stderr))
         return 1

--- a/scripts/verify_multi_project_attribution.py
+++ b/scripts/verify_multi_project_attribution.py
@@ -1722,6 +1722,31 @@ def _print_block(title: str, body: Any) -> None:
     print(sanitize_for_console(text))
 
 
+#: Cap on a single scanner stderr log printed as evidence. Generous enough that
+#: no real traceback is touched, small enough that a pathological log cannot push
+#: the scan stdout/stderr blocks after it past a truncated job log. "Not tailed"
+#: and "unbounded" are separable, and only the first is wanted.
+SCANNER_LOG_PRINT_BUDGET_BYTES = 200_000
+
+
+def _clamp_keeping_both_ends(text: str, budget: int) -> str:
+    """Trim the middle, never the ends.
+
+    A tail cut loses the head; a head cut loses the deepest frame and the
+    exception line. When a log has to be trimmed at all, the ends are the part
+    worth keeping, so the middle goes and says how much it took.
+    """
+    if len(text) <= budget:
+        return text
+    half = budget // 2
+    omitted = len(text) - (half * 2)
+    return (
+        text[:half]
+        + f"\n\n... {omitted} byte(s) omitted from the middle of this log ...\n\n"
+        + text[-half:]
+    )
+
+
 def find_scanner_error_logs(output_dir: Path, scanner: str) -> List[Path]:
     """Every stderr log a scanner wrote, across projects and target types.
 
@@ -1744,8 +1769,11 @@ def print_scanner_error_evidence(output_dir: Path, scanners: Sequence[str]) -> N
     Deliberately not tail-truncated: the useful frames of an import-time
     traceback are the *last* ones, but the deepest frame is what names the
     failing library, and a tail cut mid-frame is what makes these reports
-    unactionable. Identical logs are collapsed, since a workspace scan runs the
-    same tool once per project and typically fails the same way in each.
+    unactionable. Bounded rather than unbounded, though -- a log over
+    ``SCANNER_LOG_PRINT_BUDGET_BYTES`` loses its middle, not either end, so the
+    blocks printed after it still reach a truncated job log. Identical logs are
+    collapsed, since a workspace scan runs the same tool once per project and
+    typically fails the same way in each.
     """
     for scanner in scanners:
         logs = find_scanner_error_logs(output_dir, scanner)
@@ -1765,7 +1793,10 @@ def print_scanner_error_evidence(output_dir: Path, scanners: Sequence[str]) -> N
         for body, paths in by_content.items():
             shown = ", ".join(str(p.relative_to(output_dir)) for p in paths)
             suffix = f" (identical in {len(paths)} projects)" if len(paths) > 1 else ""
-            _print_block(f"scanner '{scanner}' stderr{suffix}: {shown}", body)
+            _print_block(
+                f"scanner '{scanner}' stderr{suffix}: {shown}",
+                _clamp_keeping_both_ends(body, SCANNER_LOG_PRINT_BUDGET_BYTES),
+            )
 
 
 def _configure_stdout_for_utf8() -> None:

--- a/tests/unit/base/test_uv_tool_mixin.py
+++ b/tests/unit/base/test_uv_tool_mixin.py
@@ -725,3 +725,69 @@ class TestIsOfflineMode:
             "automated_security_helper.core.constants.is_offline_mode", return_value=False
         ):
             assert plugin._is_offline_mode() is False
+
+
+class SpecPlugin(FakePlugin):
+    """A plugin whose scan runs under extras and a version constraint."""
+
+    def _get_tool_package_extras(self):
+        return ["sarif", "toml"]
+
+    def _get_tool_version_constraint(self):
+        return ">=1.7.0,<2.0.0"
+
+
+class TestProbeSharesTheScansEnvironment:
+    """The probe must run under the same ``--from`` spec as the scan.
+
+    ``uv tool run bandit`` and
+    ``uv tool run --from 'bandit[sarif,toml]>=1.7.0,<2.0.0' bandit`` resolve to
+    different environments. stevedore's entry-point cache is keyed on
+    ``sys.executable`` and ``sys.prefix``, so those warm two different cache
+    files -- and a probe that warms the wrong one leaves the scan's file cold for
+    N concurrent scanners to race. Serializing the probe then removes nothing.
+    Measured directly: one workspace scan produced five distinct bandit
+    environments.
+    """
+
+    def test_the_spec_matches_what_run_tool_builds(self):
+        """Same string the scan path passes as --from, or the guarantee is void."""
+        plugin = SpecPlugin(command="bandit")
+        assert plugin._uv_from_spec() == "bandit[sarif,toml]>=1.7.0,<2.0.0"
+
+    def test_no_extras_and_no_constraint_means_no_from(self):
+        """The scan passes no --from either, so the probe must not invent one."""
+        assert FakePlugin(command="bandit")._uv_from_spec() is None
+
+    def test_the_probe_is_given_the_scans_spec_by_default(self):
+        plugin = SpecPlugin(command="bandit")
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.get_uv_tool_runner"
+        ) as mock_get_runner:
+            mock_runner = MagicMock()
+            mock_runner.is_uv_available.return_value = True
+            mock_runner.get_tool_version.return_value = "bandit 1.9.4"
+            mock_get_runner.return_value = mock_runner
+
+            plugin._get_uv_tool_version("bandit")
+
+            mock_runner.get_tool_version.assert_called_once_with(
+                "bandit", "bandit[sarif,toml]>=1.7.0,<2.0.0"
+            )
+
+    def test_an_explicit_package_name_still_wins(self):
+        """JupyterConverter passes 'nbconvert' on purpose; do not override it."""
+        plugin = SpecPlugin(command="jupyter-nbconvert")
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.get_uv_tool_runner"
+        ) as mock_get_runner:
+            mock_runner = MagicMock()
+            mock_runner.is_uv_available.return_value = True
+            mock_runner.get_tool_version.return_value = "7.16.0"
+            mock_get_runner.return_value = mock_runner
+
+            plugin._get_uv_tool_version("jupyter-nbconvert", "nbconvert")
+
+            mock_runner.get_tool_version.assert_called_once_with(
+                "jupyter-nbconvert", "nbconvert"
+            )

--- a/tests/unit/test_multi_project_attribution_gate.py
+++ b/tests/unit/test_multi_project_attribution_gate.py
@@ -1074,3 +1074,132 @@ class TestWorkflowWiring:
         ]
         assert uploads
         assert any("failure()" in str(step.get("if", "")) for step in uploads)
+
+
+class TestOneDeadScannerIsReportedAsOneProblem:
+    """A dead scanner is one root cause, not ten independent defects.
+
+    When bandit dies, only checkov findings survive, so every B-prefixed marker
+    vanishes, the suppression probes find nothing, and the two thresholds see
+    identical sets. Reporting those as peers of the ERROR sends the reader
+    chasing symptoms. The counts and the exit status do not change -- only how
+    the list is grouped.
+    """
+
+    def test_healthy_results_name_no_root_cause(self, healthy, output_dir):
+        outcome = _evaluate(healthy, output_dir, exit_code=2, repo_root=REPO_ROOT)
+        assert outcome.passed
+        assert outcome.root_violations == []
+        assert outcome.errored_scanners == []
+
+    def test_a_scanner_error_is_the_single_root_cause(self, healthy, output_dir):
+        healthy["scanner_results"]["bandit"]["status"] = "ERROR"
+        outcome = _evaluate(healthy, output_dir, exit_code=2, repo_root=REPO_ROOT)
+
+        assert outcome.errored_scanners == ["bandit"]
+        assert len(outcome.root_violations) == 1
+        assert "reported status ERROR" in outcome.root_violations[0]
+        # The root cause is reported once, not twice, and the split is a
+        # partition of the full list -- nothing invented, nothing dropped.
+        assert set(outcome.root_violations) <= set(outcome.violations)
+        assert len(outcome.consequential_violations) == len(outcome.violations) - 1
+        assert (
+            outcome.root_violations[0] not in outcome.consequential_violations
+        )
+
+    def test_the_downstream_marker_failures_are_not_root_causes(
+        self, healthy, output_dir
+    ):
+        """The nine consequences of one dead scanner must not be named as causes."""
+        healthy["scanner_results"]["bandit"]["status"] = "ERROR"
+        for run in healthy["sarif"]["runs"]:
+            run["results"] = []
+        outcome = _evaluate(healthy, output_dir, exit_code=2, repo_root=REPO_ROOT)
+        assert len(outcome.violations) > 1
+        assert len(outcome.root_violations) == 1
+        assert any("marker rule" in v for v in outcome.consequential_violations)
+
+
+class TestScannerErrorEvidenceIsSurfaced:
+    """The gate must print the log that names the cause.
+
+    The aggregated results record only ``status: ERROR``. ASH writes the
+    traceback to the scanner's own stderr log, which the gate uploaded but never
+    printed -- so the one artifact explaining the failure went unread.
+    """
+
+    TRACEBACK = (
+        "Traceback (most recent call last):\n"
+        '  File "/home/runner/.local/share/uv/tools/bandit/bin/bandit", line 4\n'
+        "    from bandit.cli.main import main\n"
+        '  File ".../stevedore/_cache.py", line 193, in get_group_all\n'
+        "    result.append(importlib.metadata.EntryPoint(*vals))\n"
+        "TypeError: EntryPoint.__init__() missing 2 required positional "
+        "arguments: 'value' and 'group'\n"
+    )
+
+    def _write_logs(self, output_dir):
+        written = []
+        for project in gate.FIXTURE_PROJECTS:
+            log = (
+                output_dir
+                / "projects"
+                / project.key
+                / "scanners"
+                / "bandit"
+                / "source"
+                / "BanditScanner.stderr.log"
+            )
+            log.parent.mkdir(parents=True, exist_ok=True)
+            log.write_text(self.TRACEBACK, encoding="utf-8")
+            written.append(log)
+        return written
+
+    def test_it_finds_every_projects_stderr_log(self, output_dir):
+        written = self._write_logs(output_dir)
+        found = gate.find_scanner_error_logs(output_dir, "bandit")
+        assert sorted(found) == sorted(written)
+
+    def test_a_scanner_that_wrote_no_log_finds_nothing(self, output_dir):
+        assert gate.find_scanner_error_logs(output_dir, "bandit") == []
+
+    def test_it_prints_the_deepest_frame_and_the_exception(self, output_dir, capsys):
+        """Not tail-truncated: the line naming the failing library must survive.
+
+        This is the specific reporting defect -- the frame that identifies the
+        library and the exception type is what a reader needs, and cutting it is
+        what made these failures cost an extra debugging cycle.
+        """
+        self._write_logs(output_dir)
+        gate.print_scanner_error_evidence(output_dir, ["bandit"])
+        out = capsys.readouterr().out
+        assert "stevedore/_cache.py" in out
+        assert "EntryPoint.__init__() missing 2 required positional" in out
+        assert "Traceback (most recent call last)" in out
+
+    def test_identical_logs_are_collapsed_not_repeated_per_project(
+        self, output_dir, capsys
+    ):
+        """One tool failing the same way in four projects is one traceback."""
+        self._write_logs(output_dir)
+        gate.print_scanner_error_evidence(output_dir, ["bandit"])
+        out = capsys.readouterr().out
+        assert out.count("Traceback (most recent call last)") == 1
+        assert f"identical in {len(gate.FIXTURE_PROJECTS)} projects" in out
+
+    def test_differing_logs_are_all_printed(self, output_dir, capsys):
+        """Collapsing must key on content, so genuinely different logs survive."""
+        logs = self._write_logs(output_dir)
+        logs[0].write_text(
+            self.TRACEBACK + "ValueError: a different failure\n", encoding="utf-8"
+        )
+        gate.print_scanner_error_evidence(output_dir, ["bandit"])
+        out = capsys.readouterr().out
+        assert out.count("Traceback (most recent call last)") == 2
+        assert "ValueError: a different failure" in out
+
+    def test_an_errored_scanner_with_no_log_says_so(self, output_dir, capsys):
+        """Silence is worse than a note that the evidence is missing."""
+        gate.print_scanner_error_evidence(output_dir, ["bandit"])
+        out = capsys.readouterr().out
+        assert "reported ERROR but wrote no stderr log" in out

--- a/tests/unit/test_multi_project_attribution_gate.py
+++ b/tests/unit/test_multi_project_attribution_gate.py
@@ -1203,3 +1203,43 @@ class TestScannerErrorEvidenceIsSurfaced:
         gate.print_scanner_error_evidence(output_dir, ["bandit"])
         out = capsys.readouterr().out
         assert "reported ERROR but wrote no stderr log" in out
+
+    def test_a_pathological_log_is_bounded_but_keeps_both_ends(
+        self, output_dir, capsys
+    ):
+        """Not tailed and unbounded are separable; only the first is wanted.
+
+        Two blocks are printed after this one, and they are what a runaway log
+        would push past a truncated job log.
+        """
+        log = (
+            output_dir
+            / "projects"
+            / gate.FIXTURE_PROJECTS[0].key
+            / "scanners"
+            / "bandit"
+            / "source"
+            / "BanditScanner.stderr.log"
+        )
+        log.parent.mkdir(parents=True, exist_ok=True)
+        log.write_text(
+            "FIRST-LINE-MARKER\n"
+            + ("x" * gate.SCANNER_LOG_PRINT_BUDGET_BYTES)
+            + "\nLAST-LINE-MARKER\n",
+            encoding="utf-8",
+        )
+        gate.print_scanner_error_evidence(output_dir, ["bandit"])
+        out = capsys.readouterr().out
+        assert "FIRST-LINE-MARKER" in out
+        assert "LAST-LINE-MARKER" in out
+        assert "omitted from the middle" in out
+        assert len(out) < gate.SCANNER_LOG_PRINT_BUDGET_BYTES + 5000
+
+    def test_a_log_within_budget_is_untouched(self):
+        body = self.TRACEBACK
+        assert (
+            gate._clamp_keeping_both_ends(
+                body, gate.SCANNER_LOG_PRINT_BUDGET_BYTES
+            )
+            == body
+        )

--- a/tests/unit/utils/test_uv_tool_runner.py
+++ b/tests/unit/utils/test_uv_tool_runner.py
@@ -664,6 +664,98 @@ class TestGetToolVersionRunsOneProcessPerTool:
             runner.get_tool_version("checkov")
             assert mock_run.call_count == 2
 
+    def test_invalidation_matches_a_tool_whose_command_is_not_its_package(
+        self, runner
+    ):
+        """The key-shape the previous invalidator missed entirely.
+
+        A memo key is "<command>::<from-spec>", but the name reaching
+        install_tool_with_version is ``uv_tool_package_name or command``. For
+        JupyterConverter those differ -- command 'jupyter-nbconvert', package
+        'nbconvert' -- so a prefix match on the package name cleared nothing:
+        "jupyter-nbconvert::nbconvert".startswith("nbconvert::") is False. The
+        pre-install None then survived the install meant to invalidate it, and
+        tool_version stayed None forever after a *successful* install.
+
+        The earlier test could not catch this: it invalidated by the same name it
+        probed with and passed no package_name, which is the one shape where
+        command and package coincide -- the shape that already worked.
+        """
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert (
+                runner.get_tool_version("jupyter-nbconvert", "nbconvert") is None
+            )
+            assert mock_run.call_count == 1
+
+            # The installer knows this tool as 'nbconvert'.
+            invalidate_tool_version_cache("nbconvert")
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="7.16.6\n")
+            assert (
+                runner.get_tool_version("jupyter-nbconvert", "nbconvert") == "7.16.6"
+            )
+            assert mock_run.call_count == 2
+
+    def test_invalidation_matches_a_from_spec_carrying_extras(self, runner):
+        """Keys hold the whole --from spec, so equality on the bare name is not enough."""
+        runner._uv_available_cache = True
+        spec = "bandit[sarif,toml]>=1.7.0,<2.0.0"
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert runner.get_tool_version("bandit", spec) is None
+
+            invalidate_tool_version_cache("bandit")
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.9.4\n")
+            assert runner.get_tool_version("bandit", spec) == "bandit 1.9.4"
+            assert mock_run.call_count == 2
+
+    def test_a_real_install_invalidates_through_install_tool_with_version(
+        self, runner
+    ):
+        """End to end through the wiring, not just the invalidator in isolation.
+
+        install_tool_with_version is the single function every install path
+        funnels through, so the invalidation belongs there -- but being in the
+        right place does not help if the installer and the memo derive their keys
+        from different variables, which is exactly what went wrong.
+        """
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            assert (
+                runner.get_tool_version("jupyter-nbconvert", "nbconvert") is None
+            )
+
+        with patch.object(runner, "is_tool_installed", return_value=False), patch(
+            "automated_security_helper.core.constants.is_offline_mode",
+            return_value=False,
+        ), patch(
+            "automated_security_helper.utils.subprocess_utils.find_executable",
+            return_value=None,
+        ), patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="")
+            # The installer's own name for this tool is the package name.
+            assert runner.install_tool_with_version("nbconvert") is True
+
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="7.16.6\n")
+            assert (
+                runner.get_tool_version("jupyter-nbconvert", "nbconvert") == "7.16.6"
+            ), "the install did not clear the pre-install None"
+
     def test_installing_a_tool_forgets_its_remembered_version(self, runner):
         """An install is what makes a memoized version wrong, so it invalidates.
 
@@ -685,3 +777,118 @@ class TestGetToolVersionRunsOneProcessPerTool:
             mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.9.4\n")
             assert runner.get_tool_version("bandit") == "bandit 1.9.4"
             assert mock_run.call_count == 2
+
+
+class TestAMemoizedFailureIsRecoverable:
+    """A failed probe is cached, so it must be forcibly refreshable.
+
+    Caching failures is deliberate -- caching only successes would reopen the
+    concurrent-probe window on exactly the path where a slow cold start makes it
+    most likely. The cost is that one transient failure is then served
+    process-wide: a cold probe that exceeds the subprocess ceiling caches None,
+    and every consumer afterwards reports uv_version None and
+    is_functional False for a tool that works.
+
+    That compounds -- a non-functional result sends the mixin into
+    "Proceeding with reinstallation", install_tool_with_version returns True
+    early because the tool IS installed, so no install and therefore no
+    invalidation runs and the poison is never cleared. For a security scanner a
+    report that omits the version of the tool that produced the findings is a
+    provenance defect. So validate_cached_tool forces a re-probe.
+    """
+
+    def test_a_timeout_is_memoized_and_served_to_later_callers(self, runner):
+        """Documents the caching that makes the refresh below necessary."""
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="uv", timeout=15),
+        ) as mock_run:
+            assert runner.get_tool_version("bandit") is None
+            assert runner.get_tool_version("bandit") is None
+            assert mock_run.call_count == 1
+
+    def test_validate_cached_tool_re_probes_past_a_memoized_failure(self, runner):
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="uv", timeout=15),
+        ):
+            assert runner.get_tool_version("bandit") is None
+
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.9.4\n")
+            result = runner.validate_cached_tool("bandit")
+
+        assert result["is_functional"] is True, (
+            "a tool that works must not be reported broken because an earlier "
+            "probe timed out"
+        )
+        assert result["version"] == "bandit 1.9.4"
+
+    def test_the_refresh_overwrites_the_memo_for_everyone(self, runner):
+        """Recovery must be shared, not private to the refreshing caller."""
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="uv", timeout=15),
+        ):
+            assert runner.get_tool_version("bandit") is None
+
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.9.4\n")
+            runner.validate_cached_tool("bandit")
+            # No further subprocess: the good answer replaced the poisoned one.
+            assert runner.get_tool_version("bandit") == "bandit 1.9.4"
+            assert mock_run.call_count == 1
+
+
+class TestProbeLocksAreNamespaced:
+    """The two probes must not share a lock object.
+
+    get_tool_version keys on "<tool>::<package>" and get_uv_tool_command on
+    "<tool>::<fallback_binary>", so get_tool_version("bandit", "bandit") and
+    get_uv_tool_command("bandit") both produced "bandit::bandit". These are
+    non-reentrant threading.Lock, so sharing one is a deadlock waiting for a
+    refactor that makes either call into the other.
+    """
+
+    def test_the_two_probes_use_different_lock_keys(self, runner):
+        """Observed at call time, not by inspecting the registry afterwards.
+
+        ``_uv_tool_probe_locks`` is a WeakValueDictionary, so every lock is
+        collected as soon as the call that held it returns -- reading the keys
+        after the fact finds an empty mapping regardless of what happened.
+        """
+        import automated_security_helper.utils.uv_tool_runner as mod
+
+        real = mod._get_or_create_probe_lock
+        seen: list = []
+
+        def recording(cache_key):
+            seen.append(cache_key)
+            return real(cache_key)
+
+        runner._uv_available_cache = True
+        with patch.object(mod, "_get_or_create_probe_lock", recording), patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="bandit 1.9.4\n", stderr=""
+            )
+            runner.get_tool_version("bandit", "bandit")
+            with patch(
+                "automated_security_helper.utils.uv_tool_runner.find_uv_or_none",
+                return_value="/opt/uv/bin/uv",
+            ):
+                get_uv_tool_command("bandit")
+
+        assert "version::bandit::bandit" in seen
+        assert "command::bandit::bandit" in seen
+        # The collision the namespacing exists to prevent.
+        assert "bandit::bandit" not in seen
+        assert len(set(seen)) == 2

--- a/tests/unit/utils/test_uv_tool_runner.py
+++ b/tests/unit/utils/test_uv_tool_runner.py
@@ -14,7 +14,21 @@ from automated_security_helper.utils.uv_tool_runner import (
     find_uv_or_none,
     get_uv_tool_command,
     get_uv_tool_runner,
+    invalidate_tool_version_cache,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_caches():
+    """Clear the module-level memo caches around every test in this file.
+
+    ``get_tool_version`` memoizes per ``tool::package``, so without this a
+    version cached by one test would be served to the next and the second test
+    would assert against a value its own mock never produced.
+    """
+    _reset_uv_tool_runner_caches()
+    yield
+    _reset_uv_tool_runner_caches()
 
 
 @pytest.fixture
@@ -577,3 +591,97 @@ class TestGetUvToolCommandThreadSafety:
             assert kwargs.get("timeout") == 5, (
                 f"expected 5 s probe timeout, got {kwargs.get('timeout')}"
             )
+
+
+class TestGetToolVersionRunsOneProcessPerTool:
+    """``get_tool_version`` must spawn ONE process per tool, however many ask.
+
+    Why this is a correctness test and not a performance test: the probe *runs
+    the tool*, and a stevedore-based tool builds a shared per-user entry-point
+    cache at ``$XDG_CACHE_HOME/python-entrypoints/<digest>`` on first import.
+    stevedore writes it with a truncating ``open(path, 'w')`` and no lock, and
+    orders the JSON by iterating a set -- so two processes emit equal-length,
+    different-content streams that interleave at the 8 KiB flush boundary. The
+    spliced file can still parse while holding an entry whose arity is not 3,
+    and then EVERY later reader dies in ``stevedore/_cache.py`` with
+    ``TypeError: EntryPoint.__init__()``.
+
+    ASH builds one scanner per project and each construction probed the
+    version, so an N-project workspace scan fired N concurrent cold-start
+    imports of the same tool -- N writers racing on one file. One probe per
+    tool means one writer, so no splice is possible. Regression test for #542.
+    """
+
+    def test_concurrent_callers_spawn_exactly_one_subprocess(self, runner):
+        import threading
+        import time
+
+        runner._uv_available_cache = True
+        calls = {"n": 0}
+        calls_lock = threading.Lock()
+
+        def slow_probe(*_args, **_kwargs):
+            with calls_lock:
+                calls["n"] += 1
+            time.sleep(0.05)  # Let the other threads pile up on the cache.
+            return MagicMock(returncode=0, stdout="bandit 1.9.4\n")
+
+        seen: list = []
+        seen_lock = threading.Lock()
+        barrier = threading.Barrier(12)
+
+        def worker():
+            barrier.wait()  # Maximize the race window.
+            version = runner.get_tool_version("bandit")
+            with seen_lock:
+                seen.append(version)
+
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run",
+            side_effect=slow_probe,
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(12)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert calls["n"] == 1, (
+            "the tool must be imported once, not once per caller: "
+            f"{calls['n']} concurrent cold-start processes would race "
+            "stevedore's entry-point cache write"
+        )
+        assert seen == ["bandit 1.9.4"] * 12
+
+    def test_distinct_tools_are_not_serialized_into_one_probe(self, runner):
+        """Per-key, not global: two different tools still get their own probe."""
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="1.0\n")
+            runner.get_tool_version("bandit")
+            runner.get_tool_version("checkov")
+            assert mock_run.call_count == 2
+
+    def test_installing_a_tool_forgets_its_remembered_version(self, runner):
+        """An install is what makes a memoized version wrong, so it invalidates.
+
+        Without this, a caller that probes, installs, then re-reads the version
+        (the converters do exactly that) would keep the pre-install answer.
+        """
+        runner._uv_available_cache = True
+        with patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run"
+        ) as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.7.0\n")
+            assert runner.get_tool_version("bandit") == "bandit 1.7.0"
+            # Cached: no second process.
+            assert runner.get_tool_version("bandit") == "bandit 1.7.0"
+            assert mock_run.call_count == 1
+
+            invalidate_tool_version_cache("bandit")
+
+            mock_run.return_value = MagicMock(returncode=0, stdout="bandit 1.9.4\n")
+            assert runner.get_tool_version("bandit") == "bandit 1.9.4"
+            assert mock_run.call_count == 2

--- a/tests/unit/utils/test_uv_tool_runner_extended.py
+++ b/tests/unit/utils/test_uv_tool_runner_extended.py
@@ -8,9 +8,23 @@ import pytest
 from automated_security_helper.utils.uv_tool_runner import (
     UVToolRunner,
     UVToolRunnerError,
+    _reset_uv_tool_runner_caches,
     get_uv_tool_runner,
     reset_uv_tool_runner,
 )
+
+
+@pytest.fixture(autouse=True)
+def _isolate_module_caches():
+    """Clear the module-level memo caches around every test in this file.
+
+    ``get_tool_version`` memoizes per ``tool::package``, so without this the
+    version one test mocks would be served to the next -- and a test asserting
+    a *failed* probe would instead see the previous test's success.
+    """
+    _reset_uv_tool_runner_caches()
+    yield
+    _reset_uv_tool_runner_caches()
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

The `multi-project attribution (ubuntu-latest)` gate fails intermittently because bandit crashes at import during a workspace scan. The cause is not bandit, not a bandit release, and not the branch it surfaced on: ASH probed a uv tool's version once **per project**, so an N-project workspace scan launched N concurrent cold-start imports of the same tool, and those N processes raced each other writing stevedore's shared entry-point cache.

Two commits, deliberately separate: the functional fix, and a reporting fix for a gate that hid the cause it had already detected.

## The real exception

The gate's console output truncated the traceback at its most useful frame. The full text was sitting in the uploaded evidence artifact all along, at `projects/<project>/scanners/bandit/source/BanditScanner.stderr.log` — byte-identical in all four projects:

```
  File ".../site-packages/stevedore/extension.py", line 282, in list_entry_points
    eps = list(_cache.get_group_all(self.namespace))
  File ".../site-packages/stevedore/_cache.py", line 193, in get_group_all
    result.append(importlib.metadata.EntryPoint(*vals))
TypeError: EntryPoint.__init__() missing 2 required positional arguments: 'value' and 'group'
```

`EntryPoint()` received exactly one argument, so the cached entry's arity was 1 instead of 3.

## Mechanism

stevedore memoizes entry points in `$XDG_CACHE_HOME/python-entrypoints/<digest>`. Three properties of stevedore 5.9.1 combine badly:

1. The write is **not atomic and not locked** — a plain truncating `open(filename, 'w')` plus `json.dump`, with no temp-file-and-rename. Verified present in every version from 3.0.0 through 5.9.1.
2. `_build_cacheable_data()` builds the JSON by iterating a **set** of group names, so ordering is per-process. Two processes in the *same* environment emit byte streams of **identical length but different content**. Measured: 6 runs, 6 distinct md5s, all exactly 11875 bytes.
3. The read guard is `except (OSError, json.JSONDecodeError)`. A *truncated* write is therefore caught and safely rebuilt — but an equal-length **splice** of two different orderings stays full length, often still parses, and sails straight through the guard. There is no version stamp or shape validation to reject it.

So two concurrent writers interleave at a buffer-flush boundary and can leave a cache that parses as valid JSON while holding a wrong-arity entry. Every later reader of that cache dies. The corruption is **persistent**, which is why all four projects failed identically rather than just one.

ASH supplied the concurrency: `get_tool_version()` ran `uv tool run <tool> --version` with no memoization and no lock, and `BanditScanner.model_post_init` calls it once per scanner — one scanner per project.

Two further properties matter, both found by adversarial review of the first two commits and fixed in the third (see "Corrections" below): the probe and the scan resolved to **different uv environments**, and therefore different cache files; and stevedore folds a float32-quantized mtime into the digest, so the digest is stable only within a ~128-second bucket.

## Which hypothesis, and what closed it

**Confirmed: concurrency.** Corrected in locus — the contended resource is stevedore's own JSON cache, not the uv tools directory, and the race is at tool *run* time, not install time. The gate installs bandit in a separate prior step and the log reads `Bandit already installed via UV tool`, so no install is concurrent.

**Eliminated — a genuine bandit/stevedore incompatibility.** In the *same failing run*, a single-project job reported `bandit status=PASSED` with 44 findings on the same runner image and the same bandit 1.9.4 / stevedore 5.9.1. Same versions, non-concurrent, works.

**Eliminated — the branch's diff.** The same branch ran this gate three times: it **passed**, **passed**, then **failed**. Windows passed in the failing run. A deterministic consequence of a diff cannot pass twice.

**Eliminated — an in-process `importlib.metadata` cache.** The failing reader is a separate `bandit` subprocess; ASH's own process never imports bandit. The contended state is a file on disk.

**Eliminated — a preinstalled bandit shadowing the uv one.** The traceback's frames are all under `.local/share/uv/tools/bandit/`, so the uv-installed bandit is the one that ran.

**Not a new release.** bandit 1.9.4 (2026-02-25) and stevedore 5.9.1 (2026-08-20) both predate the failure, and `stevedore/_cache.py` is byte-identical across 5.6.0 through 5.9.1. Nothing is pinned here, deliberately: this is a concurrency defect, not a version incompatibility, and pinning would strand the repo below whichever version happened to be current.

## Reproduction

The live race is rare — I could not win it locally (0 crashes in 250 trials at 32-way concurrency, and 0 in 80 at 4-way), so I reproduced it at the byte level instead, from **real** captured cache streams rather than synthetic ones:

```
# Capture real cache streams, splice two at the flush boundary, run real bandit.
uv tool install --python 3.12 'bandit[sarif,toml]>=1.7.0,<2.0.0'
# then: splice stream_a[:8192] + stream_b[8192:] into the digest path and run bandit
```

That yields the CI traceback **frame for frame** — same files, same line numbers (`extension_loader.py:114/25/38`, `extension.py:196/297/282`, `_cache.py:193`), same exception class. The spliced entry is visibly cut mid-string, e.g. `['start_process_with_a_shell', 'bandit.plug']`.

Surveying all 380 stream pairs at that boundary: 137 invalid JSON (safe, rebuilt), 155 clean, 48 corrupt in a namespace bandit never loads (harmless), and **40 fatal**. That last category is why the failure is intermittent rather than constant — the splice must land in a `bandit.*` group.

One methodological note worth recording: an earlier version of this reproduction could not fail, because stevedore disables caching outright when `sys.executable` starts with `/tmp` (`sys.executable[0:4] == '/tmp'`). The tool directory has to live outside `/tmp` or the test silently exercises nothing.

## Both directions

**Functional fix.** With memoization and the per-key lock removed and everything else identical, the new test reports `12` concurrent cold-start processes. With the fix, exactly `1`.

**End to end.** The gate's own command now passes locally, exit code `0`, with all four marker rules present (B101, B311, B403, B405) and the B324 suppression correctly scoped to one project:

```
python scripts/verify_multi_project_attribution.py --timeout 1200
PASS: 4 project(s), one SARIF run each, ...
GATE EXIT CODE: 0
```

**Reporting fix.** Replayed against the real failing artifact: previously a flat list with the traceback cut; now 1 root cause, the rest labelled downstream, and the full traceback printed. Both new behaviors were mutation-tested — reverting each makes the corresponding tests fail.

## The reporting fix

The gate reported one dead scanner as ten problems and truncated the traceback at the frame that named the failing library. Both cost a debugging cycle every time this fires.

- Scanner `ERROR`s are now named as the **root cause**, and the marker/suppression/threshold violations that follow from a scanner producing nothing are printed under a heading saying they are downstream. This is a **partition of the existing list** — the violation strings, the totals and the exit status are unchanged, so the gate is exactly as strict as before. The gate is not weakened, skipped, or relaxed anywhere.
- Each errored scanner's stderr log is now printed **in full**, ahead of the noisier tail-truncated console output. Not tailed on purpose: the frame naming the library is the deepest one, so a tail cut mid-frame removes precisely the useful part. Identical logs are collapsed with a count (four copies of one traceback is not four pieces of evidence), collapsing keys on content so genuinely different failures all still show, and a scanner that errored without writing a log says so rather than printing nothing.

## Corrections after adversarial review

Three real defects were found in the first two commits, two of which contradicted claims those commits made about themselves. All are fixed in `c283cb09`, each with a test proven to fail beforehand.

**The invalidation missed every plugin whose command differs from its package, and `JupyterConverter` was a live regression.** A memo key is `"<command>::<from-spec>"`, but the name reaching `install_tool_with_version` is `uv_tool_package_name or command`. For `JupyterConverter` those differ — command `jupyter-nbconvert`, package `nbconvert` — and `"jupyter-nbconvert::nbconvert".startswith("nbconvert::")` is `False`, so the pre-install `None` survived the install meant to clear it and `tool_version` stayed `None` forever after a **successful** install. That is verbatim the case the second commit's own comment said the invalidation existed to prevent. The invalidator now matches either segment of the key. The original test could not catch it: it invalidated by the same name it probed with and passed no `package_name` — the one shape where command and package coincide, which already worked.

**The probe warmed a different environment than the scan.** The probe issued `uv tool run bandit --version`; the scan issues `uv tool run --from 'bandit[sarif,toml]>=1.7.0,<2.0.0' bandit`. Since the digest is over `sys.executable`/`sys.prefix`, those warm different cache files — so the scan's file was left cold for N concurrent scanners and the race was untouched on any machine where ASH does its own install. Measured on one gate run with a fresh cache: **five** distinct bandit environments before, **two** after, the four separate per-project ephemeral environments collapsing into the one the probe warms. The probe now defaults to the same `--from` spec the scan builds.

**Writer counts, measured per cache file.** A file count alone could not settle this: "two environments after" is equally consistent with the probe warming the file the scans read, and with the four scans sharing one environment *different* from the probe's — which would be the original failure precondition untouched. So the writers were counted directly, by putting a `sitecustomize.py` on `PYTHONPATH` that logs every `open()` of a cache path with its PID and mode. Every Python interpreter imports it via `site`, including the bandit subprocesses, and it was positive-controlled first: a cold run logs read-then-write, a warm run logs read only.

Two full gate runs, fresh cache each:

```
t+0.00  pid 2787709  'r' existed=False  digest b69386bf0293   <- probe, repo root
t+0.00  pid 2787709  'w' existed=False  digest b69386bf0293   <- the one write
t+4.25  pid 2789064  'r'/'w'            digest 0cdfa49893f4   <- one-off, 1 writer
t+9.62  pid 2791378  'r' existed=True   digest b69386bf0293   <- scan, project-a
t+9.68  pid 2791520  'r' existed=True   digest b69386bf0293   <- scan, project-b
t+9.72  pid 2791537  'r' existed=True   digest b69386bf0293   <- scan, apps/admin
t+9.73  pid 2791551  'r' existed=True   digest b69386bf0293   <- scan, src

digest b69386bf0293:  writers=1  readers=5   (probe + all four scans)
digest 0cdfa49893f4:  writers=1  readers=1
MAX writers on any single cache file: 1
```

The second run reproduced it exactly: `writers=1 readers=5` on the scans' digest, `writers=1 readers=1` on the other, max 1. **Every cache file has exactly one writer, and all four concurrent scans read the file the probe warmed** (`existed=True` on all four). The race is closed, not merely narrowed. The two environments are the shared ephemeral one the probe and all four scans use, and the installed tool environment touched once by a single process.

Worth recording because it is the mechanism's precondition: the four scans ran with four *different* working directories yet resolved to the **same** digest. That is exactly why four concurrent scanners could contend on one file to begin with — had the working directory differentiated the digest, each project would have had its own cache file and this failure could not occur.

The digest is cwd-invariant for two independent reasons, which together mean the result above is not an artifact of how these particular subprocesses were launched. `_hash_settings_for_path` hashes `sys.executable`, `sys.prefix`, and each `sys.path` entry with its mtime, plus each `*.dist-info`/`*.egg-info/entry_points.txt` with its mtime. First, for a console script `sys.path[0]` is the script's directory, not the working directory, so the working directory never enters the hash — that is the case measured here. Second, even for a launcher that *does* insert the working directory, some insert it as the empty string rather than an absolute path, and `os.stat('')` raises `FileNotFoundError`; `_get_mtime` catches `errno.ENOENT` and returns `-1.0`. That entry then contributes `''.encode('utf-8')` — zero bytes — plus the constant `_ftobytes(-1.0)` (`000080bf`), which is identical from every directory. So the digest does not vary with the working directory whether that directory is absent from `sys.path` or present as `''`.

One qualification remains, and it is now the only one: stevedore folds a float32-quantized mtime into the digest, so if the digest changed between probe and scan the scans would cold-start concurrently again.

That takes **two** conditions, not one. The digest moves only if a hashed mtime actually changes between the probe and the scans, **and** that change crosses a 128-second quantization boundary. It is not a ratio off the wall clock: if nothing mutates the environment during the window, every `sys.path` entry and every `entry_points.txt` keeps its mtime and the digest is byte-identical no matter how long the gap. In the quiet case the exposure is zero.

And where the first condition does fire, the second tends not to. A bandit scan has a routine mid-run mutation: bytecode caching. Creating `__pycache__` inside a `sys.path` directory both adds an entry and moves that directory's mtime. Measured across an import that did exactly that:

```
dir mtime BEFORE import : 1788988287.4477625   hash-input 9743d54e
dir mtime AFTER  import : 1788988288.5777733   hash-input 9743d54e
__pycache__ present     : True
raw mtime changed          : True
float32 HASH INPUT changed : False
```

A real 1.13-second mtime change occurred and the cache key did not observe it, because `struct.Struct('f')` quantizes both timestamps to `1788988288.0` — 1.13 s sits deep inside a 128-second bucket. So the most likely mid-run mutation is absorbed by the quantization: the second condition is small precisely when the first one fires. The digest is more stable than a boundary-crossing argument alone suggests, and this is the evidence for saying so rather than hedging.

**Follow-up, deliberately not in this PR.** The residual can be closed rather than qualified: have the probe emit the digest it warmed and have each scan assert it read that same digest, so a concurrent cold-start becomes a loud failure instead of a silent one. Not landed here for a technical reason rather than a scheduling one. It requires the probe to communicate a value to four subprocesses and each of them to verify it — new concurrency-adjacent logic on a hot path. The entire value of this PR is that its concurrency behavior is *measured*: one writer, five readers, reproduced twice, with a positive-controlled instrument. Adding an unmeasured mechanism would dilute exactly the property that makes it trustworthy, so it deserves its own change and its own verification.

Its priority is coupled to upstream, which is worth recording so the coupling is not rediscovered later. The float32 quantization keeping this digest stable is itself an upstream defect, and a report of it is under consideration. While stevedore quantizes mtimes, this follow-up is low priority. If upstream ever hashes full-precision mtimes, the digest will move far more readily — a single `__pycache__` creation would be enough — and the assertion stops being optional.

Stated plainly rather than left for a reviewer to notice: **this PR currently benefits from the bug it would be reporting.** The quantization that makes stevedore's cache invalidation unreliable is the same property that keeps probe and scan on one digest here. That is not a reason to leave the defect unreported, but it does mean fixing it upstream raises the priority of the follow-up above, and the two should be sequenced with that in mind.

**A failed probe was memoized permanently**, turning a transient per-caller failure into a process-wide one: the memo hit tests `in`, not truthiness, so one timed-out cold probe made every later consumer report `uv_version: None` and `is_functional: False` for a working tool. It compounded — a non-functional result sends the mixin into "Proceeding with reinstallation", `install_tool_with_version` returns `True` early because the tool *is* installed, so no install and therefore no invalidation ran and the poison was never cleared. For a security scanner, a report omitting the version of the tool that produced the findings is a provenance defect. Failures are still cached, since caching only successes would reopen the concurrent-probe window on exactly the path where a slow cold start makes it likeliest, but `get_tool_version(..., refresh=True)` forces a re-probe and `validate_cached_tool` uses it.

Also fixed: probe-lock keys are namespaced `version::`/`command::` (both previously produced `"bandit::bandit"`, and these are non-reentrant locks); the hardcoded `timeout=15` is now a named constant, kept at 15 rather than merged with the 5s one because lowering it raises the rate of memoized failures; `get_uv_tool_command` uses the extracted `_get_or_create_probe_lock` instead of a second inline copy; `get_installed_tool_version` receives a `--from` string rather than a `List[str]`, which had been raising `TypeError` into a broad `except` and, after memoization, caching the failure under `"bandit::['sarif', 'toml']"`; and the evidence printer is bounded at 200 KB, trimming the middle rather than either end.

## Known limitation

This prevents the corruption; it cannot repair a cache already corrupted. CI is unaffected because runners are ephemeral, but a developer who hits this once has a permanently broken tool until they remove `${XDG_CACHE_HOME:-$HOME/.cache}/python-entrypoints`.

**Reinstalling the tool is not a workaround either**, which is the first thing a reader will try. stevedore packs the mtime through `struct.Struct('f')`, giving a ~128-second quantization at current timestamps, so a reinstall that rewrites `entry_points.txt` inside the same bucket leaves the digest unchanged and the bad cache still selected. `.disable` does not help either: it is evaluated once in `__init__` and consulted only at the write, so a corrupt file already on disk is still read. The read guard is `except (OSError, json.JSONDecodeError)` with no shape validation. Deleting the directory really is the only recovery.

That quantization affects *recovery*, not *prevention* — a merely stale cache still holds well-formed 3-tuples, so it produces a missing-plugin failure rather than the arity `TypeError`. Deliberately not handled here: detecting the `TypeError` and deleting the cache would be a retry loop around a defect this change removes the cause of. The underlying non-atomic write is upstream's to fix and appears never to have been reported there.

## Related Issues

Fixes the `multi-project attribution` failure seen on #542. The fix is on main's line rather than that branch, because it affects every branch.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] CI/build change
- [ ] Refactoring (no functional change)

## Checklist
- [x] Tests added/updated for the change
- [ ] Documentation updated (if applicable)
- [x] `uv run pytest tests/unit/` passes locally
- [x] Commit messages follow conventional format

Unit suite: **6064 passed, 22 skipped, 3 xfailed, 0 failed** (skip count unchanged from the 22 on `origin/main`). All 22 skips are pre-existing and unrelated (WIP mocks, Windows-only, Pydantic model issues); none are in the files touched here. `ruff check` clean, `ruff format --check` clean on everything changed, at the pinned pre-commit version.
