### PR TITLE
ci: only bootstrap buildx for the docker OCI runner

### DIFF
--- a/.github/actions/run-scan-test/action.yml
+++ b/.github/actions/run-scan-test/action.yml
@@ -31,8 +31,19 @@ inputs:
 runs:
   using: "composite"
   steps:
+    # Only the docker cells have anything to do with a buildx builder. The two
+    # steps below that consume what this bootstraps are both gated
+    # `oci-runner == 'docker'`, and ASH's own container build shells out to
+    # `<runner> build` -- `podman build`, never `docker buildx` -- on every
+    # entrypoint (utils/ash_helpers.ps1, ./ash, run_ash_container.py). So on the
+    # podman cells this used to boot a `docker-container` buildkit builder and
+    # pull moby/buildkit:buildx-stable-1 from Docker Hub that nothing then used:
+    # six matrix cells paying a network round trip purely as failure surface. One
+    # such pull returned a 500 and took the whole job with it. Matching the gate
+    # the credential steps already use keeps docker unchanged and drops the
+    # dependency everywhere it was never earned.
     - name: Set up Docker Buildx on Linux
-      if: contains(inputs.os, 'ubuntu') && inputs.method != 'python-local' && inputs.oci-runner != 'finch'
+      if: contains(inputs.os, 'ubuntu') && inputs.method != 'python-local' && inputs.oci-runner == 'docker'
       uses: docker/setup-buildx-action@v4
 
     # ASH's container build exports and restores its layers through the GitHub


### PR DESCRIPTION
## What this changes

One line in `.github/actions/run-scan-test/action.yml`. The buildx bootstrap was gated

```yaml
if: contains(inputs.os, 'ubuntu') && inputs.method != 'python-local' && inputs.oci-runner != 'finch'
```

and is now gated

```yaml
if: contains(inputs.os, 'ubuntu') && inputs.method != 'python-local' && inputs.oci-runner == 'docker'
```

which is the same condition the two steps that consume the builder already use.

## What motivated it

`scan (powershell, ubuntu-latest) [podman]` failed on a transient Docker Hub error while booting the buildkit builder. Verbatim, from the job log:

```
#1 [internal] booting buildkit
#1 pulling image moby/buildkit:buildx-stable-1
#1 pulling image moby/buildkit:buildx-stable-1 0.3s done
#1 ERROR: Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1": received unexpected HTTP status: 500 Internal Server Error
------
> [internal] booting buildkit:
------
ERROR: Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1": received unexpected HTTP status: 500 Internal Server Error
```

The step ran with the action's default driver, `driver: docker-container`, which is what makes it pull `moby/buildkit:buildx-stable-1` rather than use the daemon's built-in builder.

**The recurrence rate of this 500 was not measured.** One occurrence is all that is evidenced here. The argument for this change is not that the error is frequent; it is that six matrix cells were exposed to it while having nothing to gain from the step.

## The measurement

Six of the 24 cells in `scan-validation` were bootstrapping a builder they never used: `bash`, `powershell` and `python-container` against podman, on both `ubuntu-latest` and `ubuntu-24.04-arm`. Each paid one Docker Hub round trip per run, carried purely as added failure surface.

Before this change 13 cells bootstrapped buildx (7 docker + 6 podman). After it, 7 do.

## Evidence that podman does not need buildx

This was traced rather than inferred from the gating.

**Nothing in the action consumes it on that path.** The only two steps in the file that use what buildx sets up are `Expose the Actions cache credentials to ASH's build` and `Revoke the Actions cache credentials from the job environment`, and both are gated `inputs.oci-runner == 'docker'`. No other step in the file references `oci-runner`. The `Revoke` step is worth singling out, because it is gated `always() && ... && inputs.oci-runner == 'docker'` and still reports `outcome=skipped` in the failing job. `always()` rules out "it skipped because an earlier step failed", so its skip is direct evidence that the `== 'docker'` clause is false on podman.

**ASH's own container build never invokes `docker buildx` on podman.** All three entrypoints build with `<runner> build`:

