### PR TITLE
fix(transpiler): point validation hints at backend class vars, not configs.yaml

### DIFF
--- a/ash-agent-plugins/.pre-commit-config.yaml
+++ b/ash-agent-plugins/.pre-commit-config.yaml
@@ -1,10 +1,11 @@
 # pre-commit hooks for the agentic-coding-plugins repo.
 #
 # Two hooks driven by `uv run`:
-#   1. transpile-base — regenerates AGENTS.md + claude/, codex/, kiro/, ...
-#                       whenever transpiler/_base/ or transpiler/ changes.
-#   2. verify-no-drift — fails the commit if any platform output differs from
-#                        what the transpiler would produce. Catches hand-edits.
+#   1. agentic-plugins-build — regenerates AGENTS.md + claude/, codex/, kiro/, ...
+#                              whenever transpiler/_base/ or transpiler/ changes.
+#   2. agentic-plugins-check — fails the commit if any platform output differs
+#                              from what the transpiler would produce, and runs
+#                              output validation. Catches hand-edits.
 #
 # uv handles its own .venv inside transpiler/ — pre-commit doesn't manage it.
 # First run is slow (creates .venv, installs jinja2); subsequent runs are ~50ms.

--- a/ash-agent-plugins/agentic-coding/transpiler/validate.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/validate.py
@@ -275,12 +275,12 @@ def validate_structural_sanity(plugins_root: Path) -> list[Error]:
             try:
                 json.loads(content)
             except json.JSONDecodeError as e:
-                errors.append(err(rel, f"invalid JSON: {e}", "Edit transpiler/_base/ or the backend's class vars under transpiler/backends/; the transpiler emits malformed JSON."))
+                errors.append(err(rel, f"invalid JSON: {e}", "Edit transpiler/_base/ or the backend's class vars; the transpiler emits malformed JSON."))
         elif path.suffix in {".yaml", ".yml"}:
             try:
                 yaml.safe_load(content)
             except yaml.YAMLError as e:
-                errors.append(err(rel, f"invalid YAML: {e}", "Edit transpiler/_base/ or the backend's class vars under transpiler/backends/; the transpiler emits malformed YAML."))
+                errors.append(err(rel, f"invalid YAML: {e}", "Edit transpiler/_base/ or the backend's class vars; the transpiler emits malformed YAML."))
         elif path.suffix in {".md", ".mdc"} and content.startswith("---"):
             try:
                 fm, _ = parse_frontmatter(content)

--- a/ash-agent-plugins/agentic-coding/transpiler/validate.py
+++ b/ash-agent-plugins/agentic-coding/transpiler/validate.py
@@ -13,7 +13,7 @@ Three validation tiers:
       All generated *.md files declared to have frontmatter actually do
         (parsed via the python-frontmatter library — handles BOM, CRLF,
          trailing-newline variants, escaped delimiters)
