### PR TITLE
fix(test): stop a CDK ref fixture reading as a stale ASH install pin

### DIFF
--- a/deploy/cdk-constructs/test/ash-scan-step.test.ts
+++ b/deploy/cdk-constructs/test/ash-scan-step.test.ts
@@ -291,15 +291,31 @@ describe('install modes', () => {
   });
 
   test('PIP pins the given git ref', () => {
+    // A commit, not a release tag, and the choice is load bearing twice over.
+    //
+    // This test only proves anything if the ref differs from the default one
+    // above, so naming the packaged version would make it pass whether or not
+    // `version` ever reached the buildspec. And a release tag here is
+    // indistinguishable, to anything reading the file as text, from an install
+    // command a user pastes: the tree-wide pin walk in
+    // tests/unit/test_agent_plugin_ash_version.py matches
+    // `automated-security-helper.git@v<semver>` wherever it appears and cannot
+    // tell a jest assertion from a real one, so a tag here either goes stale at
+    // the next release or costs that guard an exemption covering the whole
+    // file -- including the two live `@v3.7.0` pins it should keep watching.
+    // A commit is unambiguous, and it covers the third ref kind `version`
+    // documents; the default above already covers the tag case.
+    const commit = '0123456789abcdef0123456789abcdef01234567';
+
     const { template } = synthesizeWithStep({
       installMode: ASHInstallMode.PIP,
-      version: 'v3.6.0',
+      version: commit,
     });
 
     template.hasResourceProperties('AWS::CodeBuild::Project', {
       Source: Match.objectLike({
         BuildSpec: Match.stringLikeRegexp(
-          'git\\+https://github.com/awslabs/automated-security-helper.git@v3.6.0',
+          `git\\+https://github.com/awslabs/automated-security-helper.git@${commit}`,
         ),
       }),
     });


### PR DESCRIPTION
`main` is red on its own head. `ASH - Unified CI` fails 18 unit-test cells plus the `required-checks` aggregator from a single test, and this fixes it.

## The offending reference, verbatim

```
AssertionError: These install references do not name the packaged version 3.7.0:
    deploy/cdk-constructs/test/ash-scan-step.test.ts:302 pins v3.6.0

  A user or agent following any of them installs the wrong ASH, and nothing else fails -- a git ref
  resolves whether or not it is current. Fix the value, then arrange for it to be maintained: add the
  file to [tool.commitizen] version_files so `cz bump` rewrites it, or give it a {{VERSION}} template
  under scripts/version_template_manager.py. If the version is deliberately historical, add the file
  to _ALLOWED_STALE with the reason.
assert not [('deploy/cdk-constructs/test/ash-scan-step.test.ts', 302, '3.6.0')]
```

Exactly one reference, and it is not an install command.

## Root cause: an over-broad matcher, not a stale pin

Line 302 is the expected value of the jest test `PIP pins the given git ref`. The test passes `version: 'v3.6.0'` into `ASHScanStep` and asserts the synthesized buildspec carries that ref through:

```ts
test('PIP pins the given git ref', () => {
  const { template } = synthesizeWithStep({ installMode: ASHInstallMode.PIP, version: 'v3.6.0' });
  template.hasResourceProperties('AWS::CodeBuild::Project', {
    Source: Match.objectLike({
      BuildSpec: Match.stringLikeRegexp(
        'git\\+https://github.com/awslabs/automated-security-helper.git@v3.6.0',
      ),
    }),
  });
});
```

Nobody installs ASH from a `Match.stringLikeRegexp` argument, so the walk's stated harm — "a user or agent following any of them installs the wrong ASH" — does not apply to this line. The walk matches `automated-security-helper[.git]@v<semver>` wherever it appears in a decodable file and cannot tell an assertion from a command.

**Rewriting the value to 3.7.0 was rejected**, because it would not correct a reference, it would retire a test. The ref has to differ from `DEFAULT_ASH_REF` (`'v3.7.0'`) or the assertion is satisfied by the default and passes whether or not `version` ever reaches the buildspec.

**Adding the file to `_ALLOWED_STALE` was also rejected.** That dict is keyed by file, and this file holds two *live* `@v3.7.0` pins — the PIP and UVX default-install assertions. Exempting the whole file to excuse one line would stop the walk watching both, which costs more than the false positive does. The guard's own note asks for the other remedy first: "Prefer making prose version-free over adding to it."

## The fix

The fixture becomes a commit. `version` documents three ref kinds — a release tag, a branch, or a commit — and `gitRequirement` routes all three through the same interpolation, so a commit exercises the identical code path while being unmistakably not a version pin. The default-install assertion above still covers the tag case, and the sibling custom-repository test covers the branch case, so all three documented kinds now have coverage where two did before. Binding the input and the expectation to one `const` also stops the two literals drifting apart.

## Why neither pull request is at fault

The reference and the walk arrived from two branches that were never tested together, so this is a merge skew rather than a regression in either change. Measured, each with a positive control:

| SHA | What it is | Fixture present | Walk present | Could its CI see the failure |
| --- | --- | --- | --- | --- |
| `20605a8f` | #494 head | yes | no (404) | no |
| `9a9fa35d` | #542 head | no (404) | yes | no |
| `91ff3f51` | #542 merge | yes | yes | yes, but no Unified CI run exists |
| `882b4b2a` | #544 merge | yes | yes | yes — first observed run |

`deploy/cdk-constructs/` and this fixture were added by #494 at `407f5c1e` (merged 23:37:28Z); both files enter as `A`. The walk was added by #542 at `91ff3f51` (merged 23:45:01Z) from a branch cut before #494 landed — `deploy/` does not exist at its head at all. Both were correctly green on what they could see. The combination first existed at `91ff3f51`, where line 302 was already present, so `main` has been red since that merge. `882b4b2a` (#544) touched neither file; it is only where the first Unified CI run after the walk happened to land.

## Before and after

Before, on `882b4b2a`:

```
FAILED tests/unit/test_agent_plugin_ash_version.py::TestInstallRefsTrackPackagedVersion::test_every_install_ref_names_the_packaged_version
AssertionError: These install references do not name the packaged version 3.7.0:
    deploy/cdk-constructs/test/ash-scan-step.test.ts:302 pins v3.6.0
```

After:

```
tests/unit/test_agent_plugin_ash_version.py .... 11 passed in 18.61s
```

Full suite as CI runs it (`uv sync --extra cdk` then `uv run pytest`), exit 0:

```
6572 passed, 119 skipped, 3 xfailed, 1377 warnings in 108.43s
```

That is the red baseline's `1 failed, 6571 passed, 119 skipped` with the failure converted to a pass and the skip count unchanged.

## The guard is not weakened

Both supporting guards still pass, and the walk still watches the file I edited:

```
packaged version: 3.7.0
files with install refs: 49
total refs: 107
versions seen: {'3.7.0': 106, '3.0.1': 1}
allowlist: {'docs/VERSION_MANAGEMENT.md': 'illustrates the pattern shape, not an install command'}
edited file still walk-covered: True
  deploy/cdk-constructs/test/ash-scan-step.test.ts:289 -> v3.7.0
  deploy/cdk-constructs/test/ash-scan-step.test.ts:356 -> v3.7.0
offending (non-allowlisted, wrong version): []
```

Measured with the guard's own `_install_refs()`, not a reimplementation. The allowlist still has exactly one entry, unchanged. `test_the_walk_reaches_the_tree` sees 49 files against its floor of 20, and `test_the_allowlist_still_describes_real_files` passes.

The edited jest test can still fail: making `installCommands` ignore `install.version` fails `install modes > PIP pins the given git ref` (9 of 116 tests fail under that mutation). Reverted after measuring. Unmutated, all 116 tests in 3 suites pass.

Lint is unchanged against an `origin/main` baseline extracted with `git archive`. `ruff check`: 6744 findings, exit 1, on both trees. `ruff format --check`: 240 would be reformatted, 619 already formatted, on both. Zero added findings — the only changed file is TypeScript, so ruff's inputs did not move.

## Two version facts worth separating out, neither of them this bug

`[project] version` and `[tool.commitizen] version` **do agree**, both `3.7.0`, and `test_the_two_pyproject_version_fields_agree` passes. What does not agree is the repository against what shipped: the published Latest release is **v3.7.1** (2026-09-03), so a release went out without the bump landing on `main`. That is a real and separate problem, and it is emphatically *not* the cause of this red — setting the packaged version to 3.7.1 would make the walk flag dozens of now-correct `@v3.7.0` references instead of the one it flags today.

Anyone reconciling that version should know that `cz bump` currently computes a **major**:

```
bump: version 3.7.0 -> 4.0.0
tag to create: v4.0.0
increment detected: MAJOR
```

driven by an accumulated breaking change (a scanner that attempts targets and fails on all of them now reports ERROR with a non-zero exit code). Reconciling to 3.7.1 is therefore not a plain `cz bump`.

Separately, and left alone here to keep this change to the red: `deploy/cdk-constructs/` pins `@v3.7.0` in `README.md` and in the two default-install assertions, and `DEFAULT_ASH_REF` and three `buildspec*.yml` files carry a bare `v3.7.0`. None of those paths is in `[tool.commitizen] version_files`, so the next release will leave them behind and the walk will fail on the ones it can see. That is the walk behaving as designed, and it wants its own change.

## What this fixes, and what it does not

This is the part worth reading before reacting to a red check on this PR.

`required-checks` aggregates seven upstream jobs. On main's last observed Unified CI run — the merge_group run at `882b4b2a` — exactly one of them failed:

```
success    deploy-aws-helpers      success    lint
success    external-target-scan    success    multi-project-attribution
success    install-validation      success    scan-validation
failure    unit-test
```

On this PR, `unit-test` is green and two others are not:

```
success    deploy-aws-helpers      success    lint
success    external-target-scan    success    multi-project-attribution
failure    install-validation      failure    scan-validation
success    unit-test
```

All 18 unit-test cells pass, across ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-14 and windows-latest on py3.10 through py3.13, and `ts (cdk-constructs)` passes. That is the failure this PR set out to fix, and it is fixed.

`install-validation` and `scan-validation` fail on something else. Both fail on cdk-nag erroring while parsing files this diff does not touch:

```
ERROR  cdk-nag failed to scan /src/mkdocs.yml: ConstructorError: could not determine a constructor for the tag
ERROR  cdk-nag failed to scan /src/deploy/cdk/tsconfig.json: ScannerError: while scanning for the next token
ERROR  cdk-nag produced no validation report at ...
ERROR (2) Exiting due to 1 actionable findings found in ASH scan
```

Grounds for treating that as independent of this change: it is one TypeScript test file, cdk-nag scans no TypeScript, the named files are `mkdocs.yml`, `deploy/cdk/tsconfig.json` and fixtures under `tests/test_data/scanners/cdk/`, and ASH's own scan of this branch (`ash / SAST, SCA, and IaC Scan`) **passes**, so nothing added here introduces a finding. The same cdk-nag failure class also appears on a sibling PR that does not contain this commit.

So this PR removes the `unit-test` cause of main's red. It does not by itself turn main green — a second, independent breakage arrived after main's last observed run, and it needs its own fix. This change is not a prerequisite for that one, and that one is not a prerequisite for this.
