### PR TITLE
fix(container): compare the OCI runner's basename in the GHA layer-cache gate

### DIFF
--- a/automated_security_helper/interactions/run_ash_container.py
+++ b/automated_security_helper/interactions/run_ash_container.py
@@ -368,7 +368,13 @@ def _gha_layer_cache_args(
     the run's token. Distributing an image is a separate ``--push`` operation that
     this does not perform.
     """
-    if resolved_oci_runner != "docker":
+    # Compare the final path component, not the whole string. The runner arrives
+    # here already resolved: _resolve_oci_runner returns find_executable's output,
+    # which is a full path such as /usr/bin/docker, and carries a .exe suffix on
+    # Windows. ``stem`` reduces every one of those shapes -- and a bare name -- to
+    # ``docker``, while still declining neighbors like /usr/bin/docker-compose
+    # that a substring test would wrongly accept.
+    if Path(resolved_oci_runner).stem != "docker":
         return []
     if force:
         return []

--- a/automated_security_helper/interactions/run_ash_container.py
+++ b/automated_security_helper/interactions/run_ash_container.py
@@ -2,13 +2,16 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import logging
 import os
+import platform
 import re
 import shlex
 import shutil
 from subprocess import (
     CalledProcessError,
-)  # nosec B404 - Using the exception class to evaluate subprocess invocations
+    SubprocessError,
+)  # nosec B404 - Using the exception classes to evaluate subprocess invocations
 import sys
 import time
 from datetime import datetime
@@ -43,6 +46,9 @@ _SAFE_REVISION_PATTERN = re.compile(r"^[A-Za-z0-9._\-/]+$")
 
 # Discovery order for OCI runners (first found wins)
 _OCI_RUNNER_CANDIDATES = ["finch", "docker", "nerdctl", "podman"]
+
+# Memoizes the buildx capability probe, keyed by resolved runner path.
+_BUILDX_SUPPORT_CACHE: dict[str, bool] = {}
 
 
 def _validate_ash_revision(revision: str) -> bool:
@@ -341,10 +347,46 @@ def _find_dockerfile(resolved_revision: str | None) -> Path:
     return dockerfile_path
 
 
+def _runner_supports_buildx(resolved_oci_runner: str) -> bool:
+    """Whether the runner actually provides ``buildx``, probed once per path.
+
+    The filename does not establish the capability. podman ships a
+    ``podman-docker`` package whose ``/usr/bin/docker`` is a shim that execs
+    podman, and ``_OCI_RUNNER_CANDIDATES`` reaches ``docker`` before ``podman``, so
+    on such a host every name-based check passes for something that has no buildx
+    at all. Asking the binary is the only thing that separates the two.
+    """
+    if resolved_oci_runner in _BUILDX_SUPPORT_CACHE:
+        return _BUILDX_SUPPORT_CACHE[resolved_oci_runner]
+
+    supported = False
+    try:
+        result = subprocess_utils.run_command(
+            [resolved_oci_runner, "buildx", "version"],
+            capture_output=True,
+            check=False,
+            log_level=logging.DEBUG,
+            timeout=30,
+        )
+        supported = result.returncode == 0
+    except (OSError, SubprocessError) as e:
+        # run_command with check=False already converts a timeout or a missing
+        # binary into a non-zero CompletedProcess, so this is belt and braces.
+        ASH_LOGGER.debug(f"buildx probe for {resolved_oci_runner} failed: {e}")
+
+    if not supported:
+        ASH_LOGGER.debug(
+            f"{resolved_oci_runner} does not provide buildx -- skipping layer cache"
+        )
+    _BUILDX_SUPPORT_CACHE[resolved_oci_runner] = supported
+    return supported
+
+
 def _gha_layer_cache_args(
     resolved_oci_runner: str,
     build_target: str,
     force: bool,
+    offline: bool,
 ) -> List[str]:
     """Return buildx flags that read and write image layers via the GitHub Actions cache.
 
@@ -355,6 +397,7 @@ def _gha_layer_cache_args(
 
     - docker only. ``type=gha`` is a buildx cache backend. podman and finch expose
       only registry-backed caches, so there is nothing equivalent to offer them.
+    - And docker in fact, not just in name. See ``_runner_supports_buildx``.
     - Only inside a GitHub Actions run. The exporter authenticates with
       ACTIONS_RUNTIME_TOKEN and talks to ACTIONS_CACHE_URL (protocol v1) or
       ACTIONS_RESULTS_URL (v2). Note that Actions does not place these in the
@@ -386,15 +429,37 @@ def _gha_layer_cache_args(
         os.environ.get("ACTIONS_CACHE_URL") or os.environ.get("ACTIONS_RESULTS_URL")
     ):
         return []
+    # Last, because it is the only guard that shells out. By here the environment
+    # has already said we are inside Actions, so this runs about once per build.
+    if not _runner_supports_buildx(resolved_oci_runner):
+        return []
 
-    # One scope per build target. Builds sharing a scope overwrite each other's
-    # cache, so `ci` and `non-root` must not collide.
-    scope = f"ash-{build_target}"
+    # One scope per distinct set of layers. Note that build_target cannot be the
+    # discriminator: it is forced to "ci" whenever CI is set, and this point is
+    # only reachable with ACTIONS_RUNTIME_TOKEN set, so it is always "ci" here. It
+    # stays in the key anyway for callers that do vary it. What actually differs
+    # between the cache-enabled cells is the CPU architecture -- buildkit requests
+    # a different manifest per arch, so those entries can never be shared -- and
+    # OFFLINE, which the Dockerfile consumes near the top and which therefore
+    # invalidates nearly every layer below it. Without both, the cells overwrite
+    # one another and buildkit keeps only whichever finished last.
+    scope = (
+        f"ash-{build_target}-{platform.machine()}-{'offline' if offline else 'online'}"
+    )
     return [
         "--cache-from",
         f"type=gha,scope={scope}",
+        # mode=min rather than mode=max. The Actions cache is capped at 10 GB per
+        # repository and evicts by least-recent access across every workflow, so
+        # exporting each intermediate stage of a multi-GB scanner image, once per
+        # scope, risks evicting the setup-uv cache that the unit-test matrix
+        # restores -- a failure that would surface in an unrelated job.
+        #
+        # ignore-error keeps a cache-service outage from failing the build. A
+        # transient 400 from this export step took three scan cells down, while
+        # the import above degraded to a plain cache miss on its own.
         "--cache-to",
-        f"type=gha,mode=max,scope={scope}",
+        f"type=gha,mode=min,ignore-error=true,scope={scope}",
     ]
 
 
@@ -427,7 +492,9 @@ def _build_image(
     # Layer caching needs buildx: type=gha is not supported by the default docker
     # driver. buildx also leaves the local image store untouched unless asked, so
     # --load is required or the image would not exist for the subsequent run.
-    cache_args = _gha_layer_cache_args(resolved_oci_runner, build_target, force)
+    cache_args = _gha_layer_cache_args(
+        resolved_oci_runner, build_target, force, offline
+    )
     if cache_args:
         build_cmd = [
             *oci_command_prefix,

--- a/tests/unit/interactions/test_gha_layer_cache_args.py
+++ b/tests/unit/interactions/test_gha_layer_cache_args.py
@@ -8,10 +8,15 @@ contradicts the caller. The default is therefore "return nothing", and these tes
 pin both that default and the one combination that opts in.
 """
 
+import logging
+import subprocess
+
 import pytest
 
+from automated_security_helper.interactions import run_ash_container
 from automated_security_helper.interactions.run_ash_container import (
     _gha_layer_cache_args,
+    _runner_supports_buildx,
 )
 
 # The credentials buildx needs. Actions does not expose these to `run:` steps by
@@ -21,6 +26,26 @@ _ACTIONS_ENV = {
     "ACTIONS_RUNTIME_TOKEN": "token",
     "ACTIONS_CACHE_URL": "https://example.invalid/cache/",
 }
+
+
+@pytest.fixture(autouse=True)
+def buildx_present(monkeypatch):
+    """Assume the resolved runner really does provide buildx.
+
+    The capability check shells out, so leaving it live would make every test in
+    this file depend on whether the machine running them happens to have docker
+    and buildx installed. ``TestBuildxCapabilityProbe`` exercises the real
+    function; everything else states the assumption and moves on.
+    """
+    monkeypatch.setattr(
+        run_ash_container, "_runner_supports_buildx", lambda runner: True
+    )
+
+
+@pytest.fixture(autouse=True)
+def pinned_arch(monkeypatch):
+    """Pin the architecture so scope strings are deterministic off arm hardware."""
+    monkeypatch.setattr(run_ash_container.platform, "machine", lambda: "x86_64")
 
 
 @pytest.fixture
@@ -34,20 +59,32 @@ def in_actions(monkeypatch):
 
 class TestCacheEnabled:
     def test_docker_in_actions_emits_both_directions(self, in_actions):
-        args = _gha_layer_cache_args("docker", "ci", force=False)
+        args = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
         assert args == [
             "--cache-from",
-            "type=gha,scope=ash-ci",
+            "type=gha,scope=ash-ci-x86_64-online",
             "--cache-to",
-            "type=gha,mode=max,scope=ash-ci",
+            "type=gha,mode=min,ignore-error=true,scope=ash-ci-x86_64-online",
         ]
 
     def test_scope_is_per_build_target(self, in_actions):
-        """Targets must not share a scope; buildx lets one overwrite the other."""
-        ci = _gha_layer_cache_args("docker", "ci", force=False)
-        non_root = _gha_layer_cache_args("docker", "non-root", force=False)
-        assert "scope=ash-ci" in ci[1]
-        assert "scope=ash-non-root" in non_root[1]
+        """Targets must not share a scope; buildx lets one overwrite the other.
+
+        Worth knowing while reading this: ``build_target`` cannot actually differ
+        on any path that reaches the cache. run_ash_container forces it to "ci"
+        whenever CI is set, and the cache needs ACTIONS_RUNTIME_TOKEN, which only
+        exists inside Actions -- where CI is always set. So "non-root" here is a
+        value the live path cannot produce, and it is asserted only because
+        build_target remains a parameter that a future caller could vary. The
+        discriminators that matter today are architecture and offline, covered by
+        ``TestScopeSeparatesWhatCannotBeShared``.
+        """
+        ci = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        non_root = _gha_layer_cache_args(
+            "docker", "non-root", force=False, offline=False
+        )
+        assert "scope=ash-ci-x86_64-online" in ci[1]
+        assert "scope=ash-non-root-x86_64-online" in non_root[1]
         assert ci != non_root
 
     def test_results_url_alone_is_sufficient(self, monkeypatch):
@@ -56,40 +93,40 @@ class TestCacheEnabled:
         monkeypatch.delenv("ACTIONS_CACHE_URL", raising=False)
         monkeypatch.setenv("ACTIONS_RESULTS_URL", "https://example.invalid/results/")
         monkeypatch.delenv("ASH_DISABLE_GHA_BUILD_CACHE", raising=False)
-        assert _gha_layer_cache_args("docker", "ci", force=False) != []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) != []
 
 
 class TestCacheDeclined:
     @pytest.mark.parametrize("runner", ["podman", "finch", "nerdctl", ""])
     def test_non_docker_runners_decline(self, in_actions, runner):
         """type=gha is a buildx backend; the others only cache via a registry."""
-        assert _gha_layer_cache_args(runner, "ci", force=False) == []
+        assert _gha_layer_cache_args(runner, "ci", force=False, offline=False) == []
 
     def test_force_declines(self, in_actions):
         """force means --no-cache, so reading a cache would contradict the caller."""
-        assert _gha_layer_cache_args("docker", "ci", force=True) == []
+        assert _gha_layer_cache_args("docker", "ci", force=True, offline=False) == []
 
     def test_opt_out_env_declines(self, in_actions, monkeypatch):
         monkeypatch.setenv("ASH_DISABLE_GHA_BUILD_CACHE", "1")
-        assert _gha_layer_cache_args("docker", "ci", force=False) == []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) == []
 
     def test_blank_opt_out_is_not_an_opt_out(self, in_actions, monkeypatch):
         """An empty or whitespace value must not silently disable caching."""
         monkeypatch.setenv("ASH_DISABLE_GHA_BUILD_CACHE", "   ")
-        assert _gha_layer_cache_args("docker", "ci", force=False) != []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) != []
 
     def test_missing_token_declines(self, monkeypatch):
         monkeypatch.delenv("ACTIONS_RUNTIME_TOKEN", raising=False)
         monkeypatch.setenv("ACTIONS_CACHE_URL", "https://example.invalid/cache/")
         monkeypatch.delenv("ASH_DISABLE_GHA_BUILD_CACHE", raising=False)
-        assert _gha_layer_cache_args("docker", "ci", force=False) == []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) == []
 
     def test_missing_endpoint_declines(self, monkeypatch):
         monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "token")
         monkeypatch.delenv("ACTIONS_CACHE_URL", raising=False)
         monkeypatch.delenv("ACTIONS_RESULTS_URL", raising=False)
         monkeypatch.delenv("ASH_DISABLE_GHA_BUILD_CACHE", raising=False)
-        assert _gha_layer_cache_args("docker", "ci", force=False) == []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) == []
 
     def test_outside_actions_declines(self, monkeypatch):
         """The common case: a developer building locally must be unaffected."""
@@ -100,7 +137,159 @@ class TestCacheDeclined:
             "ASH_DISABLE_GHA_BUILD_CACHE",
         ):
             monkeypatch.delenv(key, raising=False)
-        assert _gha_layer_cache_args("docker", "ci", force=False) == []
+        assert _gha_layer_cache_args("docker", "ci", force=False, offline=False) == []
+
+    def test_runner_without_buildx_declines(self, in_actions, monkeypatch):
+        """A binary named docker that has no buildx must not be offered type=gha.
+
+        This is the podman-docker case: that package installs a /usr/bin/docker
+        shim which execs podman, and runner discovery reaches docker before
+        podman, so every other guard here passes for a runner that cannot honor a
+        buildx cache backend.
+        """
+        monkeypatch.setattr(
+            run_ash_container, "_runner_supports_buildx", lambda runner: False
+        )
+        assert (
+            _gha_layer_cache_args("/usr/bin/docker", "ci", force=False, offline=False)
+            == []
+        )
+
+
+class TestExportIsFailSoftAndBounded:
+    """The two properties that keep a live cache from breaking unrelated things.
+
+    Both were established by a real CI run rather than reasoned about: a transient
+    400 from the cache service failed three scan cells, and the Actions cache is
+    capped per repository and evicts across workflows.
+    """
+
+    def test_only_cache_to_ignores_errors(self, in_actions):
+        """cache-to must be fail-soft; cache-from must not be.
+
+        buildkit already degrades a failed import into a cache miss and carries on
+        -- the observed run continued building for over two minutes after one --
+        so wrapping the read direction would hide real problems for no gain. The
+        export failure is what aborted the build.
+        """
+        args = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        cache_from = args[args.index("--cache-from") + 1]
+        cache_to = args[args.index("--cache-to") + 1]
+        assert "ignore-error=true" in cache_to
+        assert "ignore-error" not in cache_from
+
+    def test_export_is_mode_min(self, in_actions):
+        """mode=max would export every intermediate stage of a multi-GB image.
+
+        Against a 10 GB per-repository cap that evicts by least-recent access
+        across all workflows, that risks evicting caches other jobs depend on.
+        """
+        args = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        cache_to = args[args.index("--cache-to") + 1]
+        assert "mode=min" in cache_to
+        assert "mode=max" not in cache_to
+
+
+class TestScopeSeparatesWhatCannotBeShared:
+    """Architecture and OFFLINE change the layers, so they must change the key.
+
+    Under a single scope the cache-enabled cells demonstrably could not share
+    entries -- they requested different manifests -- and buildkit keeps only
+    whichever build finished last, so the cache never survives to be reused.
+    """
+
+    def test_architecture_is_in_the_scope(self, in_actions, monkeypatch):
+        monkeypatch.setattr(run_ash_container.platform, "machine", lambda: "x86_64")
+        amd64 = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        monkeypatch.setattr(run_ash_container.platform, "machine", lambda: "aarch64")
+        arm64 = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        assert "scope=ash-ci-x86_64-online" in amd64[1]
+        assert "scope=ash-ci-aarch64-online" in arm64[1]
+        assert amd64 != arm64
+
+    def test_offline_is_in_the_scope(self, in_actions):
+        online = _gha_layer_cache_args("docker", "ci", force=False, offline=False)
+        offline = _gha_layer_cache_args("docker", "ci", force=False, offline=True)
+        assert "scope=ash-ci-x86_64-online" in online[1]
+        assert "scope=ash-ci-x86_64-offline" in offline[1]
+        assert online != offline
+
+    def test_both_directions_use_the_same_scope(self, in_actions):
+        """Reading one key and writing another would never produce a hit."""
+        args = _gha_layer_cache_args("docker", "ci", force=False, offline=True)
+        cache_from = args[args.index("--cache-from") + 1]
+        cache_to = args[args.index("--cache-to") + 1]
+        assert "scope=ash-ci-x86_64-offline" in cache_from
+        assert "scope=ash-ci-x86_64-offline" in cache_to
+
+
+class TestBuildxCapabilityProbe:
+    """The real ``_runner_supports_buildx``, with only the subprocess faked.
+
+    The autouse fixture above replaces the module attribute, but the name imported
+    at the top of this file still refers to the original function, so these
+    exercise it rather than the stand-in.
+    """
+
+    @pytest.fixture(autouse=True)
+    def clear_probe_cache(self):
+        """The probe memoizes by path, so the cache must not leak between tests."""
+        run_ash_container._BUILDX_SUPPORT_CACHE.clear()
+        yield
+        run_ash_container._BUILDX_SUPPORT_CACHE.clear()
+
+    def test_exit_zero_means_supported(self, monkeypatch):
+        monkeypatch.setattr(
+            run_ash_container.subprocess_utils,
+            "run_command",
+            lambda *a, **k: subprocess.CompletedProcess(args=[], returncode=0),
+        )
+        assert _runner_supports_buildx("/usr/bin/docker") is True
+
+    def test_non_zero_exit_means_unsupported(self, monkeypatch):
+        """What the podman-docker shim does: `podman buildx version` is not a command."""
+        monkeypatch.setattr(
+            run_ash_container.subprocess_utils,
+            "run_command",
+            lambda *a, **k: subprocess.CompletedProcess(args=[], returncode=125),
+        )
+        assert _runner_supports_buildx("/usr/bin/docker") is False
+
+    def test_a_raising_probe_is_treated_as_unsupported(self, monkeypatch):
+        """A timeout or a missing binary must decline the cache, not crash the build."""
+
+        def boom(*args, **kwargs):
+            raise subprocess.TimeoutExpired(cmd="docker buildx version", timeout=30)
+
+        monkeypatch.setattr(run_ash_container.subprocess_utils, "run_command", boom)
+        assert _runner_supports_buildx("/usr/bin/docker") is False
+
+    def test_the_probe_runs_once_per_runner(self, monkeypatch):
+        """It sits on the build path, so it must not shell out repeatedly."""
+        calls = []
+
+        def record(args, **kwargs):
+            calls.append(args)
+            return subprocess.CompletedProcess(args=args, returncode=0)
+
+        monkeypatch.setattr(run_ash_container.subprocess_utils, "run_command", record)
+        assert _runner_supports_buildx("/usr/bin/docker") is True
+        assert _runner_supports_buildx("/usr/bin/docker") is True
+        assert len(calls) == 1
+        assert calls[0] == ["/usr/bin/docker", "buildx", "version"]
+
+    def test_the_probe_does_not_log_at_info(self, monkeypatch):
+        """Probing is bookkeeping; it should not narrate itself into scan output."""
+        seen = {}
+
+        def record(args, **kwargs):
+            seen.update(kwargs)
+            return subprocess.CompletedProcess(args=args, returncode=0)
+
+        monkeypatch.setattr(run_ash_container.subprocess_utils, "run_command", record)
+        _runner_supports_buildx("/usr/bin/docker")
+        assert seen["log_level"] == logging.DEBUG
+        assert seen["timeout"] == 30
 
 
 class TestRunnerArrivesResolved:
@@ -119,20 +308,46 @@ class TestRunnerArrivesResolved:
             "/usr/bin/docker",
             "/usr/local/bin/docker",
             "/opt/homebrew/bin/docker",
-            # The Windows shape. Spelled with forward slashes so the final
-            # component is the same one pathlib sees on either platform.
+            # Forward slashes parse the same under either pathlib flavor, so this
+            # case says nothing about Windows on its own -- the shape Windows
+            # actually produces is backslash-separated, and is covered by
+            # test_windows_backslash_path_is_accepted below.
             "C:/Program Files/Docker/docker.exe",
             # Still accepted: a bare name remains valid input.
             "docker",
         ],
     )
     def test_resolved_docker_paths_enable_the_cache(self, in_actions, runner):
-        assert _gha_layer_cache_args(runner, "ci", force=False) == [
+        assert _gha_layer_cache_args(runner, "ci", force=False, offline=False) == [
             "--cache-from",
-            "type=gha,scope=ash-ci",
+            "type=gha,scope=ash-ci-x86_64-online",
             "--cache-to",
-            "type=gha,mode=max,scope=ash-ci",
+            "type=gha,mode=min,ignore-error=true,scope=ash-ci-x86_64-online",
         ]
+
+    def test_windows_backslash_path_is_accepted(self, in_actions, monkeypatch):
+        """The shape find_executable actually returns on Windows.
+
+        ``Path`` resolves to ``WindowsPath`` there, which reads a backslash as a
+        separator; a POSIX interpreter does not, and would take the whole string
+        as one component. Dispatching the module's ``Path`` to the Windows flavor
+        is what makes this assertion mean anything off Windows -- and it has to be
+        asserted here, because no Windows cell in CI can reach this gate: the
+        credentials are gated on ubuntu, and windows-latest appears in the scan
+        matrix only as python-local.
+        """
+        from pathlib import PureWindowsPath
+
+        monkeypatch.setattr(run_ash_container, "Path", PureWindowsPath)
+        assert (
+            _gha_layer_cache_args(
+                r"C:\Program Files\Docker\docker.exe",
+                "ci",
+                force=False,
+                offline=False,
+            )
+            != []
+        )
 
     @pytest.mark.parametrize(
         "runner",
@@ -143,7 +358,7 @@ class TestRunnerArrivesResolved:
         ],
     )
     def test_resolved_non_docker_paths_still_decline(self, in_actions, runner):
-        assert _gha_layer_cache_args(runner, "ci", force=False) == []
+        assert _gha_layer_cache_args(runner, "ci", force=False, offline=False) == []
 
     @pytest.mark.parametrize(
         "runner",
@@ -160,4 +375,4 @@ class TestRunnerArrivesResolved:
         directory, so a substring test would enable a buildx-only cache for a
         runner that cannot honor it.
         """
-        assert _gha_layer_cache_args(runner, "ci", force=False) == []
+        assert _gha_layer_cache_args(runner, "ci", force=False, offline=False) == []

--- a/tests/unit/interactions/test_gha_layer_cache_args.py
+++ b/tests/unit/interactions/test_gha_layer_cache_args.py
@@ -101,3 +101,63 @@ class TestCacheDeclined:
         ):
             monkeypatch.delenv(key, raising=False)
         assert _gha_layer_cache_args("docker", "ci", force=False) == []
+
+
+class TestRunnerArrivesResolved:
+    """The runner reaches this gate already resolved to a path, never as a name.
+
+    ``_resolve_oci_runner`` returns whatever ``find_executable`` produced, and that
+    is a full path -- ``/usr/bin/docker``, plus a ``.exe`` suffix on Windows. Every
+    test above passes the bare string ``docker``, which no caller supplies, so the
+    suite could pass while the gate rejected the only value it is ever handed.
+    These pin the resolved shape instead.
+    """
+
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            "/usr/bin/docker",
+            "/usr/local/bin/docker",
+            "/opt/homebrew/bin/docker",
+            # The Windows shape. Spelled with forward slashes so the final
+            # component is the same one pathlib sees on either platform.
+            "C:/Program Files/Docker/docker.exe",
+            # Still accepted: a bare name remains valid input.
+            "docker",
+        ],
+    )
+    def test_resolved_docker_paths_enable_the_cache(self, in_actions, runner):
+        assert _gha_layer_cache_args(runner, "ci", force=False) == [
+            "--cache-from",
+            "type=gha,scope=ash-ci",
+            "--cache-to",
+            "type=gha,mode=max,scope=ash-ci",
+        ]
+
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            "/usr/bin/podman",
+            "/usr/local/bin/finch",
+            "/usr/bin/nerdctl",
+        ],
+    )
+    def test_resolved_non_docker_paths_still_decline(self, in_actions, runner):
+        assert _gha_layer_cache_args(runner, "ci", force=False) == []
+
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            "/usr/bin/docker-compose",
+            "/usr/bin/docker-credential-ecr-login",
+            "/usr/bin/not-docker",
+        ],
+    )
+    def test_neighbors_of_docker_on_path_decline(self, in_actions, runner):
+        """Matching must be on the whole final component, not a substring of it.
+
+        ``docker`` is a prefix of several unrelated binaries that sit in the same
+        directory, so a substring test would enable a buildx-only cache for a
+        runner that cannot honor it.
+        """
+        assert _gha_layer_cache_args(runner, "ci", force=False) == []