-      Every path declared in configs.yaml exists in the output
+      Every path declared by a backend's class vars exists in the output
 
   Tier 3 — Known platform constraints (documented hard rules from each
             platform's docs that we encoded during research)
@@ -275,18 +275,18 @@ def validate_structural_sanity(plugins_root: Path) -> list[Error]:
             try:
                 json.loads(content)
             except json.JSONDecodeError as e:
-                errors.append(err(rel, f"invalid JSON: {e}", "Edit transpiler/_base/ or configs.yaml; the transpiler emits malformed JSON."))
+                errors.append(err(rel, f"invalid JSON: {e}", "Edit transpiler/_base/ or the backend's class vars under transpiler/backends/; the transpiler emits malformed JSON."))
         elif path.suffix in {".yaml", ".yml"}:
             try:
                 yaml.safe_load(content)
             except yaml.YAMLError as e:
-                errors.append(err(rel, f"invalid YAML: {e}", "Edit transpiler/_base/ or configs.yaml; the transpiler emits malformed YAML."))
+                errors.append(err(rel, f"invalid YAML: {e}", "Edit transpiler/_base/ or the backend's class vars under transpiler/backends/; the transpiler emits malformed YAML."))
         elif path.suffix in {".md", ".mdc"} and content.startswith("---"):
             try:
                 fm, _ = parse_frontmatter(content)
             except yaml.YAMLError as e:
                 errors.append(err(rel, f"invalid YAML frontmatter: {e}",
-                                  "Edit transpiler/templates/ or configs.yaml frontmatter_fields."))
+                                  "Edit transpiler/templates/ or the backend's SKILL/COMMANDS/AGENTS frontmatter_fields."))
                 continue
             if fm is None and _has_frontmatter_block(content):
                 errors.append(err(rel, "frontmatter delimiters present but block could not be parsed",
@@ -456,7 +456,7 @@ def validate_copilot_instructions_size(plugins_root: Path) -> list[Error]:
     if chars > COPILOT_INSTRUCTIONS_MAX_CHARS:
         return [err(p,
                     f"copilot-instructions.md is {chars} chars > {COPILOT_INSTRUCTIONS_MAX_CHARS} (Code Review limit)",
-                    "Trim transpiler/_base/skill.md or lower truncate_chars in configs.yaml.")]
+                    "Trim transpiler/_base/skill.md or lower truncate_chars in the `copilot` backend's INSTRUCTION_FILE class var.")]
     return []
 
 
@@ -469,7 +469,7 @@ def validate_windsurf_rule_size(plugins_root: Path) -> list[Error]:
         size = len(rule_path.read_bytes())
         if size > WINDSURF_RULE_MAX_BYTES:
             errors.append(err(rule_path, f"windsurf rule is {size} bytes > {WINDSURF_RULE_MAX_BYTES}",
-                              "Trim transpiler/_base/skill.md or lower truncate_bytes in configs.yaml."))
+                              "Trim transpiler/_base/skill.md or lower truncate_bytes in the `windsurf` backend's SKILL class var."))
     return errors
 
 
@@ -590,7 +590,7 @@ def validate_mcpb_archive(plugins_root: Path) -> list[Error]:
             ptr = "/".join(str(p) for p in verr.absolute_path)
             errors.append(err(f"{archive}#manifest.json/{ptr}",
                               f"MCPB archive manifest schema violation: {verr.message}",
-                              "Edit transpiler/_base/manifest.json or configs.yaml `mcpb_bundle`."))
+                              "Edit transpiler/_base/manifest.json or the `mcpb` backend's MCPB_BUNDLE class var."))
 
     # Verify the archive's manifest matches the on-disk source manifest.
     # Normalize both via json round-trip to ignore insignificant whitespace


### PR DESCRIPTION
## What this fixes

Two sets of user-facing references in `ash-agent-plugins/` that survived the
class-per-backend refactor and now point at things that are not in the tree:
`validate.py`'s fix-hints, and the `.pre-commit-config.yaml` header comment.

Branched from `origin/main` at `9c4f9644`. `main` has since advanced to
`882b4b2a`, which merged #544; that changed the picture for the sweep below and
is accounted for. Neither of the two files here was touched by it, so this branch
is `MERGEABLE` — just behind. It is left un-rebased deliberately.

---

## Defect 1 — `validate.py` sent users to a deleted file

`configs.yaml` is absent from the tree. `git ls-files` over
`ash-agent-plugins/agentic-coding/transpiler` lists 86 files and none is
`configs.yaml`, `transpile.py`, or `schema.py` — all three went in the refactor
that replaced them with backend sub-packages plus `transpiler/registry.py`.

### Count measured, versus the count in the report

The report said **seven user-facing error hints**. There are **seven
references**, but they are not all error hints:

| Line | Kind | What it said |
|---|---|---|
| 16 | module docstring, Tier 2 summary | "Every path declared in configs.yaml exists in the output" |
| 278 | fix-hint | "Edit transpiler/\_base/ or configs.yaml; the transpiler emits malformed JSON." |
| 283 | fix-hint | "Edit transpiler/\_base/ or configs.yaml; the transpiler emits malformed YAML." |
| 289 | fix-hint | "Edit transpiler/templates/ or configs.yaml frontmatter\_fields." |
| 459 | fix-hint | "Trim transpiler/\_base/skill.md or lower truncate\_chars in configs.yaml." |
| 472 | fix-hint | "Trim transpiler/\_base/skill.md or lower truncate\_bytes in configs.yaml." |
| 593 | fix-hint | "Edit transpiler/\_base/manifest.json or configs.yaml \`mcpb\_bundle\`." |