- `utils/ash_helpers.ps1` line 282 -- `$buildCmd += @($RESOLVED_OCI_RUNNER, 'build')`. The file contains no occurrence of `buildx`. This is the entrypoint the failing cell uses.
- `./ash` line 162 -- `${RESOLVED_OCI_RUNNER} build \`. No occurrence of `buildx`.
- `automated_security_helper/interactions/run_ash_container.py` line 434 -- `build_cmd = [*oci_command_prefix, resolved_oci_runner, "build"]`.

On podman that is `podman build`, which does not use the Docker daemon's buildx at all.

**The one `buildx` call site in the tree is unreachable on podman.** `run_ash_container.py` line 429 uses the `buildx` sub-command only when `_gha_layer_cache_args` returns flags, and that function's first guard is `if resolved_oci_runner != "docker": return []` (line 371). Its own docstring states the reason: "docker only. `type=gha` is a buildx cache backend. podman and finch expose only registry-backed caches, so there is nothing equivalent to offer them."

**No other workflow or action consumes the builder.** `docker/setup-buildx-action` appears exactly once in the repository, in this file. No other workflow or action references `buildx`. The builder is per-job state, and the failing job's post phase tears it down with `docker buildx rm`, so nothing outlives the job to consume it.

**The finch exemption already demonstrated this in practice.** `scripts/setup-finch-linux.sh` line 22 runs `apt-get remove -y ... docker-buildx-plugin ...`, so the finch cells complete this action with the buildx plugin uninstalled entirely. That is a working demonstration that a non-docker runner needs nothing from the step, not just a precedent.

## Which cells change

Behavior changes on exactly six cells, all podman, all of which now skip the step:

| os | method | oci-runner |
|---|---|---|
| ubuntu-latest | bash | podman |
| ubuntu-latest | powershell | podman |
| ubuntu-latest | python-container | podman |
| ubuntu-24.04-arm | bash | podman |
| ubuntu-24.04-arm | powershell | podman |
| ubuntu-24.04-arm | python-container | podman |

Unchanged:

- The seven docker cells still run it: `bash`, `powershell` and `python-container` on `ubuntu-latest` and on `ubuntu-24.04-arm`, plus the offline `python-container` cell.
- The three finch cells skipped before and skip now (`'finch' != 'finch'` was false; `'finch' == 'docker'` is false).
- The eight `python-local` cells skipped before and skip now, on the `inputs.method != 'python-local'` clause. All eight pass `oci-runner: ""`, so none of them is affected by swapping the operator on the runner clause; that was checked explicitly, since an empty-runner cell with a non-`python-local` method would have changed behavior.
- The macOS and Windows cells never matched `contains(inputs.os, 'ubuntu')`.

`.github/actions/run-scan-test` has exactly one caller, `scan-validation` in `ash-unified-ci.yml`, so that enumeration is complete.

## On adding a retry

Not in this PR, deliberately.

The file already has a shell `retry` helper wrapping npm, curl, brew and pip in the community-plugin step, and extending that idiom to a network-dependent step that just failed on a transient upstream error is a reasonable idea. But `docker/setup-buildx-action` is a JavaScript action, so the shell helper cannot wrap it. The options are a third-party retry action, which is a new external dependency in a security scanner's CI and deserves review on its own terms, or `continue-on-error` plus a duplicate re-attempt step, which introduces a construct that appears nowhere in this file today. Either one is materially harder to review than a one-line gate change, and neither is needed to fix what this PR fixes.

Worth stating plainly: this change does not eliminate the failure mode, it reduces the exposed surface from 13 cells to 7. The seven docker cells still pull `moby/buildkit:buildx-stable-1` and can still hit the same 500. A retry there is a sensible follow-up, and so is asking whether those cells need the `docker-container` driver at all -- `driver: docker` pulls no image, though it also forecloses the `type=gha` layer cache the surrounding comments are built around, so that is a behavior change rather than a reliability no-op and belongs in its own change.

## Out of scope, but found while tracing

`_resolve_oci_runner` returns the value of `_find_runner`, which returns `subprocess_utils.find_executable`, which returns `shutil.which(cmd)` -- an absolute path such as `/usr/bin/docker`. `_gha_layer_cache_args` compares that value against the literal `"docker"`. So the guard at line 371 currently rejects every runner including docker, which would mean the `type=gha` layer cache is not actually in use on the docker cells. Not touched here: fixing it would change build behavior on the docker cells, which does not belong in a CI reliability change, and it does not affect this PR either way, since podman fails that comparison under both readings.

## Verification

- `actionlint` 1.7.12, run over all 12 workflow files, before and after: 9 findings both times, output byte-identical, so zero new findings. Exit code 1 in both runs, from pre-existing findings in `ash-repo-docs.yml` and `run-ash-security-scan.yml`, neither of which this PR touches. Note that actionlint has no action-metadata mode: pointed directly at a composite `action.yml` it parses the file as a workflow and reports five spurious `syntax-check` errors for the missing `on` and `jobs` keys. That path is not a usable signal for this file, which is why the comparison above is workflow-level, where actionlint does resolve the local `./.github/actions/run-scan-test` reference.
- The YAML parses. After the change the file has 19 steps, exactly one `docker/setup-buildx-action` step with no `with:` block, and all three steps whose gate mentions `oci-runner` now carry the identical `inputs.oci-runner == 'docker'` condition.
- Full test suite: 6039 passed, 117 skipped, 3 xfailed, 0 failed. No test reads this action file's contents; the single test that names the path uses it as a string literal in a SARIF fixture. So the suite confirms no collateral breakage rather than validating the gate itself.
- The PR title validates against `cz check`, which `ash-pr-title-check.yml` gates on.