--- a/tests/unit/interactions/test_run_ash_container_helpers_coverage.py
+++ b/tests/unit/interactions/test_run_ash_container_helpers_coverage.py
@@ -535,13 +535,27 @@ class TestBuildImage:
         monkeypatch.setenv("ACTIONS_RUNTIME_TOKEN", "token")
         monkeypatch.setenv("ACTIONS_CACHE_URL", "https://example.invalid/cache")
         monkeypatch.delenv("ASH_DISABLE_GHA_BUILD_CACHE", raising=False)
+        # The gate probes the runner for buildx, which would otherwise shell out
+        # and make this test depend on the machine running it.
+        monkeypatch.setattr(rac, "_runner_supports_buildx", lambda runner: True)
+        # Pin the architecture, which is part of the cache scope, so the expected
+        # string does not change on arm runners.
+        monkeypatch.setattr(rac.platform, "machine", lambda: "x86_64")
 
-        _build_image(**_build_image_kwargs(dockerfile, debug=True))
+        # build_target is "ci" rather than this module's "non-root" default because
+        # that is the only value reachable here: run_ash_container forces "ci"
+        # whenever CI is set, and the cache requires ACTIONS_RUNTIME_TOKEN, which
+        # only exists inside Actions.
+        _build_image(**_build_image_kwargs(dockerfile, build_target="ci", debug=True))
 
         cmd = recorded_commands[0]
         assert cmd[:4] == ["docker", "buildx", "build", "--load"]
         assert "--cache-from" in cmd