So: **six fix-hints plus one docstring line**, not seven fix-hints. The
docstring line matters for the same reason — it is the file's own description of
what Tier 2 checks, and it named the deleted file as the source of the paths.

One more correction: the file is at `agentic-coding/transpiler/validate.py`, not
`agentic-coding/transpiler/transpiler/validate.py`. It is a top-level module at
the project root, imported by `transpiler/cli.py:143` as
`from validate import validate_all`, and deliberately not in the wheel's package
list.

### The replacement, and how each name was checked

The file already had the right idiom, three instances of it, in
`EXTERNAL_SCHEMAS` at lines 69/74/79 — those were updated during the refactor
and read "Edit transpiler/\_base/manifest.json or the \`mcpb\` backend's
MCPB\_BUNDLE class var". The six stale hints now match that idiom rather than
inventing a new one:

| Setting | Now named as |
|---|---|
| `truncate_chars` | the `copilot` backend's `INSTRUCTION_FILE` class var |
| `truncate_bytes` | the `windsurf` backend's `SKILL` class var |
| `frontmatter_fields` | the backend's `SKILL`/`COMMANDS`/`AGENTS` class vars |
| `mcpb_bundle` | the `mcpb` backend's `MCPB_BUNDLE` class var |
| declared output paths | a backend's class vars |

Each name was resolved against the live registry rather than read off the
source, so no hint can name a class var that does not exist:

```
$ uv run --directory ash-agent-plugins/agentic-coding/transpiler python -c "..."
registry size: 17
copilot.INSTRUCTION_FILE.truncate_chars = 4000
windsurf.SKILL.truncate_bytes           = 12000
mcpb.MCPB_BUNDLE.archive_path           = ash.mcpb
backends with frontmatter_fields on SKILL/COMMANDS/AGENTS: 9
```

4000 and 12000 are the same numbers as `COPILOT_INSTRUCTIONS_MAX_CHARS` and
`WINDSURF_RULE_MAX_BYTES`, the constants the two size checks compare against, so
each hint points at the knob that actually produced the failure.

### On naming a command

**No rewritten hint names a command.** All six are "Edit ..." or "Trim ..."
hints whose defect was naming the wrong *file*, so the fix is the right edit
site and there is no way for this change to introduce a broken command.
`agentic-plugins` is the live entry point; the `transpile` console script is not
referenced anywhere here.

The two command-bearing hints already in the file were left alone after
confirming both resolve, since a stale one would be the same defect:

```
$ uv run --project ash-agent-plugins/agentic-coding/transpiler \
    python -c "import tools.refresh_schemas as m; print(m.main)"
refresh-schemas -> <function main at 0x7f8053766f20>

$ uv run --project ash-agent-plugins/agentic-coding/transpiler --extra refresh \
    python -c "import tools.generate_models as m; print(m.main)"
generate-models -> <function main at 0x7f44fc24af20>
```

### Proving the new text is what a user sees

No test in the suite imports `validate` or asserts any hint text — `git grep`
for `validate_`, `truncate_`, `frontmatter_fields`, and `MCPB_BUNDLE` across
`tests/` returns nothing. So "the tests pass" is no evidence at all here.

Instead the six runtime-reachable hints were driven directly, with inputs built
to trip each branch: malformed JSON, malformed YAML, malformed frontmatter, a
4100-char instruction file, a 12100-byte rule, and an archive whose
`manifest.json` fails the MCPB schema. Every block is a positive control — the
probe exits non-zero if any check returns zero errors, so "no output" cannot
read as success. All six fired:

```
=== structural_sanity (JSON/YAML/frontmatter) -> 3 error(s) ===
  HINT: Edit transpiler/templates/ or the backend's SKILL/COMMANDS/AGENTS frontmatter_fields.
  HINT: Edit transpiler/_base/ or the backend's class vars; the transpiler emits malformed YAML.
  HINT: Edit transpiler/_base/ or the backend's class vars; the transpiler emits malformed JSON.
=== copilot_instructions_size -> 1 error(s) ===
  HINT: Trim transpiler/_base/skill.md or lower truncate_chars in the `copilot` backend's INSTRUCTION_FILE class var.
=== windsurf_rule_size -> 1 error(s) ===
  HINT: Trim transpiler/_base/skill.md or lower truncate_bytes in the `windsurf` backend's SKILL class var.
=== mcpb_archive -> 5 error(s) ===
  HINT: Edit transpiler/_base/manifest.json or the `mcpb` backend's MCPB_BUNDLE class var.

PROBE OK - 6 distinct hints fired, none names configs.yaml
```

The seventh reference is the module docstring, which is not runtime-reachable.

### Correction after review: the first repair reintroduced the defect

The initial rewrite of the two structural-sanity hints read "Edit
`transpiler/_base/` or the backend's class vars **under `transpiler/backends/`**".
Adversarial review caught that those two fragments resolve from *different*
working directories, so no reader could satisfy both — backends live at
`transpiler/transpiler/backends`, because the project root and the package share
a name:

| fragment | from `agentic-coding/` | from the transpiler project root |
|---|---|---|
| `transpiler/_base/` | exists | absent |
| `transpiler/backends/` | absent | exists |

Each row was checked in both directions — the absences with `git ls-files`, and
the presences too, so that a missing result could not be a bad pathspec reading
as a real absence.

Fixed by dropping the directory, which is also what the file's idiom already
does: the three hints that were clean before this PR (69, 74, 79) name the class
var with no path, and so do the four other rewrites here. Only these two
appended one. Spelling it `transpiler/transpiler/backends/` would be accurate but
reads like a typo and invites someone to "correct" it back.

**Why the first pass missed it, since the lesson generalizes.** Every class var
was resolved against the live registry, and that check passed. The appended
directory was the one element of those two hints that *was not a class var*, so
it fell outside what was verified — a check scoped to one kind of element does
not cover a sentence containing two.

The replacement text is now verified the way the originals were. All 13 path
fragments in the file's hints are resolved against the git tree from every
plausible root, asserting both that each exists somewhere and that no single hint
mixes fragments needing different roots:

```
13 distinct path fragments referenced in validate.py
fragment                              repo root  ash-agent-plugins/  agentic-coding/  project root
transpiler/_base/                     -          -                   EXISTS           -
transpiler/_base/manifest.json        -          -                   EXISTS           -
transpiler/_base/skill.md             -          -                   EXISTS           -
transpiler/templates/                 -          -                   EXISTS           -
generated_models/  schemas/  tools/…  -          -                   -                EXISTS
...
PASS - every fragment resolves, and every multi-path hint shares a common root
```

The `generated_models/`, `schemas/` and `tools/` fragments are rooted at the
project root rather than `agentic-coding/`, but those are pre-existing *code
comments* describing the source layout, not hints telling a user where to edit,
and no hint mixes the two conventions.

---

## Defect 2 — the pre-commit header named hooks that do not exist

Confirmed exactly as reported. `ash-agent-plugins/.pre-commit-config.yaml`
described `transpile-base` (line 4) and `verify-no-drift` (line 6). Neither id is
in the file. The two it defines are `agentic-plugins-build` (line 18) and
`agentic-plugins-check` (line 25), so the comment explaining the file
contradicted the file eleven lines below it.

Both names now match, verified by parsing the file rather than reading it:

```
parsed OK; hook ids = ['agentic-plugins-build', 'agentic-plugins-check']
```

The second entry also now mentions output validation. `agentic-plugins check`
runs drift detection *and* validation in one pass — its own hook name already
says "Verify drift + validation across all backends" — so the old comment
described half of it. The hanging indent is preserved: both new ids are 21
characters, so the continuation lines stay aligned.

---

## Full sweep of the same class

