### PR TITLE
fix(retry): make the configured backoff actually happen

### DIFF
--- a/automated_security_helper/assets/with-retry.sh
+++ b/automated_security_helper/assets/with-retry.sh
@@ -23,6 +23,41 @@ set -o pipefail
 # Overridable so the retry behaviour can be exercised without waiting out the
 # real backoff. Defaults are what every Dockerfile caller gets.
 max=${WITH_RETRY_MAX_ATTEMPTS:-3}; delay=${WITH_RETRY_DELAY:-5}; attempt=1
+
+# Both knobs feed integer arithmetic below -- `$((delay * 2))` and
+# `[ $attempt -le $max ]` -- and bash arithmetic cannot parse a non-integer.
+# A fractional WITH_RETRY_DELAY such as 0.1, which is the obvious way to ask for
+# a fast-but-nonzero backoff, made `delay=$((delay * 2))` a syntax error. That
+# error aborts the enclosing `while` WITHOUT aborting the script (there is no
+# `set -e` here, and adding one would change how the attempt loop reports), so
+# exactly ONE attempt ran and the script still printed "All 3 attempts failed"
+# and exited 1. The attempt count was wrong and the only message anybody reads
+# said otherwise, which is precisely why no assertion on that message could see
+# it. Reject the bad value instead of retrying once and misreporting it.
+#
+# `case` rather than a regex or `expr` so this stays dependency-free: it runs in
+# the container build stage before most of the toolchain exists.
+case $max in
+  '' | *[!0-9]*)
+    echo "with-retry: WITH_RETRY_MAX_ATTEMPTS must be a non-negative integer, got '$max'" >&2
+    exit 2
+    ;;
+esac
+case $delay in
+  '' | *[!0-9]*)
+    echo "with-retry: WITH_RETRY_DELAY must be a whole number of seconds, got '$delay'" >&2
+    exit 2
+    ;;
+esac
+# Guarded separately, and only once $max is known to be numeric so `-lt` is
+# safe. max=0 would skip the loop entirely and then report "All 0 attempts
+# failed" with exit 1 -- a failure indistinguishable from the command having
+# been run and failed, when it was never run at all.
+if [ "$max" -lt 1 ]; then
+  echo "with-retry: WITH_RETRY_MAX_ATTEMPTS must be at least 1, got '$max'" >&2
+  exit 2
+fi
+
 while [ $attempt -le $max ]; do
   bash -o pipefail -c "$*" && exit 0
   echo "Attempt $attempt/$max failed, retrying in ${delay}s..." >&2