-        assert "type=gha,scope=ash-non-root" in cmd
+        assert "type=gha,scope=ash-ci-x86_64-online" in cmd
+        # The export direction must stay fail-soft and bounded: a transient cache
+        # 400 must not fail the build, and mode=max would push a multi-GB image
+        # into a 10 GB per-repository quota that other workflows share.
+        assert "type=gha,mode=min,ignore-error=true,scope=ash-ci-x86_64-online" in cmd
         assert "Running build command:" in capfd.readouterr().out
 
     def test_without_the_gha_cache_a_plain_build_is_used(


### PR DESCRIPTION
## The defect

`_gha_layer_cache_args` compared an already-resolved runner path against the bare string `"docker"`, so the comparison failed for every runner and the `type=gha` layer cache had never been enabled for anyone.

Repairing that comparison made the path execute for the first time, which exposed three further problems in the code it turned on. All four are fixed here.

## The verified trace, and what each step returns

| Step | Returns |
| --- | --- |
| `_resolve_oci_runner(oci_runner)` (`run_ash_container.py:277`) | the return value of `_find_runner`, not the candidate name — `return path` |
| `_find_runner(name)` | `subprocess_utils.find_executable(name)` verbatim |
| `find_executable(command)` (`utils/subprocess_utils.py:26`) | an absolute path on both branches: `shutil.which(cmd)`, or `poss.as_posix()` for the `ASH_BIN_PATH` and `/usr/local/bin` fallbacks. `None` only when nothing is found, and `_resolve_oci_runner` then raises `RuntimeError` |
| `_gha_layer_cache_args(resolved_oci_runner, ...)` | compared that absolute path against `"docker"` |

`resolved_oci_runner` is assigned once and passed straight through to `_build_image` and on to the gate. **There is no normalization step anywhere between them.** This holds even when the runner is given explicitly: `OCI_RUNNER=docker` still goes through `find_executable`, so the gate still sees a path.

Measured on a host where `docker` is `/usr/bin/docker`, with the Actions cache environment set so every other guard passes:

```
find_executable('docker')                        -> '/usr/bin/docker'
_gha_layer_cache_args('/usr/bin/docker',    ...) -> cache declined -> []
_gha_layer_cache_args('docker',             ...) -> CACHE ENABLED
```

Only the bare name — the one shape production never produces — was accepted.

## Why this survived: the tests passed an input no caller supplies

`test_gha_layer_cache_args.py` did assert a non-empty return, and `test_run_ash_container_helpers_coverage.py` even asserted the full `docker buildx build --load` argv end to end. Both passed the literal `"docker"`. So the positive case was covered with a value the resolver cannot produce, and the suite stayed green while the only value the gate ever receives was rejected. Coverage was not the gap; the input shape was.

The fix is `Path(resolved_oci_runner).stem != "docker"`, which accepts `/usr/bin/docker`, a bare `docker`, and the `.exe` form `find_executable` builds on Windows, while declining `/usr/bin/docker-compose` and the other `docker`-prefixed binaries that share a directory with it. `_resolve_oci_runner` is called exactly once and no other bare-name comparison against a resolved runner exists in `automated_security_helper/`, so this is one instance rather than a class.

## What turning the path on actually revealed

The first push of this branch failed three cells that a control PR passes: `scan (python-container, ubuntu-latest)`, `scan (python-container, ubuntu-24.04-arm)`, and `scan (python-container, ubuntu-latest) [offline]`. That set is exactly `method: python-container` and `oci-runner: docker` and `contains(os, 'ubuntu')` — precisely the condition under which the repaired gate returns flags. Nothing else moved. (The red `unit-test` cells are a `mikepenz/action-junit-report` token-permission error that appears identically on the control PR; the tests themselves passed and uploaded results.)

### 1. `ignore-error=true` on `cache-to`, and only on `cache-to`

The configuration was correct — buildx on the `docker-container` driver, credentials present, argv well-formed. The cache service returned an HTML error page:

```
23:54:06  #6  importing cache manifest from gha:10602703455898056127
23:54:06  #6  ERROR: failed to parse error response 400: <h2>Our services aren't available right now</h2>...
23:54:17  #13 [core 7/28] RUN apt-get update && ...      <- build continued, cache miss
23:56:48  #46 exporting to GitHub Actions Cache
23:56:48  #46 ERROR: failed to parse error response 400: <h2>Our services aren't available right now</h2>...
23:56:49  ERROR: failed to build: failed to solve: ...
```

The import failure at `#6` was non-fatal — the build ran on for another 2m42s. The export failure at `#46` was fatal, and the propagated error carries `#46`'s edge-reference id rather than `#6`'s. So buildkit already degrades gracefully on `cache-from` and dies on `cache-to`, and only the write direction needs wrapping. `cache-from` is deliberately left bare so real read problems stay visible.

An earlier revision of this description argued that `ignore-error` would mask misconfiguration and left it out. That reasoning does not survive this run: there was no misconfiguration to mask, only a transient upstream outage taking a security scan down with it. The claim has been withdrawn.

**The fix is confirmed by the same failure recurring and being absorbed.** The cache service returned the identical 400 on the export step of the re-run, and the cell passed anyway:

```
01:01:55  #46 exporting to GitHub Actions Cache
01:01:55  #46 preparing build cache for export 0.0s done
01:01:57  #46 sending cache export 1.6s done
01:01:57  #46 ERROR: failed to parse error response 400: <h2>Our services aren't available right now</h2>...
          (no "failed to build: failed to solve" anywhere in the job)
scan (python-container, ubuntu-latest)   pass   6m35s
```

Same step, same error, opposite outcome: before this change that `#46` 400 produced `ERROR: failed to build: failed to solve` and exit 1. An import 400 recurred at `#4` in the same run and was tolerated as before. So the cache is genuinely live rather than silently declining — the log shows the probe running as `/usr/bin/docker buildx version`, the new scope on both directions, and both an import and an export attempt.

### 2. The gate trusted the filename, which is not the capability

podman's `podman-docker` package installs a `/usr/bin/docker` script that emulates the Docker CLI by exec'ing podman, and `_OCI_RUNNER_CANDIDATES` reaches `docker` before `podman`. On a RHEL or Fedora host with that package and no finch, the resolved runner is named `docker`, has no buildx, and passes every name-based check.

That matters more than a lost optimization: before the comparison fix the gate rejected everything and the shim worked, so a name-only check would be a hard regression for that population. ASH is a distributed public scanner, so third-party CI is a real user base for it.

No path accessor can tell these apart, so the gate now asks: `<runner> buildx version`, memoized per resolved path. It runs last, after the environment checks have already established we are inside Actions, so it shells out about once per build and never on a local run that was going to decline anyway.

### 3. The scope key pinned a constant and omitted both dimensions that vary

`scope` was `f"ash-{build_target}"`, and `build_target` cannot discriminate on any path that reaches the cache: it is forced to `"ci"` whenever `CI` is set, and the cache requires `ACTIONS_RUNTIME_TOKEN`, which exists only inside Actions, where `CI` is always set. So the scope was the constant `ash-ci` and the `ci`/`non-root` collision the old comment guarded against was unreachable.

What does vary across the three cache-enabled cells is CPU architecture and `OFFLINE`. The logs show the two architectures requesting different manifests under that one scope (`gha:10602703455898056127` on amd64, `gha:16327726473344493535` on arm64), so they demonstrably cannot share entries, and buildkit keeps only whichever build finished last. `ARG OFFLINE` is consumed at `Dockerfile:53` and exported as `ENV` at line 61, so an offline and an online build share almost no layers below that point. Both are now in the key.

**`mode=max` is dropped in favor of `mode=min`, and this is the reason.** Tripling the scope count while exporting every intermediate stage of a multi-GB scanner image runs straight at a documented 10 GB per-repository cache cap that evicts by least-recent access **across all workflows in the repository**. The most likely casualty is the `astral-sh/setup-uv` cache that the 18-cell unit-test matrix restores — a regression that would surface in a different job and be nearly impossible to attribute. `mode=min` bounds the export to the layers of the target image, which is what a rebuild of the same cell reuses anyway.

A shared fallback scope on `cache-from` was considered and rejected: nothing writes such a scope, so reading it would be dead weight.

## Both-directions test proof

Against the original single-scope, `mode=max`, no-`ignore-error` code, 12 of the new assertions fail, including `test_only_cache_to_ignores_errors`, `test_export_is_mode_min`, `test_architecture_is_in_the_scope`, `test_offline_is_in_the_scope` and `test_both_directions_use_the_same_scope`. Against the original bare-string comparison, the four resolved-docker-path cases fail. All pass after.

The Windows case is asserted on the flavor that produces it. A backslash path only resolves correctly under `WindowsPath`; under a POSIX interpreter `PurePosixPath(r"C:\...\docker.exe").stem` is the entire string. Production is correct because `Path` dispatches to `WindowsPath` on Windows, but the previous revision's comment claimed a forward-slash spelling made the case platform-neutral, which was false and would have talked the next reader out of checking. The test now dispatches the module's `Path` to `PureWindowsPath`, and removing that dispatch makes it fail. This is the only coverage the `.exe` branch has anywhere: no Windows cell in CI can reach this gate, because the credentials are gated on ubuntu and `windows-latest` appears in the scan matrix only as `python-local`.

`test_scope_is_per_build_target` keeps its assertion but now records that `"non-root"` is a value the cache-enabled path cannot produce, with the reachable discriminators covered separately — the same trap this PR diagnoses for the runner, eight lines above the new class. The identical trap in `test_run_ash_container_helpers_coverage.py` is corrected the same way. Both files now stub the capability probe so they do not depend on whether the machine running them has docker installed.

## Verification

Full suite as CI runs it — `uv sync --extra cdk` then `uv run pytest`:

| | passed | skipped | xfailed | failed |
| --- | --- | --- | --- | --- |
| `origin/main` baseline | 6561 | 119 | 3 | 0 |
| this branch | 6584 | 119 | 3 | 0 |

The +23 are the new cases. Skipped is unchanged at 119 and xfailed at 3, so nothing was skipped or turned into an expected failure.

Lint, compared against an `origin/main` baseline across all three touched files: 46 findings before, 46 after, zero added and zero removed — all pre-existing `UP006`, `DTZ005`, `BLE001` and `SIM102`. The capability probe catches `(OSError, SubprocessError)` rather than a bare `Exception` specifically so it does not add a 5th `BLE001`; that is safe because `run_command` with `check=False` already converts a timeout or a missing binary into a non-zero `CompletedProcess` and never raises. Both test files are clean under `ruff check` and `ruff format --check`. `run_ash_container.py` would be reformatted both before and after, at the same 11 hunks, none touching the changed lines.

## What was not measured

**The cache's effect on build time was not measured**, and this revision still does not measure it. What is now shown is narrower: the flags are emitted, and a cache-service failure no longer fails the build. Whether the cache shortens the container build, and by how much, is not established here.

The eviction risk above is likewise reasoned from the documented 10 GB cap and its cross-workflow LRU policy, not from an observed eviction. `mode=min` is a precaution against it, not a measurement of it.