Swept `ash-agent-plugins/` for `configs.yaml`, `transpile.py`, `schema.py`,
`render_platform`, `schemas/refresh.sh`, and both old hook names. Every hit:

### Fixed here

| File:line | Stale reference |
|---|---|
| `transpiler/validate.py:16` | `configs.yaml` (docstring) |
| `transpiler/validate.py:278,283,289,459,472,593` | `configs.yaml` (six fix-hints) |
| `.pre-commit-config.yaml:4` | `transpile-base` |
| `.pre-commit-config.yaml:6` | `verify-no-drift` |

### Left: owned by #544, which has since merged and fixed them

These were live hits when the sweep first ran, and were left alone because
PR #544, "fix(transpiler): drop the dead transpile entry point and fix the docs
it broke", was open against `main` and already changed every file below. That
PR's own body explicitly handed off `validate.py` as the follow-up this PR is.

**It merged mid-flight, as `882b4b2a`.** Re-running the whole sweep against the
new `main` confirms every one of these is now gone, so leaving them was the
right call rather than a deferral — duplicating them here would have been a
conflict for no gain:

```
$ git grep -nF -e configs.yaml -e transpile.py -e schema.py -e render_platform \
    -e refresh.sh -e transpile-base -e verify-no-drift origin/main -- ash-agent-plugins/
.pre-commit-config.yaml:4,6                    <- this PR (Defect 2)
transpiler/transpiler/backends/__init__.py:7   <- deliberate historical note, see below
transpiler/validate.py:16,278,283,289,459,472,593  <- this PR (Defect 1)
```

`validate.py` is untouched by `882b4b2a`: all seven references survive at
identical line numbers, which is both why this PR is still needed and why it does
not conflict. Once it lands, the only remaining `configs.yaml` mention anywhere in
the subtree is the intentional one in `backends/__init__.py`.

| File:line | Stale reference |
|---|---|
| `README.md:54` | `transpile.py` |
| `README.md:55` | `schema.py`, `configs.yaml` |
| `README.md:56` | `configs.yaml` |
| `README.md:83` | `configs.yaml`, `render_platform()` |
| `README.md:85` | `configs.yaml` |
| `README.md:128` | `configs.yaml` |
| `README.md:134` | `schemas/refresh.sh` |
| `transpiler/README.md:9,10,18` | `transpiler/transpile.py` |
| `transpiler/registry.py:4` | "all 15 platform modules" — `backends/__init__.py` imports 17, and the registry holds 17 |
| `transpiler/pyproject.toml:4,27` | "14 AI coding agent platforms", and the dead `transpile` script |

`render_platform` was checked independently: it exists nowhere in the tree
except that one README sentence, so the reference is genuinely dead — but it is
#544's line to delete.

### Left: correct as written

- **`transpiler/backends/__init__.py:7`** — "kept in the same order as the
  original `configs.yaml` so generated output ordering is stable across the
  refactor". This is a past-tense historical note explaining *why* the import
  order is what it is. It does not send anyone to the file, and removing the
  reference would remove the reason the order is load-bearing. Accurate, kept.
- **`validate.py:69,74,79`** — already name backend class vars. These are the
  idiom the six fixes were matched to.
- **`validate.py:188,224`** — name `refresh-schemas` and `generate-models`; both
  verified to resolve above.
- **The seven "Run the transpiler." hints** (lines 358, 364, 369, 374, 379, 384,
  580) — generic, and still true.
- **`validate.py:33-35`** — "Hints point back at the `_base/` source file the
  user should edit". Now slightly incomplete, since some hints point at class
  vars instead, but that was already true of lines 69/74/79 before this change,
  and it names nothing that fails to exist. Not a stale reference; left.
- **`.pre-commit-config.yaml:10`** — "installs jinja2". `jinja2` is still a
  declared dependency and the sentence does not claim it is the only one.
- **`transpiler/README.md:3`** — "14 platform plugin packages" looks wrong
  against the gate's "17 platform outputs", but it is not: 14 are named AI
  coding agent platforms, and the other three registry entries are not platforms
  in that sense — `mcpb` is a package format, and `generic-skill` and
  `skills-root` are the same agentskills.io release landing in two places. The
  root `README.md:3` already reconciles this explicitly. Left, and it is #544's
  file regardless.