--- a/automated_security_helper/plugin_modules/ash_aws_plugins/aws_utils.py
+++ b/automated_security_helper/plugin_modules/ash_aws_plugins/aws_utils.py
@@ -89,9 +89,30 @@ def retry_with_backoff(
                         # If we shouldn't retry, re-raise the exception
                         raise
 
-                    # Calculate delay with exponential backoff and jitter
-                    delay = min(
-                        base_delay * (2**retries) + random.uniform(0, 1), max_delay  # nosec B311 — jitter for retry backoff, not security
+                    # Calculate delay with exponential backoff and jitter.
+                    #
+                    # Clamped non-negative deliberately. ``base_delay`` and
+                    # ``max_delay`` reach here from reporter config --
+                    # CloudWatchLogsReporter and S3Reporter both declare them as
+                    # bare ``float`` fields with no lower bound and hand them
+                    # straight to this decorator -- so a negative ``max_delay``
+                    # made this expression negative, and ``time.sleep`` raises
+                    # ValueError on a negative argument. That ValueError is then
+                    # swallowed by the broad ``except Exception`` in
+                    # ``_create_log_stream_with_retry``, so the retry silently
+                    # became zero retries and the log blamed the log stream.
+                    #
+                    # The floor is 0.0 rather than some small positive number
+                    # because ``base_delay=0`` is a legitimate way to ask for
+                    # immediate retries; what must not happen is a *negative*
+                    # interval reaching sleep, or an exception escaping from the
+                    # arithmetic that is supposed to protect a throttled API.
+                    delay = max(
+                        0.0,
+                        min(
+                            base_delay * (2**retries) + random.uniform(0, 1),  # nosec B311 — jitter for retry backoff, not security
+                            max_delay,
+                        ),
                     )
 
                     # Log the retry

--- a/automated_security_helper/utils/uv_tool_runner.py
+++ b/automated_security_helper/utils/uv_tool_runner.py
@@ -1,5 +1,6 @@
 """UV tool runner utility for managing UV-based tool execution and installation."""
 
+import random
 import subprocess  # nosec B404 — uv_tool_runner is the subprocess orchestrator for tool execution
 import threading
 import time
@@ -24,6 +25,53 @@ class UVToolRetryConfig:
     exponential_base: float = 2.0
     jitter: bool = True
     network_check_timeout: float = 5.0
+
+    def __post_init__(self) -> None:
+        """Clamp the schedule into a range that can actually be slept on.
+
+        These values arrive from scanner config by way of
+        ``UVToolMixin._install_uv_tool``, which builds this from a plain dict
+        with ``.get(key, default)`` and validates nothing. A negative
+        ``max_delay`` makes the computed interval negative, and ``time.sleep``
+        raises ``ValueError`` on a negative argument -- which, raised from inside
+        the install path, is indistinguishable to the caller from the install
+        itself having failed.
+
+        Normalizing rather than raising keeps one nonsensical knob from aborting
+        a scan, and because it mutates the fields in place, the mixin's existing
+        ``[INSTALLATION_CONFIG]`` debug line reports the values that will
+        actually be used instead of the ones that were asked for.
+
+        ``exponential_base`` floors at 1.0 rather than above it: 1.0 is a
+        deliberate fixed-interval retry, which is a legitimate choice. Below 1.0
+        the backoff would *shrink* between attempts, which never is.
+        """
+        self.max_retries = max(0, int(self.max_retries))
+        self.base_delay = max(0.0, float(self.base_delay))
+        # Ordered after base_delay so the cap can never sit below the floor.
+        self.max_delay = max(self.base_delay, float(self.max_delay))
+        self.exponential_base = max(1.0, float(self.exponential_base))
+        self.network_check_timeout = max(0.0, float(self.network_check_timeout))
+
+
+def _install_retry_delay(config: UVToolRetryConfig, attempt: int) -> float:
+    """Seconds to wait after 0-based ``attempt`` before the next install try.
+
+    Exponential growth, capped at ``max_delay``, optionally jittered, and
+    clamped non-negative.
+
+    The ``max(0.0, ...)`` overlaps with ``UVToolRetryConfig.__post_init__``,
+    which already guarantees ``max_delay >= base_delay >= 0``, and that overlap
+    is deliberate rather than sloppy: ``UVToolRetryConfig`` is a plain *mutable*
+    dataclass, so ``config.max_delay = -1`` after construction re-opens the hole
+    that normalization closed. This clamp sits closest to ``time.sleep``, which is
+    the only place the value actually has to be safe. Both guards are covered by
+    tests that distinguish them -- see ``TestRetryDelayIsAlwaysSleepable``.
+    """
+    delay = config.base_delay * (config.exponential_base**attempt)
+    if config.jitter:
+        delay += random.uniform(0, 1)  # nosec B311 — retry jitter, not security
+    return max(0.0, min(delay, config.max_delay))
 
 
 class UVToolRunner:
@@ -211,7 +259,13 @@ class UVToolRunner:
             tool_name: Name of the tool to install
             version_constraint: Optional version constraint (e.g., ">=1.7.0,<2.0.0")
             timeout: Timeout in seconds for installation
-            retry_config: Optional retry configuration
+            retry_config: Optional retry policy. ``None`` (the default) means a
+                single attempt. When supplied, a non-zero exit from
+                ``uv tool install`` is retried up to ``max_retries`` further
+                times, waiting an exponentially growing, capped, optionally
+                jittered interval between attempts. A timeout and an
+                OSError-shaped failure are both terminal either way -- see the
+                handlers below for why.
             package_extras: Optional list of package extras (e.g., ["sarif", "toml"])
             with_dependencies: Optional list of additional dependencies to install with --with flag
             progress_callback: Optional callback function for progress updates
@@ -295,46 +349,91 @@ class UVToolRunner:
             progress_thread = threading.Thread(target=progress_monitor, daemon=True)
             progress_thread.start()
 
-        try:
-            subprocess.run(  # nosec B603 — list args, validated uv executable path
-                cmd,
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-                check=True,
-                encoding="utf-8",
-                errors="replace",
-            )
+        # ``retry_config`` was accepted here and then silently dropped: there was
+        # no retry loop in this function at all, so a caller asking for
+        # ``max_retries=3`` got exactly one attempt. BanditScanner asks for
+        # exactly that (``ash_builtin/scanners/bandit_scanner.py``), and
+        # ``UVToolMixin._install_uv_tool`` logs "[INSTALLATION_CONFIG] Using
+        # custom retry configuration / max_retries=3, base_delay=1.0s" *before*
+        # calling in -- so the only observable anybody had announced a retry
+        # policy that did not exist. The tests around this asserted that log
+        # line, or that the config dict was passed through, or the bool this
+        # returns; none of the three moves when the retry is missing, which is
+        # why it survived. The regression tests added alongside this fix assert
+        # the attempt count and the sleep intervals instead.
+        #
+        # ``retry_config=None`` still means a single attempt, so every caller
+        # that never asked for retries keeps its behaviour exactly.
+        attempts = (1 + retry_config.max_retries) if retry_config else 1
+        last_error: str | None = None
 
-            # Stop progress monitoring
-            if progress_thread:
-                progress_thread = None
+        for attempt in range(attempts):
+            try:
+                subprocess.run(  # nosec B603 — list args, validated uv executable path
+                    cmd,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout,
+                    check=True,
+                    encoding="utf-8",
+                    errors="replace",
+                )
 
-            # Installing is exactly the event that makes a remembered version
-            # wrong, so drop this tool's memoized probe result. Without this, a
-            # caller that probed before installing (converters re-read
-            # tool_version afterwards) would keep seeing the pre-install answer.
-            invalidate_tool_version_cache(tool_name)
+                # Stop progress monitoring
+                if progress_thread:
+                    progress_thread = None
 
-            return True
-        except subprocess.TimeoutExpired as e:
-            # Handle timeout specifically
-            raise UVToolRunnerError(
-                f"Tool installation timed out after {timeout} seconds for {tool_name}. "
-                f"Command: {' '.join(cmd)}"
-                f"Error: {e}"
-            )
-        except subprocess.CalledProcessError as e:
-            # Handle non-zero exit codes
-            error_msg = f"Tool installation failed for {tool_name} with exit code {e.returncode}"
-            if e.stderr:
-                error_msg += f". Error: {e.stderr.strip()}"
-            raise UVToolRunnerError(error_msg)
-        except Exception as e:
-            # Handle other exceptions
-            raise UVToolRunnerError(
-                f"Unexpected error during tool installation for {tool_name}: {e}"
-            )
+                # Installing is exactly the event that makes a remembered version
+                # wrong, so drop this tool's memoized probe result. Without this, a
+                # caller that probed before installing (converters re-read
+                # tool_version afterwards) would keep seeing the pre-install answer.
+                invalidate_tool_version_cache(tool_name)
+
+                return True
+            except subprocess.TimeoutExpired as e:
+                # Deliberately terminal, not retried. This attempt already spent
+                # the whole ``timeout`` budget, so retrying would multiply wall
+                # clock by the attempt count -- three 300s timeouts is fifteen
+                # minutes of a scan phase spent waiting on a tool that is not
+                # coming. A timeout is also the one failure the caller can
+                # already see in its own elapsed time.
+                raise UVToolRunnerError(
+                    f"Tool installation timed out after {timeout} seconds for {tool_name}. "
+                    f"Command: {' '.join(cmd)}"
+                    f"Error: {e}"
+                )
+            except subprocess.CalledProcessError as e:
+                # A non-zero exit from ``uv tool install`` is the transient shape
+                # worth retrying: a reset connection, a 5xx from the index, a DNS
+                # blip. Remember the message and fall through to the backoff.
+                last_error = f"Tool installation failed for {tool_name} with exit code {e.returncode}"
+                if e.stderr:
+                    last_error += f". Error: {e.stderr.strip()}"
+            except Exception as e:
+                # Not retried: this is the OSError shape -- ``uv`` itself missing,
+                # not executable, or a bad cwd -- and no amount of waiting fixes
+                # any of them.
+                raise UVToolRunnerError(
+                    f"Unexpected error during tool installation for {tool_name}: {e}"
+                )
+
+            # ``retry_config is not None`` is redundant with ``attempt + 1 <
+            # attempts`` today: ``attempts`` is 1 whenever ``retry_config`` is
+            # falsy, so this line is reachable only when a real config exists.
+            # It is written out anyway for two reasons. A type checker cannot see
+            # that correlation and reports ``UVToolRetryConfig | None`` against
+            # ``_install_retry_delay``'s non-optional parameter. More to the
+            # point, if a later change to how ``attempts`` is derived ever broke
+            # the correlation, the failure would be an AttributeError raised
+            # *from inside the retry path* -- code that runs only once something
+            # has already gone wrong, and that no test exercising a successful
+            # install would ever reach. That is the same invisible-on-the-error-
+            # path shape as the missing retry this function was fixed for, so the
+            # invariant is stated in the condition rather than left implicit.
+            if retry_config is not None and attempt + 1 < attempts:
+                time.sleep(_install_retry_delay(retry_config, attempt))
+
+        raise UVToolRunnerError(last_error)
 
     def run_tool(
         self,

--- a/tests/unit/assets/test_with_retry.py
+++ b/tests/unit/assets/test_with_retry.py
@@ -141,6 +141,126 @@ class TestExitStatus:
         assert "All 3 attempts failed" in result.stderr
 
 
+def _sleep_recorder(tmp_path):
+    """Put a `sleep` on PATH that records its argv and returns immediately.
+
+    Returns ``(shim_dir, log_path)``.
+    """
+    shim_dir = tmp_path / "shim"
+    shim_dir.mkdir()
+    log = tmp_path / "sleep-argv"
+    shim = shim_dir / "sleep"
+    shim.write_text('#!/bin/bash\nprintf "%s\\n" "$*" >> "' + str(log) + '"\nexit 0\n')
+    shim.chmod(0o755)
+    return shim_dir, log
+
+
+class TestTheIntervalItActuallySleeps:
+    """What `sleep` is handed -- not what the log line says it was handed.
+
+    Every test above collapses the backoff with `WITH_RETRY_DELAY=0`, which is
+    what keeps them fast and also means not one of them can observe the interval.
+    With the delay pinned to zero, `delay=$((delay * 2))` stays zero forever, so a
+    change that destroyed the growth entirely would leave every assertion in this
+    file green.
+
+    That is the shape worth guarding against: the attempt count and the
+    "retrying in Ns" line are both emitted *upstream* of the arithmetic, so they
+    keep printing after the arithmetic is gone. These tests shim `sleep` onto
+    PATH and assert the argv it received, which pins the arithmetic without
+    measuring wall clock -- an elapsed-time bound would flake low on a fast
+    machine and high on a loaded one.
+    """
+
+    def test_default_backoff_doubles_and_sleep_receives_it(self, tmp_path):
+        """The Dockerfile passes no overrides, so this is the schedule in production."""
+        shim_dir, log = _sleep_recorder(tmp_path)
+        env = {**os.environ, "PATH": f"{shim_dir}{os.pathsep}{os.environ['PATH']}"}
+        env.pop("WITH_RETRY_DELAY", None)
+        env.pop("WITH_RETRY_MAX_ATTEMPTS", None)
+
+        result = subprocess.run(  # nosec B603 B607 — fixed script path, list args
+            ["bash", str(WITH_RETRY), "false"],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=60,
+            check=False,
+        )
+
+        assert result.returncode == 1, result.stderr
+        assert log.is_file(), (
+            "sleep was never invoked, so there is no backoff between attempts at "
+            "all and every retry fires back-to-back"
+        )
+        assert log.read_text().split() == ["5", "10", "20"], (
+            "the interval must double between attempts. ['5', '5', '5'] is a "
+            "fixed delay wearing the name backoff, and an empty or partial list "
+            "means the arithmetic broke part-way through the loop"
+        )
+
+
+class TestMalformedKnobsAreRejectedNotSilentlyHonoured:
+    """A non-integer delay used to truncate the loop to a single attempt.
+
+    `sleep $delay; delay=$((delay * 2))` is bash integer arithmetic, and bash
+    cannot parse `0.1` -- the obvious way to ask for a fast-but-nonzero backoff.
+    The arithmetic error aborts the enclosing `while` without aborting the script
+    (there is no `set -e` here), so exactly ONE attempt ran and the script still
+    printed "All 3 attempts failed" and exited 1.
+
+    Both of those observables were therefore useless for catching it: the exit
+    code was already 1 and the summary already said 3. So these assert how many
+    times the command actually ran.
+    """
+
+    def test_a_fractional_delay_is_rejected_before_any_attempt(self, tmp_path):
+        marker = tmp_path / "attempts"
+        result = run_with_retry(
+            f"printf x >> {marker}; false",
+            extra_env={"WITH_RETRY_DELAY": "0.1"},
+        )
+        assert not marker.exists(), (
+            "a rejected configuration must run the command zero times; a marker "
+            "holding one 'x' is the old behaviour, where the loop ran once and "
+            "then silently truncated while claiming three attempts"
+        )
+        assert result.returncode == 2, result.stderr
+
+    def test_a_non_numeric_attempt_count_is_rejected(self, tmp_path):
+        marker = tmp_path / "attempts"
+        result = run_with_retry(
+            f"printf x >> {marker}; false",
+            extra_env={"WITH_RETRY_MAX_ATTEMPTS": "three"},
+        )
+        assert not marker.exists()
+        assert result.returncode == 2, result.stderr
+
+    def test_zero_attempts_is_rejected_rather_than_reported_as_a_failed_run(
+        self, tmp_path
+    ):
+        """max=0 skipped the loop and then reported "All 0 attempts failed".
+
+        Exiting 1 with the command never run is indistinguishable from exiting 1
+        with the command run and failed, and the second is what a reader assumes.
+        """
+        marker = tmp_path / "attempts"
+        result = run_with_retry(f"printf x >> {marker}; false", attempts=0)
+        assert not marker.exists()
+        assert result.returncode == 2, result.stderr
+
+    def test_a_valid_integer_delay_is_still_accepted(self, tmp_path):
+        """Positive control: the guard must not reject the values callers use."""
+        marker = tmp_path / "attempts"
+        result = run_with_retry(
+            f"printf x >> {marker}; false",
+            attempts=2,
+            extra_env={"WITH_RETRY_DELAY": "0"},
+        )
+        assert marker.read_text() == "xx", "both attempts must have run"
+        assert result.returncode == 1
+
+
 def test_script_is_present_and_executable_source():
     """A missing script would make every test above skip-shaped rather than fail."""
     assert WITH_RETRY.is_file(), f"expected with-retry.sh at {WITH_RETRY}"

--- a/tests/unit/plugin_modules/ash_aws_plugins/test_aws_utils.py
+++ b/tests/unit/plugin_modules/ash_aws_plugins/test_aws_utils.py
@@ -104,6 +104,86 @@ class TestRetryWithBackoff:
         assert "ValidationError" in str(excinfo.value)
 
 
+class TestRetryIntervals:
+    """The interval is the one thing the tests above never observe.
+
+    They pass ``base_delay=0.01`` to stay fast and then assert only the call
+    count, so replacing the exponential with a constant -- or with zero -- would
+    leave every one of them green while the decorator hammered a throttled API
+    back-to-back. So these assert what ``time.sleep`` is handed.
+
+    No wall-clock bound is used: an elapsed-time assertion flakes low on a fast
+    machine and high on a loaded one, and would not distinguish a broken
+    schedule from a busy host.
+    """
+
+    @staticmethod
+    def _throttling_error():
+        return botocore.exceptions.ClientError(
+            {"Error": {"Code": "ThrottlingException", "Message": "Rate exceeded"}},
+            "operation",
+        )
+
+    def _sleeps_while_always_failing(self, **retry_kwargs):
+        mock_func = MagicMock(side_effect=self._throttling_error())
+        decorated_func = retry_with_backoff(**retry_kwargs)(mock_func)
+
+        sleeps = []
+        with (
+            patch(
+                "automated_security_helper.plugin_modules.ash_aws_plugins.aws_utils.time.sleep",
+                side_effect=sleeps.append,
+            ),
+            pytest.raises(botocore.exceptions.ClientError),
+        ):
+            decorated_func()
+        return sleeps, mock_func
+
+    def test_the_interval_grows_between_retries(self):
+        sleeps, mock_func = self._sleeps_while_always_failing(
+            max_retries=3, base_delay=10.0, max_delay=600.0
+        )
+
+        assert mock_func.call_count == 4
+        assert len(sleeps) == 3, "one wait between each pair of attempts, no more"
+        assert sleeps == sorted(sleeps), sleeps
+        # Jitter adds at most 1.0s and each step doubles a >=10s base, so the
+        # per-attempt envelopes cannot overlap and exact bounds are safe here.
+        assert 10.0 <= sleeps[0] < 11.0, sleeps
+        assert 20.0 <= sleeps[1] < 21.0, sleeps
+        assert 40.0 <= sleeps[2] < 41.0, sleeps
+
+    def test_the_interval_is_capped_at_max_delay(self):
+        sleeps, _ = self._sleeps_while_always_failing(
+            max_retries=4, base_delay=10.0, max_delay=25.0
+        )
+        assert all(interval <= 25.0 for interval in sleeps), sleeps
+        assert sleeps[-1] == 25.0, sleeps
+
+    def test_a_negative_max_delay_never_reaches_sleep(self):
+        """Reachable from reporter config, and it used to raise inside the retry.
+
+        CloudWatchLogsReporter and S3Reporter both declare ``base_delay`` and
+        ``max_delay`` as bare ``float`` fields with no lower bound and hand them
+        straight to this decorator. ``time.sleep`` raises ValueError on a negative
+        argument, and the broad ``except Exception`` in
+        ``_create_log_stream_with_retry`` swallows it -- so the retry silently
+        became zero retries and the warning blamed the log stream.
+        """
+        sleeps, mock_func = self._sleeps_while_always_failing(
+            max_retries=2, base_delay=1.0, max_delay=-30.0
+        )
+
+        assert all(interval >= 0.0 for interval in sleeps), sleeps
+        assert mock_func.call_count == 3, "the retries themselves must still happen"
+
+    def test_a_negative_base_delay_never_reaches_sleep(self):
+        sleeps, _ = self._sleeps_while_always_failing(
+            max_retries=2, base_delay=-5.0, max_delay=60.0
+        )
+        assert all(interval >= 0.0 for interval in sleeps), sleeps
+
+
 class TestGetAvailableModels:
     """Tests for the get_available_models function."""
 

--- a/tests/unit/utils/test_uv_tool_runner.py
+++ b/tests/unit/utils/test_uv_tool_runner.py
@@ -1,6 +1,7 @@
 """Tests for utils/uv_tool_runner.py — covers UVToolRunner class methods."""
 
 import subprocess  # nosec B404
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import pytest
@@ -9,6 +10,7 @@ from automated_security_helper.utils.uv_tool_runner import (
     UVToolRunner,
     UVToolRunnerError,
     UVToolRetryConfig,
+    _install_retry_delay,
     _reset_uv_tool_runner_caches,
     find_executable,
     find_uv_or_none,
@@ -291,6 +293,297 @@ class TestInstallToolWithVersion:
                 )
                 install_cmd = mock_run.call_args_list[-1][0][0]
                 assert "bandit[sarif,toml]" in install_cmd
+
+
+def _always_fails_with_reset(attempt_number):
+    """Every attempt dies the way a flaky index does: non-zero exit, no output."""
+    return subprocess.CalledProcessError(
+        1, ["uv", "tool", "install"], "", "Connection reset by peer"
+    )
+
+
+@contextmanager
+def _install_harness(runner, outcome_for_attempt):
+    """Reduce ``install_tool_with_version`` to just its own install subprocess.
+
+    ``is_tool_installed`` is stubbed out rather than driven through
+    ``subprocess.run`` deliberately: these tests read a *count*, and a count that
+    silently also included the ``uv tool list`` probe could not be read.
+
+    ``outcome_for_attempt(n)`` is called with the 1-based attempt number and
+    returns either a ``CompletedProcess``-alike to return or an exception
+    instance to raise.
+    """
+    installs: list = []
+    sleeps: list = []
+
+    def _run(cmd, *args, **kwargs):
+        installs.append(cmd)
+        outcome = outcome_for_attempt(len(installs))
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    runner._uv_available_cache = True
+    with (
+        patch.object(runner, "is_tool_installed", return_value=False),
+        patch(
+            "automated_security_helper.utils.subprocess_utils.find_executable",
+            return_value=None,
+        ),
+        patch(
+            "automated_security_helper.core.constants.is_offline_mode",
+            return_value=False,
+        ),
+        patch(
+            "automated_security_helper.utils.uv_tool_runner.subprocess.run",
+            side_effect=_run,
+        ),
+        patch(
+            "automated_security_helper.utils.uv_tool_runner.time.sleep",
+            side_effect=sleeps.append,
+        ),
+    ):
+        yield installs, sleeps
+
+
+class TestInstallRetriesActuallyHappen:
+    """Regression tests for ``retry_config`` being honoured at all.
+
+    ``install_tool_with_version`` used to accept ``retry_config`` and ignore it.
+    There was no retry loop in the function, so a caller asking for
+    ``max_retries=3`` got exactly one attempt -- and BanditScanner asks for
+    exactly that on every cold install.
+
+    Why it survived review is the part worth pinning. Every observable anyone
+    checked sits *upstream* of the missing code:
+    ``UVToolMixin._install_uv_tool`` logs "[INSTALLATION_CONFIG] Using custom
+    retry configuration / max_retries=3, base_delay=1.0s" before it calls in;
+    ``test_bandit_scanner_behavior`` asserts the config dict was passed with the
+    installer stubbed out; ``test_uv_tool_mixin.test_with_custom_retry_config``
+    mocks the runner wholesale; and ``TestUVToolRetryConfig`` above reads the
+    dataclass's own fields back to itself. All four still pass with the retry
+    entirely absent. They were not vacuous -- they just watched something the
+    defect does not move.
+
+    So these assert the two things it does move: how many installs are attempted,
+    and what ``time.sleep`` is handed between them. Jitter is off wherever an
+    exact interval is asserted, so the schedule is arithmetic rather than a
+    range. Nothing here measures wall clock, which would flake low on a fast
+    machine and high on a loaded one.
+    """
+
+    def test_a_retry_config_buys_one_attempt_per_configured_retry(self, runner):
+        config = UVToolRetryConfig(max_retries=3, base_delay=0.0, jitter=False)
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (installs, _),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=config)
+        assert len(installs) == 4, (
+            "expected 1 initial attempt plus 3 retries; a 1 here means "
+            "retry_config is being accepted and dropped again"
+        )
+
+    def test_no_retry_config_still_means_exactly_one_attempt(self, runner):
+        """Callers that never asked for retries must be left alone."""
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (installs, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit")
+        assert len(installs) == 1
+        assert sleeps == []
+
+    def test_a_none_config_never_reaches_the_delay_computation(self, runner):
+        """The delay helper takes a non-optional config, so it must not be called
+        with ``None`` -- and that call site runs only on the retry path.
+
+        This is the invariant behind ``retry_config is not None`` in the sleep
+        guard. It holds today because ``attempts`` is 1 whenever ``retry_config``
+        is falsy, so ``attempt + 1 < attempts`` is already False. The reason to
+        pin it rather than trust it: a break would surface as an AttributeError
+        thrown from *inside* the retry path, which only executes after an install
+        has already failed. Every test that installs successfully, and every test
+        that fails without a retry config, would stay green.
+
+        Asserting it by making the delay helper explode is deliberate -- it fails
+        if the guard is ever loosened, rather than merely checking a count that
+        happens to match.
+        """
+        sentinel = AssertionError("_install_retry_delay called with no retry_config")
+
+        with (
+            patch(
+                "automated_security_helper.utils.uv_tool_runner._install_retry_delay",
+                side_effect=sentinel,
+            ),
+            _install_harness(runner, _always_fails_with_reset) as (installs, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=None)
+
+        assert len(installs) == 1
+        assert sleeps == []
+
+    def test_the_interval_grows_and_is_exactly_the_configured_schedule(self, runner):
+        config = UVToolRetryConfig(
+            max_retries=3,
+            base_delay=1.0,
+            exponential_base=2.0,
+            max_delay=60.0,
+            jitter=False,
+        )
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (_, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=config)
+        assert sleeps == [1.0, 2.0, 4.0], (
+            "the interval must grow between attempts. A flat list is a "
+            "fixed-interval retry wearing the name backoff; an empty list is no "
+            "backoff at all, which fires every retry back-to-back at whatever "
+            "the retry was supposed to be gentle with"
+        )
+
+    def test_the_interval_stops_growing_at_max_delay(self, runner):
+        config = UVToolRetryConfig(
+            max_retries=4,
+            base_delay=10.0,
+            exponential_base=2.0,
+            max_delay=25.0,
+            jitter=False,
+        )
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (_, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=config)
+        assert sleeps == [10.0, 20.0, 25.0, 25.0]
+
+    def test_nothing_is_slept_after_the_final_attempt(self, runner):
+        """A wait after the last try buys nothing and only delays the error."""
+        config = UVToolRetryConfig(max_retries=2, base_delay=1.0, jitter=False)
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (installs, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=config)
+        assert len(installs) == 3
+        assert len(sleeps) == len(installs) - 1
+
+    def test_a_transient_failure_is_recovered_by_the_retry(self, runner):
+        """Fails once on the network then succeeds: the case the config exists for."""
+
+        def _fails_once(attempt_number):
+            if attempt_number == 1:
+                return subprocess.CalledProcessError(
+                    1, ["uv", "tool", "install"], "", "Recv failure"
+                )
+            return MagicMock(returncode=0)
+
+        config = UVToolRetryConfig(max_retries=3, base_delay=1.0, jitter=False)
+        with _install_harness(runner, _fails_once) as (installs, sleeps):
+            assert (
+                runner.install_tool_with_version("bandit", retry_config=config) is True
+            )
+        assert len(installs) == 2, "the second attempt is what made this succeed"
+        assert sleeps == [1.0], "exactly one wait, taken between the two attempts"
+
+    def test_a_timeout_is_not_retried(self, runner):
+        """Deliberate: the attempt already spent the whole timeout budget.
+
+        Retrying would multiply wall clock by the attempt count, so three 300s
+        timeouts would be fifteen minutes of a scan phase spent waiting on a tool
+        that is not coming.
+        """
+
+        def _times_out(attempt_number):
+            return subprocess.TimeoutExpired("uv", 300)
+
+        config = UVToolRetryConfig(max_retries=3, base_delay=1.0, jitter=False)
+        with (
+            _install_harness(runner, _times_out) as (installs, sleeps),
+            pytest.raises(UVToolRunnerError, match="timed out"),
+        ):
+            runner.install_tool_with_version("bandit", timeout=300, retry_config=config)
+        assert len(installs) == 1
+        assert sleeps == []
+
+    def test_jitter_stays_inside_the_growing_envelope(self, runner):
+        """With jitter on the exact values vary, but the growth must survive it."""
+        config = UVToolRetryConfig(
+            max_retries=3,
+            base_delay=10.0,
+            exponential_base=2.0,
+            max_delay=600.0,
+            jitter=True,
+        )
+        with (
+            _install_harness(runner, _always_fails_with_reset) as (_, sleeps),
+            pytest.raises(UVToolRunnerError),
+        ):
+            runner.install_tool_with_version("bandit", retry_config=config)
+        # Jitter adds at most 1.0s, and each step doubles a >=10s base, so the
+        # envelopes cannot overlap and the sequence must still be increasing.
+        assert sleeps == sorted(sleeps), sleeps
+        assert 10.0 <= sleeps[0] < 11.0, sleeps
+        assert 20.0 <= sleeps[1] < 21.0, sleeps
+        assert 40.0 <= sleeps[2] < 41.0, sleeps
+
+
+class TestRetryDelayIsAlwaysSleepable:
+    """``time.sleep`` raises ValueError on a negative argument.
+
+    ``UVToolRetryConfig`` is assembled in ``UVToolMixin._install_uv_tool`` from a
+    plain dict via ``.get(key, default)`` with no validation, so a nonsensical
+    value reaches the arithmetic instead of being rejected at the boundary. A
+    negative interval would surface as a ValueError thrown from inside the
+    install path, which a caller cannot tell apart from the install itself having
+    failed.
+    """
+
+    def test_a_negative_max_delay_cannot_produce_a_negative_interval(self):
+        config = UVToolRetryConfig(base_delay=1.0, max_delay=-30.0, jitter=False)
+        intervals = [_install_retry_delay(config, n) for n in range(4)]
+        assert all(interval >= 0.0 for interval in intervals), intervals
+
+    def test_a_negative_base_delay_cannot_produce_a_negative_interval(self):
+        config = UVToolRetryConfig(base_delay=-5.0, jitter=False)
+        intervals = [_install_retry_delay(config, n) for n in range(4)]
+        assert all(interval >= 0.0 for interval in intervals), intervals
+
+    def test_the_cap_is_never_normalized_below_the_floor(self):
+        """A max_delay under base_delay would cap every interval below its start."""
+        config = UVToolRetryConfig(base_delay=10.0, max_delay=1.0)
+        assert config.max_delay >= config.base_delay
+
+    def test_a_sub_unit_exponential_base_cannot_shrink_the_backoff(self):
+        config = UVToolRetryConfig(base_delay=1.0, exponential_base=0.5, jitter=False)
+        intervals = [_install_retry_delay(config, n) for n in range(4)]
+        assert intervals == sorted(intervals), intervals
+
+    def test_negative_max_retries_becomes_a_single_attempt(self):
+        """``1 + max_retries`` must not be able to produce an empty range."""
+        assert UVToolRetryConfig(max_retries=-4).max_retries == 0
+
+    def test_a_field_mutated_after_construction_still_cannot_go_negative(self):
+        """The one case ``__post_init__`` cannot reach, so the only case that
+        distinguishes the two overlapping guards.
+
+        Every other test in this class is satisfied by the normalization in
+        ``__post_init__`` alone -- deleting the ``max(0.0, ...)`` clamp inside
+        ``_install_retry_delay`` leaves them all green, which would make the
+        clamp an untested guard whose removal nothing notices.
+        ``UVToolRetryConfig`` is a plain mutable dataclass, so assigning to a
+        field after construction bypasses normalization entirely. That is what
+        this pins, and it fails if the clamp is removed.
+        """
+        config = UVToolRetryConfig(base_delay=1.0, jitter=False)
+        config.max_delay = -30.0
+
+        intervals = [_install_retry_delay(config, n) for n in range(3)]
+        assert intervals == [0.0, 0.0, 0.0], intervals
 
 
 class TestGetUvToolRunner:


### PR DESCRIPTION
## What this fixes

Three retry mechanisms each announced a delay they did not take. All three are the same shape: the diagnostic message is emitted *upstream* of the arithmetic that computes the interval, so the message keeps printing after the interval is gone.

### 1. `install_tool_with_version` accepted `retry_config` and ignored it

`automated_security_helper/utils/uv_tool_runner.py` — the function took a `retry_config: Optional[UVToolRetryConfig]` parameter, documented "retry logic" in its docstring, and had **no retry loop at all**. A caller asking for `max_retries=3` got exactly one attempt.

The parameter is not decorative. There is a live chain:

- `plugin_modules/ash_builtin/scanners/bandit_scanner.py` builds `{"max_retries": 3, "base_delay": 1.0, "max_delay": 60.0}`
- `base/uv_tool_mixin.py` converts it to a `UVToolRetryConfig` and logs `[INSTALLATION_CONFIG] Using custom retry configuration / max_retries=3, base_delay=1.0s`
- then passes `retry_config=config` into a function that never read it

Measured with `subprocess.run` stubbed to fail the way a reset connection does:

| | attempts | sleeps |
|---|---|---|
| before | 1 | none |
| after | 4 | 1.71s, 2.64s, 4.61s |

`retry_config=None` still means a single attempt, so every caller that never asked for retries keeps its behavior exactly. A timeout stays terminal on purpose: that attempt already spent the whole `timeout` budget, so retrying would multiply wall clock by the attempt count, and three 300s timeouts is fifteen minutes of a scan phase waiting on a tool that is not coming.

### 2. `retry_with_backoff` could hand `time.sleep` a negative number

`plugin_modules/ash_aws_plugins/aws_utils.py` — `base_delay` and `max_delay` reach this decorator from reporter config, and `CloudWatchLogsReporter` and `S3Reporter` both declare them as bare `float` fields with no lower bound. A negative `max_delay` made the computed interval negative; `time.sleep` raises `ValueError` on a negative argument; and the broad `except Exception` in `_create_log_stream_with_retry` swallows it. The retry silently became zero retries and the warning blamed the log stream.

The interval is now clamped non-negative. The floor is `0.0` rather than some small positive number because `base_delay=0` is a legitimate way to ask for immediate retries — what must not happen is a negative interval reaching `sleep`, or an exception escaping the arithmetic that exists to protect a throttled API.

### 3. `with-retry.sh` truncated its own retry loop and misreported it

`automated_security_helper/assets/with-retry.sh` — `sleep $delay; delay=$((delay * 2))` is bash integer arithmetic, which cannot parse a value like `0.1`, the obvious way to ask for a fast-but-nonzero backoff. That arithmetic error aborts the enclosing `while` **without** aborting the script (there is no `set -e`), so exactly one attempt ran and the script still printed `All 3 attempts failed` and exited 1.

Observed directly, with a marker file counting executions:

```
$ WITH_RETRY_DELAY=0.1 bash with-retry.sh 'printf x >> marker; false'
Attempt 1/3 failed, retrying in 0.1s...
with-retry.sh: line 29: 0.1: syntax error: invalid arithmetic operator (error token is ".1")
All 3 attempts failed
$ cat marker
x          # one attempt, not three
```

Both knobs are now validated up front and a bad one exits 2. `max=0` is rejected too, because it skipped the loop entirely and then reported `All 0 attempts failed` with exit 1 — indistinguishable from the command having run and failed.

The default schedule is unchanged. Verified with a `sleep` shim on `PATH`: it receives `5`, `10`, `20`.

## Why this survived review, and what the new tests assert instead

This is the part worth keeping. Every observable the existing tests watched sits upstream of the arithmetic:

- `test_bandit_scanner_behavior` asserts the config dict was passed through, with the installer stubbed out
- `test_uv_tool_mixin.test_with_custom_retry_config` mocks the runner wholesale and asserts `result is True`
- `TestUVToolRetryConfig` reads the dataclass's own fields back to itself
- every test in `test_with_retry.py` sets `WITH_RETRY_DELAY=0`, which collapses the backoff to a constant zero and makes the interval unobservable **by construction**
- the AWS retry tests pass `base_delay=0.01` to stay fast and then assert only the call count

None of those assertions was vacuous. They just watched something the defect does not move.

The 24 tests added here assert the things it does move: **the attempt count, the argv `sleep` received, and the exact interval schedule.** Jitter is switched off wherever an exact interval is asserted, so the schedule is arithmetic rather than a range. Nothing measures wall clock — a lower bound flakes on a fast machine and an upper bound on a slow one — so the shell test shims `sleep` onto `PATH` and reads back what it was handed.

## Mutation proof

Each fix was proved by mutating the specific thing it changes and confirming the right tests redden, and that the pre-existing ones do not:

| mutation | reddens | pre-existing tests |
|---|---|---|
| backoff made constant (`delay = base_delay`) | 3 interval tests | all 65 others pass |
| retry loop reverted (`attempts = 1`) | 6 tests | all 25 in the file pass |
| AWS exponential flattened + clamp removed | 4 tests | all 4 `TestRetryWithBackoff` pass |
| shell doubling made a no-op (`delay * 1`) | 1 sleep-argv test | all 7 others pass |

The constant-backoff mutation is the informative one: it reddens *only* the interval assertions while every attempt-count test stays green. Count assertions alone would have shipped it.

The flattened AWS mutation logs this, which is the defect shape verbatim — message printed, backoff destroyed:

```
WARNING Retrying due to ClientError (ThrottlingException). Attempt 1/2 after -30.00s delay
```

One negative result worth recording: removing the `max(0.0, ...)` clamp from `_install_retry_delay` initially reddened **nothing**, because `__post_init__` already normalizes the inputs. Two overlapping guards, neither distinguishable by test. Rather than delete one, there is now a test for the single case only the clamp can catch — `UVToolRetryConfig` is a plain mutable dataclass, so assigning `config.max_delay = -30.0` after construction bypasses normalization. That test fails with `[-30.0, -30.0, -30.0]` when the clamp is removed.

## A note on the sleep guard

The guard reads `if retry_config is not None and attempt + 1 < attempts:`. The first clause is redundant today — `attempts` is 1 whenever `retry_config` is falsy, so the second clause already prevents the call. It is written out anyway because a type checker cannot see that correlation, and more importantly because if a later change to how `attempts` is derived broke it, the failure would be an `AttributeError` raised *from inside the retry path*: code that runs only after something has already gone wrong, invisible to any test that never triggers a retry. Both halves are pinned — breaking the correlation reddens the attempt-count assertions, and removing the clause on top of that fires a sentinel in the delay helper.

## Follow-ups deliberately not in this PR

**The shell `retry` helper in `.github/actions/run-scan-test/action.yml` is sound and untouched.** It is owned by another open PR. Its `sleep $((n * 10))` is arithmetic expansion, not command substitution, and `n` is always a valid integer seeded at 1, so the delay cannot be empty, zero, or negative; the backoff grows 10s then 20s (linear, not exponential, but it grows). Read and left alone.

Two observations in that file, for whoever owns it. `ERROR_COUNT=$(echo "$REPORT_OUTPUT" | grep -c "ERROR" | head -1)` runs under the runner's default `-e -o pipefail`, and `grep -c` exits 1 when the count is zero — so a report containing no `ERROR` at all makes the assignment fail and kills the step. Separately, `FERRET_CONSTRAINT="$(...)"` is the command-substitution shape done correctly, guarded by an explicit `-z` check.

**Three more inert retry configs, same family, not fixed here.** `s3_reporter.py` and `bedrock_summary_reporter.py` expose `max_retries`/`base_delay`/`max_delay` in their user-facing config schema, and neither is read: `@retry_with_backoff()` at `s3_reporter.py:269` takes no arguments, and `bedrock_summary_reporter.py` imports `retry_with_backoff` and never calls it. `cloudwatch_logs_reporter.py:257` has the same bare-decorator gap for `put_log_events` while `:222` correctly forwards config.

Left out on purpose. These decorators are applied at class-definition time, so reading `self.config.options` requires restructuring each method to decorate an inner function at call time — a design change, not a defect fix. And the effective values currently equal the declared defaults (`3` / `1.0` / `60.0`), so nothing is broken today for anyone who has not overridden them. The defect is "a user override is silently ignored", not "no retry happens".

**Also noted, not changed:** `monitor_workspace_progress`'s `poll_interval` is an unvalidated public keyword parameter that busy-spins at `0` (no in-tree caller passes it). `_sleep_interval_for` is documented as a "Backoff schedule" but is a three-step ladder keyed to completed-scanner count, not attempt number, so it does not grow per attempt. `retry_with_backoff` has no upper bound on `max_retries`, and `base_delay * (2**retries)` would raise `OverflowError` somewhere past a thousand retries — unreachable in practice at a 60s cap, but the exponent is computed before the cap applies.

## Verification

- `pytest tests/unit`: **6520 passed, 24 skipped, 3 xfailed, 2 failed, 192 errors.** All 192 errors are one cause, `tests/unit/deploy - ModuleNotFoundError: No module named 'moto'`, repeated once per xdist worker — a missing optional test dependency in this environment. The 2 failures are `test_agent_plugin_ash_version.py::test_every_install_ref_names_the_packaged_version` and `test_cdk_nag_container_deps.py::test_fallback_matches_installed_metadata`, both version/dependency drift; neither file references any module this PR touches. Baseline is therefore 6496 passed with the same 2 failures and 192 errors.
- **No test was weakened, skipped, or deleted.** The test diff removes zero lines: +24 test functions, 0 removed, 0 existing assertions changed.
- `ruff check` on the five changed Python files: **83 findings, identical to the `origin/main` baseline** for the same files, with an identical rule breakdown. Zero new lint.
- `ruff format --check`: four of the five are clean, including `aws_utils.py`, which was *unformatted* at baseline — this change incidentally fixed that. The fifth, `test_uv_tool_runner.py`, was already unformatted on `main` under ruff 0.16 and the formatter's remaining diff touches none of the added lines. Note the tree is formatted for the ruff pinned in `.pre-commit-config.yaml` (v0.11.8), not the `>=0.16` in the dev dependency group.