---

## Verification

| Check | Result |
|---|---|
| `agentic-plugins check` (drift + validation) | **exit 0** — 17 outputs match `_base/`, identical to the `origin/main` run |
| `pytest` (transpiler suite) | **26 passed**, 0 failed, 0 skipped — unchanged |
| `ruff check` on `validate.py` | **identical to the `origin/main` baseline** — 1 pre-existing `BLE001` at `234:12`, zero added |
| `ruff format` neutrality | formatted `origin/main` vs formatted branch differ **only** by the 7 intended strings |
| `cz check` on the PR title | passes |
| `cz check --rev-range origin/main..HEAD` | passes, all three subjects |
| Hint path fragments resolvable | **13/13**, and no hint mixes working roots |
| `.pre-commit-config.yaml` | parses; hook ids confirmed |

Nothing outside `ash-agent-plugins/.pre-commit-config.yaml` and
`ash-agent-plugins/agentic-coding/transpiler/validate.py` is touched — 2 files,
12 insertions, 11 deletions. No test was weakened, skipped, or deleted; no test
file changed at all. `_base/` is untouched, which is why the drift gate should
be stable — but it was run before and after rather than assumed.

The `ruff check` comparison was done by piping the `origin/main` copy through
`--stdin-filename` at the real path, so config resolution is identical on both
sides rather than differing because the baseline sat in a temp directory. Both
sides print exactly `validate.py:234:12: BLE001`.

### The test count was reported as 30; on this branch's base it is 26

At `9c4f9644`, where this branch starts, the suite is **26 passed, 0 skipped**,
and this PR leaves it at 26 — it changes no test file. The 30 figure belongs to
#544, which adds `tests/test_console_scripts.py` (its body: "30 passed ... 26 on
main plus 4 new"). Now that #544 has merged, `main` is at 30, so 30 is what CI
will report once this branch is up to date. Both numbers are right; they just
describe different commits. Nothing here is skipped, weakened, or deleted either
way.

Worth recording for anyone re-running it: `uv run --project ... pytest` with no
path argument collects the **repository root** `tests/` and dies in
`tests/conftest.py` with `ModuleNotFoundError: No module named 'tests.utils'`,
and `pytest` is not in the default dependency set either. The invocation that
actually runs this suite is:

```
uv run --directory ash-agent-plugins/agentic-coding/transpiler --extra test pytest
```

### Pre-existing lint and formatting state, deliberately not addressed

This subtree has never been through `ruff format`. Measured over
`agentic-coding/transpiler` with `ruff 0.16.6`:

```
$ ruff format --check   ->  39 files would be reformatted, 10 files already formatted
$ ruff check --statistics
    24 I001    unsorted-imports          4 PYI030  unnecessary-literal-union
     7 UP037   quoted-annotation         2 BLE001  blind-except
     5 F401    unused-import             2 SIM102  collapsible-if
     ... 48 errors total
```

42 Python files are tracked here; `ruff check` scans 43 paths, the extra one
being `pyproject.toml` (which is where the single `RUF200` comes from). The "5
pre-existing errors" figure that circulates for this subtree is the `F401`
subset specifically, in `backends/aider/__init__.py`, `emitters.py`, and
`orchestrator.py`; the total under a default `ruff` invocation is 48. Neither
number is changed by this PR.

The root `pre-commit` config carries the ruff hooks, this directory's own config
does not, and neither drift workflow runs them, which is how the subtree got
here.

`validate.py` was already in the "would reformat" set on `origin/main` and still
is — that verdict is unchanged. Rather than rest on a binary file-level verdict,
both versions were run through `ruff format` and the results diffed: the only
differences are the seven strings this PR intends to change, so these edits add
no new formatting divergence.

Reformatting the subtree is a separate change. Folding a 39-file reformat into a
correctness fix would make both unreviewable, so it is left alone here and noted
as its own known issue.
