### PR TITLE
fix(cdk-nag): preserve pack attribution, separate unevaluated rules, and surface converted-target errors

### DIFF
--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, Optional, Tuple
 
 from automated_security_helper.config.default_config import get_default_config
 from automated_security_helper.core.constants import ASH_DEFAULT_SEVERITY_LEVEL
+from automated_security_helper.core.enums import ScannerStatus
 from automated_security_helper.models.asharp_model import (
     AshAggregatedResults,
     ScannerSeverityCount,
@@ -592,6 +593,45 @@ class ScannerStatisticsCalculator:
         return excluded, dependencies_missing, error
 
     @staticmethod
+    def any_target_errored(
+        asharp_model: AshAggregatedResults, scanner_name: str
+    ) -> bool:
+        """True when ANY target this scanner reported under came back ERROR.
+
+        ``ScanPhase`` gives each scanner one task carrying both the source tree and the
+        converted tree, and ``ScanResultProcessor`` writes one serialized container per target
+        under ``additional_reports[scanner][target_type]``. ERROR is what
+        ``ScanResultsContainer.determine_status`` returns when a tracking scanner failed every
+        target it attempted -- so an ERROR here means no rule was evaluated against that tree.
+
+        ``get_scanner_status_info`` used to derive its ``error`` flag from the ``"source"``
+        report alone. A cdk-nag that passed on the source tree and errored on the converted one
+        therefore rolled up to PASSED: the ERROR container was written to disk, serialized into
+        the aggregated results, and never read. Nothing downstream could recover the fact,
+        because ``error`` is the flag every rolled-up status keys on.
+
+        "Any", not "all", and the asymmetry with the severity gate is the point. A finding count
+        of zero is ambiguous, so the guards in ``determine_status`` are careful about which
+        zero they are looking at. An ERROR is not ambiguous: one target that evaluated nothing
+        is a hole in the scan whether or not its sibling was fine, and a report that averages
+        it away against a passing sibling is asserting coverage it does not have.
+
+        Modelled on ``scanner_evaluated_nothing``, which already reads across every target for
+        the same structural reason. That function existed with that quantifier and this one did
+        not, and the gap between them is exactly where the defect lived.
+        """
+        reports = asharp_model.additional_reports.get(scanner_name)
+        if not isinstance(reports, dict):
+            return False
+
+        for target_report in reports.values():
+            if not isinstance(target_report, dict):
+                continue
+            if target_report.get("status") == ScannerStatus.ERROR.value:
+                return True
+        return False
+
+    @staticmethod
     def scanner_evaluated_nothing(
         asharp_model: AshAggregatedResults, scanner_name: str
     ) -> bool:
@@ -662,6 +702,15 @@ class ScannerStatisticsCalculator:
         genuinely different fact, and it is answered by ``scanner_evaluated_nothing`` rather than
         folded into ``excluded`` here -- see ``_status_info_from_report`` for what folding it in
         used to cost.
+
+        ``error`` is the one of the three read across every target rather than off a single
+        report, and that asymmetry is deliberate. A scanner is switched off, or its tool is
+        absent, for the whole run -- those are facts about configuration, and the scanner-level
+        report states them correctly. Whether a rule was evaluated is a fact about one tree, and
+        a scanner gets two. See ``any_target_errored`` for what reading only the source report
+        cost. Widening ``excluded`` the same way would be actively wrong: one target carrying an
+        unrecognized status makes ``_status_info_from_report`` return ``excluded=True`` for
+        backward compatibility, which would then claim the operator had switched the scanner off.
         """
         excluded = False
         dependencies_missing = False
@@ -703,6 +752,14 @@ class ScannerStatisticsCalculator:
         else:
             # If the scanner is not found in the dictionary, check for errors
             error = True
+
+        # ORed in after the branches above rather than replacing them. Those branches also
+        # produce ``excluded`` and ``dependencies_missing``, which stay scanner-level, and the
+        # first branch reads a report keyed ``"None"`` -- a scanner that never reached a target
+        # at all -- which ``any_target_errored`` covers as well since it walks every key.
+        error = error or ScannerStatisticsCalculator.any_target_errored(
+            asharp_model, scanner_name
+        )
 
         return excluded, dependencies_missing, error
 

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -17,9 +17,15 @@ from automated_security_helper.core.exceptions import ScannerError
 from automated_security_helper.schemas.sarif_schema_model import (
     ArtifactLocation,
     Invocation,
+    Level,
+    Message,
+    Message1,
     MultiformatMessageString,
+    Notification,
     PropertyBag,
     ReportingDescriptor,
+    ReportingDescriptorReference,
+    ReportingDescriptorReference3,
     Result,
     Run,
     SarifReport,
@@ -98,8 +104,8 @@ def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
 
     The CDK's policy-validation guide is the correct destination for those: it documents the
     plugin, the shared validation report, and the ``Validations.of(scope).acknowledge()``
-    mechanism that governs a CloudFormation Validate finding. It is also the right destination
-    for a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
+    mechanism that governs a CloudFormation Validate finding. It is also the right fallback for
+    a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
     such a plugin implements.
 
     A finding with NO pack recorded keeps the previous destination, and that is deliberately
@@ -113,6 +119,71 @@ def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
     if not pack or _rule_is_from_pack(rule_id, pack):
         return f"{_CDK_NAG_RULES_URL}#{str(rule_level).lower()}s"
     return _CDK_POLICY_VALIDATION_URL
+
+
+def _unevaluated_rule_notifications(
+    results: list[Result],
+) -> list[Notification]:
+    """One SARIF notification per rule that could not be evaluated.
+
+    WHY THE RESULT ALONE IS NOT ENOUGH
+    ----------------------------------
+    A ``notApplicable`` result says "this one rule reached no verdict on this one resource",
+    and that is true but easy to miss: it sits in the same results array as the findings, at a
+    severity of ``none``, and most report surfaces sort or filter by severity. The fact a reader
+    needs is coarser -- "part of this scan did not run" -- and it belongs where a reader looks
+    for facts about the run.
+
+    SARIF has exactly that place, and the schema says so in its own words. ``invocation``'s
+    ``toolExecutionNotifications`` is "A list of runtime conditions detected by the tool during
+    the analysis", and ``notification.associatedRule`` is "A reference used to locate the rule
+    descriptor associated with this notification". A rule raising mid-evaluation is a runtime
+    condition, and the rule it happened to is the thing to associate it with. This is the
+    representation SARIF already defines for the case, so it is used rather than a bespoke
+    property.
+
+    ``level=error`` rather than ``warning``. For a security scanner, a rule that silently did
+    not run is the more serious of the two facts it can report -- a violation at least tells you
+    what to fix. ``warning`` is the field's default, so this is a deliberate override.
+
+    Deduplicated by rule id. One rule that cannot resolve a property will raise for every
+    construct that shares the shape, and the run-level statement is about the rule, not about
+    each occurrence -- the per-resource detail is already carried by the results themselves.
+    """
+    from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+    notifications: list[Notification] = []
+    seen: set[str] = set()
+    for result in results:
+        finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
+        if finding_props.get("compliance") != NOT_EVALUATED:
+            continue
+        rule_id = result.ruleId or ""
+        if rule_id in seen:
+            continue
+        seen.add(rule_id)
+        pack = str(finding_props.get("pack", "") or "unknown")
+        notifications.append(
+            Notification(
+                level=Level.error,
+                message=Message(
+                    root=Message1(
+                        text=(
+                            f"Rule {rule_id} from pack '{pack}' could not be evaluated, so "
+                            "this scan reports nothing about compliance with it. "
+                            f"{finding_props.get('rule_info', '')}".strip()
+                        )
+                    )
+                ),
+                associatedRule=ReportingDescriptorReference(
+                    # The id-bearing variant. ReportingDescriptorReference is a union whose
+                    # other two members require an index or a guid, neither of which exists
+                    # here -- the rule is identified by the id cdk-nag reported it under.
+                    root=ReportingDescriptorReference3(id=rule_id)
+                ),
+            )
+        )
+    return notifications
 
 
 def _reporting_descriptor_for(
@@ -159,6 +230,7 @@ def _reporting_descriptor_for(
             ],
         ),
     )
+
 
 # Matches the ``extra == "cdk"`` half of a PEP 508 marker. importlib.metadata
 # renders the marker with single quotes while pyproject.toml and pip emit double
@@ -717,6 +789,13 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
                             executionSuccessful=scan_succeeded,
                             exitCode=0 if scan_succeeded else 1,
                             exitCodeDescription="\n".join(self.errors),
+                            # Rules cdk-nag could not evaluate, reported as conditions of the
+                            # run rather than only as individual results. A rule that did not
+                            # run is a hole in this scan's coverage, and coverage is a property
+                            # of the run -- see _unevaluated_rule_notifications.
+                            toolExecutionNotifications=_unevaluated_rule_notifications(
+                                sarif_results
+                            ),
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=self.context.source_dir),
                             ),

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -60,6 +60,106 @@ _CDK_EXTRA_FALLBACK_REQUIREMENTS: List[str] = [
     "constructs>=10.8,<11.0.0",
 ]
 
+# Where cdk-nag documents its own rules, and where the CDK documents everything else that can
+# write into the same validation report.
+_CDK_NAG_RULES_URL = "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md"
+_CDK_POLICY_VALIDATION_URL = (
+    "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+)
+
+
+def _rule_is_from_pack(rule_id: str, pack: str) -> bool:
+    """Whether ``rule_id`` was minted by cdk-nag's ``applyRule`` for ``pack``.
+
+    A derived test rather than a hardcoded list of pack names. cdk-nag builds every rule id as
+    ``f"{packName}-{ruleSuffix}"`` -- 3.0.2's ``applyRule`` does so literally, and
+    :func:`~automated_security_helper.utils.cdk_nag_wrapper._rule_id_parts` already relies on
+    the same construction from the other end. So ``AwsSolutions`` owns ``AwsSolutions-S1``,
+    while ``CloudFormation Validate`` demonstrably does not own ``F3017``.
+
+    An allowlist of cdk-nag pack names was the alternative and was rejected: it goes stale the
+    moment cdk-nag adds a pack, and the failure is silent -- a new pack's rules would start
+    being treated as foreign and lose their documentation link, which is a quieter version of
+    the defect this function exists to fix. A denylist naming only the CDK's built-in plugin is
+    worse still, because it is wrong for every third-party plugin a user registers.
+    """
+    return bool(pack) and rule_id.startswith(f"{pack}-")
+
+
+def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
+    """The document that actually describes ``rule_id``.
+
+    Every rule used to be pointed at cdk-nag's RULES.md, which is right for a cdk-nag rule and
+    wrong for anything else in the report. From aws-cdk-lib 2.262.0 the CDK registers
+    ``CloudFormationValidatePlugin`` on every app unconditionally, so a scan of a template with
+    a placeholder KMS key identifier yields ``F3017`` findings whose help link opened a page
+    that does not mention ``F3017`` -- and, more to the point, does not describe how to
+    acknowledge one.
+
+    The CDK's policy-validation guide is the correct destination for those: it documents the
+    plugin, the shared validation report, and the ``Validations.of(scope).acknowledge()``
+    mechanism that governs a CloudFormation Validate finding. It is also the right destination
+    for a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
+    such a plugin implements.
+
+    A finding with NO pack recorded keeps the previous destination, and that is deliberately
+    narrow. Redirecting only findings positively known to be foreign means the change cannot
+    move the help link on anything it has not identified. An absent pack is not evidence of a
+    foreign producer -- inside this scanner's own report the likeliest producer is cdk-nag, the
+    level-derived anchor degrades to the generic ``#rules`` index which claims nothing about a
+    specific rule, and guessing "foreign" from missing data would send genuine cdk-nag rules
+    away from their own documentation. That is the same misattribution in the other direction.
+    """
+    if not pack or _rule_is_from_pack(rule_id, pack):
+        return f"{_CDK_NAG_RULES_URL}#{str(rule_level).lower()}s"
+    return _CDK_POLICY_VALIDATION_URL
+
+
+def _reporting_descriptor_for(
+    result: Result, tool_name: str, tool_type: str
+) -> ReportingDescriptor:
+    """Build the SARIF rule descriptor for one cdk-nag-path finding.
+
+    Extracted to module level for the same reason ``_build_nag_pack`` and ``_level_and_kind``
+    were: inline in ``scan()`` it could only be exercised by driving a full synthesis, and
+    nothing in the suite did that. Two of its three defects were invisible for exactly that
+    reason.
+
+    ``tags`` reads the result's own property bag. It used to read ``finding_props["tags"]``,
+    and ``finding_props`` is ``_NagFinding.as_dict()``, which has no ``tags`` key -- so that
+    lookup returned its ``[]`` default every single time. It looked like it forwarded the
+    finding's tags and forwarded nothing, which is why the pack name never reached the rule
+    even though the wrapper had been putting it on the result all along.
+
+    ``pack`` is also written as a labelled property. The pack is present in ``tags`` too, but
+    only as one unlabelled string among nine, so a consumer cannot tell it apart from the
+    resource id or the resource type sitting beside it; a named field can be read.
+    """
+    finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
+    pack = str(finding_props.get("pack", "") or "")
+    rule_level = str(finding_props.get("rule_level", "rule"))
+
+    return ReportingDescriptor(
+        id=result.ruleId,
+        shortDescription=MultiformatMessageString(text=result.message.root.text),
+        fullDescription=MultiformatMessageString(
+            text=result.message.root.text,
+            markdown=result.message.root.markdown,
+        ),
+        helpUri=_rule_help_uri(result.ruleId or "", pack, rule_level),
+        properties=PropertyBag(
+            pack=pack,
+            rule_level=finding_props.get("rule_level", "unknown"),
+            rule_info=finding_props.get("rule_info", "unknown"),
+            tags=list(result.properties.tags or [])
+            + [
+                f"pack::{pack}" if pack else "pack::unknown",
+                f"tool_name::{tool_name}",
+                f"tool_type::{tool_type}",
+            ],
+        ),
+    )
+
 # Matches the ``extra == "cdk"`` half of a PEP 508 marker. importlib.metadata
 # renders the marker with single quotes while pyproject.toml and pip emit double
 # quotes, so neither style can be assumed.
@@ -576,29 +676,11 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
                 continue
             rule_map[result.ruleId] = result
 
-            finding_props = result.properties.model_extra.get("cdk_nag_finding", {})
-
             rules.append(
-                ReportingDescriptor(
-                    id=result.ruleId,
-                    shortDescription=MultiformatMessageString(
-                        text=result.message.root.text,
-                    ),
-                    fullDescription=MultiformatMessageString(
-                        text=result.message.root.text,
-                        markdown=result.message.root.markdown,
-                    ),
-                    helpUri=f"https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#{str(finding_props.get('rule_level', 'rule')).lower()}s",
-                    properties=PropertyBag(
-                        rule_level=finding_props.get("rule_level", "unknown"),
-                        rule_info=finding_props.get("rule_info", "unknown"),
-                        tags=finding_props.get("tags", [])
-                        + [
-                            f"tool_name::{self.config.name}",
-                            f"tool_type::{self.tool_type or 'UNKNOWN'}",
-                        ],
-                    ),
-                    # help,
+                _reporting_descriptor_for(
+                    result,
+                    tool_name=self.config.name,
+                    tool_type=self.tool_type or "UNKNOWN",
                 )
             )
         tool = Tool(

--- a/automated_security_helper/utils/cdk_nag_wrapper.py
+++ b/automated_security_helper/utils/cdk_nag_wrapper.py
@@ -93,6 +93,45 @@ def _build_nag_pack(pack_name: str):
     return pack_type(verbose=True)
 
 
+# The compliance state for a rule that reached no verdict, as opposed to one that reached the
+# verdict "non-compliant". A third value alongside "Non-Compliant" and "Suppressed" rather than
+# a boolean flag, because ``compliance`` is what :func:`_level_and_kind` dispatches on and what
+# the scanner reads back out of the SARIF property bag -- a parallel flag would have to be
+# threaded through both and could disagree with the field beside it.
+#
+# Exported so a test can assert against this constant rather than a repeated string literal.
+NOT_EVALUATED = "Not-Evaluated"
+
+# How cdk-nag 3.0.2 spells "this rule raised instead of returning a verdict".
+#
+# There is no structural marker to key on. ``applyRule`` wraps each rule in a try/catch and, on
+# an exception, calls the SAME ``addViolation`` a real violation goes through -- passing the
+# exception message as a third argument, which ``addViolation`` turns into this description
+# prefix. The severity stays whatever the rule declared, so a rule that never ran arrived as
+# ``severity: "error"`` and rendered CRITICAL.
+#
+# The prefix, not the whole string: ``addViolation`` appends the exception text when the pack was
+# built with ``verbose`` and a fixed hint about intrinsic functions otherwise, so the two forms
+# share only this much. ASH passes ``verbose=True`` in :func:`_build_nag_pack`, and matching the
+# prefix means that stops being load-bearing -- if it ever flips, detection keeps working
+# instead of silently reverting to reporting these as critical findings.
+_UNEVALUATED_DESCRIPTION_PREFIX = "Rule threw an error during validation."
+
+
+def _compliance_for_violation(description: str) -> str:
+    """Whether this report row is a violation or a rule that never produced one.
+
+    Kept as a named function rather than an inline ``startswith`` so the one place that decides
+    this is greppable, and so the marker constant has exactly one reader.
+    """
+    if description.startswith(_UNEVALUATED_DESCRIPTION_PREFIX):
+        return NOT_EVALUATED
+    # The validation report carries violations only, so for everything else "Non-Compliant" is
+    # the sole possible value and ``include_compliant_checks`` has nothing to include -- see the
+    # note in :func:`_violations_from_validation_report`.
+    return "Non-Compliant"
+
+
 class _NagFinding:
     """One cdk-nag violation, exposing the field names the downstream mapping reads.
 
@@ -184,7 +223,38 @@ def _level_and_kind(
     scanner reads ``compliance`` back out of the SARIF property bag, and a report format that
     restores suppression records would need the mapping intact. They are, today, unreachable
     from the report path -- see the note in :func:`_violations_from_validation_report`.
+
+    THE NOT-EVALUATED ROW, AND WHY notApplicable RATHER THAN open
+    ------------------------------------------------------------
+    SARIF 2.1.0 defines two kinds that could plausibly carry "this rule produced no verdict",
+    and the distinction between them is the whole question. Quoting the OASIS Standard
+    incorporating Approved Errata 01, section 3.27.9:
+
+      "notApplicable" : The rule specified by ruleId was not evaluated, because it does not
+      apply to the analysis target.
+
+      "open" : The specified rule was evaluated, and the tool concluded that there was
+      insufficient information to decide whether a problem exists.
+
+    ``open`` opens with "was evaluated", and its NOTE 1 scopes the value to proof-based tools
+    that completed an analysis and could not prove either direction. cdk-nag's rule did not
+    complete -- it raised partway through ``resolveIfPrimitive`` -- so "was not evaluated" is
+    the accurate half. Section 3.27.9's own example for ``notApplicable`` is a result whose
+    message reads "<target> was not evaluated for rule <id> because <reason>", which is the
+    shape this path produces.
+
+    ``Level.none`` is then required rather than chosen. Section 3.27.10 defines it as "The
+    concept of 'severity' does not apply to this result because the kind property (3.27.9) has
+    a value other than 'fail'". ASH's ladder maps ``none`` to INFO, so a rule that did not run
+    stops being counted as a critical finding as a consequence of getting the SARIF right --
+    not as a separate adjustment that could be changed independently and drift apart from it.
+
+    Checked before the ``Non-Compliant`` row on purpose: a not-evaluated row arrives carrying
+    whatever severity the rule declared, which for a cdk-nag error-level rule is ``"Error"``,
+    so falling through to the row below would render it ``fail``/``error`` exactly as before.
     """
+    if compliance == NOT_EVALUATED:
+        return Level.none, Kind.notApplicable
     if compliance == "Non-Compliant":
         if rule_level == "Error":
             return Level.error, Kind.fail
@@ -192,6 +262,26 @@ def _level_and_kind(
     if compliance == "Suppressed" and exception_reason != "N/A":
         return Level.none, Kind.review
     return Level.none, Kind.informational
+
+
+def _result_message_text(finding: "_NagFinding", target: str) -> str:
+    """The human-readable message for one SARIF result.
+
+    A not-evaluated finding gets a message that leads with the fact, because ``kind`` is the
+    machine-readable half and plenty of report surfaces render only the message. The wording
+    follows the example SARIF 2.1.0 section 3.27.9 gives for ``notApplicable`` -- name the
+    target, name the rule, then give the reason -- rather than inventing a phrasing.
+
+    Everything else keeps the previous text verbatim, including the "Exception Reason" line for
+    a value that is almost always ``N/A``. Changing that would move the message on every
+    ordinary finding, which is a report-output change with no defect behind it.
+    """
+    if finding.compliance == NOT_EVALUATED:
+        return (
+            f"'{target}' was NOT evaluated for rule {finding.rule_id}, so this result says "
+            f"nothing about whether the template complies with it.\n\n{finding.rule_info}"
+        )
+    return f"{finding.rule_info}\n\nException Reason: {finding.exception_reason}"
 
 
 def _rule_id_parts(rule_id: str) -> tuple[str, str | None]:
@@ -512,6 +602,15 @@ def _violations_from_validation_report(
             rule_id = violation.get("ruleName") or ""
             rule_info = violation.get("description") or ""
             rule_level = _normalize_rule_level(violation.get("severity", ""))
+            # Decided once per violation rather than per construct: every construct under one
+            # violation shares the description, so the state cannot differ between them.
+            compliance = _compliance_for_violation(rule_info)
+            if compliance == NOT_EVALUATED:
+                ASH_LOGGER.warning(
+                    f"cdk-nag rule '{rule_id}' from pack '{pack_name}' could not be "
+                    f"evaluated against this template, so it reports NOTHING about the "
+                    f"template's compliance with it: {rule_info}"
+                )
             # One violation can cite several constructs; each becomes its own finding so the
             # SARIF result points at a single resource, as it did under 2.x.
             for construct in violation.get("violatingConstructs", []) or []:
@@ -522,10 +621,7 @@ def _violations_from_validation_report(
                     _NagFinding(
                         rule_id=rule_id,
                         resource_id=construct_path,
-                        # The validation report carries violations only. "Non-Compliant" is
-                        # therefore the sole possible value, and include_compliant_checks has
-                        # nothing to include -- see the note in the docstring.
-                        compliance="Non-Compliant",
+                        compliance=compliance,
                         exception_reason="N/A",
                         rule_level=rule_level,
                         rule_info=rule_info,
@@ -871,7 +967,7 @@ def run_cdk_nag_against_cfn_template(
                         kind=kind,
                         message=Message(
                             root=Message1(
-                                text=f"{line.rule_info}\n\nException Reason: {line.exception_reason}"
+                                text=_result_message_text(line, cfn_file_rel_path)
                             )
                         ),
                         analysisTarget=ArtifactLocation(

--- a/automated_security_helper/utils/cdk_nag_wrapper.py
+++ b/automated_security_helper/utils/cdk_nag_wrapper.py
@@ -100,9 +100,17 @@ class _NagFinding:
     ``resource_id``, ``compliance``, ``exception_reason``, ``rule_level``, ``rule_info``) so
     the SARIF construction below is untouched by the v3 migration. ``NagReportLine`` itself is
     not used because v3 no longer ships the file-report schema it belonged to.
+
+    ``pack`` is the one field with no 2.x counterpart, and it exists because v3's report is not
+    cdk-nag's. See :func:`_violations_from_validation_report`: the file is CDK's shared
+    policy-validation report, every registered plugin writes into it, and from aws-cdk-lib
+    2.262.0 the CDK registers one of its own. So the plugin that produced a finding is no longer
+    implied by the file it came out of, and carrying it here is what lets it stay attributable
+    after the caller flattens the per-pack mapping into a single result list.
     """
 
     __slots__ = (
+        "pack",
         "rule_id",
         "resource_id",
         "compliance",
@@ -119,6 +127,7 @@ class _NagFinding:
         exception_reason: str,
         rule_level: str,
         rule_info: str,
+        pack: str = "",
     ) -> None:
         self.rule_id = rule_id
         self.resource_id = resource_id
@@ -126,6 +135,7 @@ class _NagFinding:
         self.exception_reason = exception_reason
         self.rule_level = rule_level
         self.rule_info = rule_info
+        self.pack = pack
 
     def as_dict(self) -> Dict[str, str]:
         """The raw finding record, attached to the SARIF result's property bag.
@@ -134,6 +144,7 @@ class _NagFinding:
         ``result.properties.model_extra["cdk_nag_finding"]`` and indexes it by these keys.
         """
         return {
+            "pack": self.pack,
             "rule_id": self.rule_id,
             "resource_id": self.resource_id,
             "compliance": self.compliance,
@@ -518,6 +529,14 @@ def _violations_from_validation_report(
                         exception_reason="N/A",
                         rule_level=rule_level,
                         rule_info=rule_info,
+                        # The plugin that produced this finding, kept per-row rather than
+                        # relying on the mapping key. The caller iterates
+                        # ``results.items()``, binds the key to a loop variable and extends
+                        # one flat list with the values, so the key does not survive into
+                        # SARIF -- and after aws-cdk-lib 2.262.0 the key is the only thing
+                        # that distinguishes a cdk-nag rule from a CloudFormation Validate
+                        # one.
+                        pack=pack_name,
                     )
                 )
 

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -129,6 +129,25 @@ def foreign_plugin_template(tmp_path: Path) -> Path:
     return path
 
 
+# The two shapes ASH's own repository feeds cdk-nag today. Both are read by the YAML/JSON
+# loader, and neither can survive it: an unknown tag has no constructor, and JSON with comments
+# is not a flow mapping.
+UNPARSEABLE_TARGETS = {
+    "mkdocs.yml": (
+        "site_name: Fixture\n"
+        "markdown_extensions:\n"
+        "  - pymdownx.emoji:\n"
+        "      emoji_index: !!python/name:material.extensions.emoji.twemoji\n"
+    ),
+    "tsconfig.json": (
+        "{\n"
+        "  // a comment makes this not plain JSON\n"
+        '  "compilerOptions": {"strict": true}\n'
+        "}\n"
+    ),
+}
+
+
 @pytest.fixture()
 def unevaluatable_template(tmp_path: Path) -> Path:
     path = tmp_path / "unevaluatable.template.json"
@@ -449,3 +468,96 @@ class TestRuleThatCouldNotBeEvaluated:
             f"notifications name {sorted(notified_rules)} but the notApplicable results are "
             f"{sorted(unevaluated_rules)}"
         )
+
+
+class TestTargetThatCouldNotBeParsed:
+    """A file cdk-nag cannot parse must stay OUT of the findings channel.
+
+    WHY THIS EXISTS WITHOUT A FIX BESIDE IT
+    ---------------------------------------
+    ASH's own CI feeds cdk-nag files that are not CloudFormation at all -- ``mkdocs.yml`` and
+    ``deploy/cdk/tsconfig.json`` -- and the scan logs two parse failures next to a non-zero exit
+    citing "1 actionable findings". The obvious reading is that the two failures became the
+    finding. They did not: that run's summary table attributes the single actionable finding to
+    detect-secrets, at CRITICAL, with cdk-nag itself on ``Action 0 / PASSED``. Two unrelated
+    facts, printed near each other.
+
+    So there is nothing to fix here, and that is exactly why the property is worth pinning. It
+    is currently correct and nothing asserted it, which is the state a regression arrives in.
+    A future change that turned a target-level parse failure into a synthetic finding would
+    inflate the count and fail builds on repositories whose only problem is that a YAML file is
+    not a template.
+
+    WHAT THIS ASSERTS, AND WHAT IT REFUSES TO ASSERT
+    -----------------------------------------------
+    The count and the channel, never the wording. A test that watched the log message would pass
+    while the miscount survived, because the message is emitted before the finding would be
+    constructed. So: the number of results, the absence of any result attributed to the
+    unparseable files, and the presence of both failures in ``exitCodeDescription`` -- the error
+    channel the scanner actually reports them through.
+
+    WHAT IS DELIBERATELY NOT ASSERTED AS CORRECT
+    --------------------------------------------
+    ``executionSuccessful`` is True and ``exitCode`` is 0 on this run even though a third of the
+    targets were never evaluated, because ``determine_status`` only reports ERROR once
+    ``targets_failed >= targets_attempted``. Partial coverage loss being invisible in the
+    rolled-up status is a real and separate defect from the three this module covers; it is not
+    fixed here and this test does not pretend the value is right, it only records what it is.
+    """
+
+    def test_an_unparseable_target_is_an_error_not_a_finding(
+        self, test_plugin_context, non_compliant_template: Path
+    ):
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        # A real template alongside them, so the scan has something it CAN evaluate. Without it
+        # every target fails, the scanner reports ERROR, and the test would be measuring the
+        # total-failure path instead of the partial one.
+        (source_dir / "template.json").write_text(non_compliant_template.read_text())
+        for name, body in UNPARSEABLE_TARGETS.items():
+            (source_dir / name).write_text(body)
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+        assert report is not False, "scanner refused to run"
+
+        assert scanner.targets_attempted == 3, (
+            f"expected all three files in the scan set, got {scanner.targets_attempted}"
+        )
+        assert scanner.targets_failed == len(UNPARSEABLE_TARGETS), (
+            f"expected {len(UNPARSEABLE_TARGETS)} parse failures, got {scanner.targets_failed}"
+        )
+
+        run = report.runs[0]
+        results = run.results or []
+        assert results, (
+            "the real template produced no findings, so this fixture is not exercising the "
+            "partial-failure path"
+        )
+        # The channel assertion. Named per file so a failure says which one leaked.
+        for name in UNPARSEABLE_TARGETS:
+            leaked = [
+                r.ruleId
+                for r in results
+                if name in str(getattr(r.analysisTarget, "uri", "") or "")
+            ]
+            assert not leaked, (
+                f"{name} could not be parsed yet produced findings {leaked}"
+            )
+
+        # And the error channel does carry them, which is the positive artifact: "not a finding"
+        # on its own would also be satisfied by the failure vanishing entirely.
+        description = run.invocations[0].exitCodeDescription or ""
+        for name in UNPARSEABLE_TARGETS:
+            assert name in description, (
+                f"{name} failed to parse but is absent from exitCodeDescription, so the "
+                f"failure is recorded nowhere a consumer can see it"
+            )

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -59,6 +59,42 @@ def non_compliant_template(tmp_path: Path) -> Path:
     return path
 
 
+# A template that trips the CDK's OWN validation plugin as well as a nag pack. From
+# aws-cdk-lib 2.262.0 the CDK registers CloudFormationValidatePlugin unconditionally, so its
+# findings arrive in the same validation-report.json as cdk-nag's -- and a placeholder KMS key
+# identifier is the cheapest way to make it produce one (rule F3017). The bucket is also
+# non-compliant for AwsSolutions, which is load-bearing: both packs must appear in one report
+# or the test cannot show the two being told apart.
+FOREIGN_PLUGIN_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Fixture that trips both a nag pack and the CDK's own validation plugin",
+    "Resources": {
+        "PlaceholderKeyBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "BucketName": "ash-cdk-nag-foreign-plugin-fixture",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "aws:kms",
+                                "KMSMasterKeyID": "my-kms-key",
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+    },
+}
+
+@pytest.fixture()
+def foreign_plugin_template(tmp_path: Path) -> Path:
+    path = tmp_path / "foreign_plugin.template.json"
+    path.write_text(json.dumps(FOREIGN_PLUGIN_TEMPLATE, indent=2))
+    return path
+
+
 class TestRealNagPack:
     def test_pack_constructs_against_installed_cdk_nag(self):
         """The wrapper's own construction call must work on the installed major.
@@ -143,4 +179,120 @@ class TestRealNagPack:
         assert response is None, (
             "wrapper returned a populated response for a non-CloudFormation input; an "
             "empty-but-successful result is what makes a total failure look clean"
+        )
+
+
+class TestReportAttribution:
+    """Which tool produced a finding, measured against the real report rather than a fixture.
+
+    ``validation-report.json`` belongs to CDK, not to cdk-nag: it is the shared policy-validation
+    report, every registered ``IPolicyValidationPlugin`` writes into it, and from aws-cdk-lib
+    2.262.0 the CDK registers ``CloudFormationValidatePlugin`` on every app whether or not the
+    caller asked for it. So "the report came out of a cdk-nag run" stopped implying "cdk-nag
+    produced these rules", and the equivalent unit tests in
+    ``tests/unit/utils/test_cdk_nag_report_fidelity.py`` assert against a hand-written report
+    that could drift away from what the installed libraries actually emit. This class is what
+    stops that drift.
+    """
+
+    def test_a_cdk_plugin_that_is_not_a_nag_pack_is_named_as_its_own_pack(
+        self, foreign_plugin_template: Path, tmp_path: Path
+    ):
+        """The CDK's built-in plugin must be attributed to itself, not to cdk-nag.
+
+        The pack assertion is on the finding record. The per-pack mapping key is also correct
+        and is not sufficient on its own: the scanner binds that key to a loop variable, logs
+        it, and extends one flat result list, so it does not reach SARIF.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            run_cdk_nag_against_cfn_template,
+        )
+
+        response = run_cdk_nag_against_cfn_template(
+            template_path=foreign_plugin_template,
+            nag_packs=["AwsSolutionsChecks"],
+            outdir=tmp_path / "cdk-out-foreign",
+        )
+
+        assert response is not None and response.failure is None
+        packs = set(response.results)
+        assert "CloudFormation Validate" in packs, (
+            "the CDK's own validation plugin did not report; this fixture no longer "
+            f"exercises the defect. Packs present: {sorted(packs)}"
+        )
+        assert "AwsSolutions" in packs, (
+            f"the nag pack did not report, so nothing is being told apart. Packs: {sorted(packs)}"
+        )
+
+        for pack_name, findings in response.results.items():
+            assert findings, f"pack {pack_name!r} reported no findings"
+            for finding in findings:
+                record = (finding.properties.model_extra or {})["cdk_nag_finding"]
+                assert record["pack"] == pack_name, (
+                    f"{finding.ruleId} came from {pack_name!r} but records its pack as "
+                    f"{record['pack']!r}"
+                )
+
+        # The rule that made this defect visible in the first place, named so the fixture
+        # cannot quietly stop producing it.
+        foreign_rule_ids = {
+            f.ruleId for f in response.results["CloudFormation Validate"]
+        }
+        assert "F3017" in foreign_rule_ids, (
+            f"expected the placeholder-KMS-key rule F3017, got {sorted(foreign_rule_ids)}"
+        )
+
+    def test_the_scanner_documents_a_foreign_rule_against_the_right_guide(
+        self, test_plugin_context, foreign_plugin_template: Path
+    ):
+        """The rule descriptor a consumer reads, built by the real scanner.
+
+        ``helpUri`` was cdk-nag's RULES.md for every rule in the report, including the CDK's
+        own. Following it for ``F3017`` reaches a page that neither documents the rule nor
+        describes how to acknowledge it. The exact destination is named rather than "not the
+        cdk-nag URL", which would also be satisfied by an empty value.
+
+        This is the only test in this class that goes through ``CdkNagScanner.scan`` rather than
+        the wrapper, and it is what covers the reporting half: the rule descriptor is assembled
+        by the scanner, from a per-pack mapping it has already flattened.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "foreign_plugin.template.json").write_text(
+            foreign_plugin_template.read_text()
+        )
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+        assert report is not False, "scanner refused to run"
+
+        rules = {r.id: r for r in report.runs[0].tool.driver.rules or []}
+        assert "F3017" in rules, (
+            f"F3017 produced no rule descriptor; got {sorted(rules)}"
+        )
+
+        foreign = rules["F3017"]
+        assert foreign.properties.model_extra["pack"] == "CloudFormation Validate"
+        assert "pack::CloudFormation Validate" in foreign.properties.tags
+        assert (
+            str(foreign.helpUri)
+            == "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+        )
+
+        # The control: a genuine cdk-nag rule from the same scan keeps pointing at cdk-nag.
+        nag_rule_ids = [rid for rid in rules if rid.startswith("AwsSolutions-")]
+        assert nag_rule_ids, f"no cdk-nag rule in the same report; got {sorted(rules)}"
+        nag_rule = rules[nag_rule_ids[0]]
+        assert nag_rule.properties.model_extra["pack"] == "AwsSolutions"
+        assert str(nag_rule.helpUri).startswith(
+            "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#"
         )

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -88,10 +88,51 @@ FOREIGN_PLUGIN_TEMPLATE = {
     },
 }
 
+# A template on which a nag rule RAISES rather than returning a verdict.
+#
+# cdk-nag rules read primitive properties through NagRules.resolveIfPrimitive, which throws
+# "the rule could not be validated" when the value resolves to a non-primitive -- which is what
+# a Ref to a CloudFormation Parameter resolves to. applyRule catches that and records it through
+# the same addViolation a real violation uses, so the report cannot be told apart structurally.
+#
+# Two resources rather than one because two different rules have to be exercised: EC2Volume's
+# Encrypted trips AwsSolutions-EC26 and the security group description trips AwsSolutions-EC27.
+# Measured against cdk-nag 3.0.2, both come back at severity "error".
+UNEVALUATABLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Fixture whose primitive properties resolve to intrinsic functions",
+    "Parameters": {
+        "SgDescription": {"Type": "String", "Default": "fixture security group"},
+        "VolumeEncrypted": {"Type": "String", "Default": "true"},
+    },
+    "Resources": {
+        "IntrinsicSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {"GroupDescription": {"Ref": "SgDescription"}},
+        },
+        "IntrinsicVolume": {
+            "Type": "AWS::EC2::Volume",
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "Size": 8,
+                "Encrypted": {"Ref": "VolumeEncrypted"},
+            },
+        },
+    },
+}
+
+
 @pytest.fixture()
 def foreign_plugin_template(tmp_path: Path) -> Path:
     path = tmp_path / "foreign_plugin.template.json"
     path.write_text(json.dumps(FOREIGN_PLUGIN_TEMPLATE, indent=2))
+    return path
+
+
+@pytest.fixture()
+def unevaluatable_template(tmp_path: Path) -> Path:
+    path = tmp_path / "unevaluatable.template.json"
+    path.write_text(json.dumps(UNEVALUATABLE_TEMPLATE, indent=2))
     return path
 
 
@@ -295,4 +336,116 @@ class TestReportAttribution:
         assert nag_rule.properties.model_extra["pack"] == "AwsSolutions"
         assert str(nag_rule.helpUri).startswith(
             "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#"
+        )
+
+
+class TestRuleThatCouldNotBeEvaluated:
+    def test_an_unevaluated_rule_is_not_reported_as_a_violation(
+        self, unevaluatable_template: Path, tmp_path: Path
+    ):
+        """A rule that raised must render as notApplicable with no severity.
+
+        cdk-nag reports a rule that threw through the same ``addViolation`` as a real finding,
+        at whatever severity the rule declared -- ``"error"`` for these two, which ASH's ladder
+        reads as CRITICAL. So before this change a template referencing a parameter produced
+        critical security findings for rules that never ran.
+
+        Both directions are asserted from one report: the unevaluated rules must be
+        ``notApplicable``/``none``, and a genuine violation from the same run must still be
+        ``fail``/``error``.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            run_cdk_nag_against_cfn_template,
+        )
+
+        response = run_cdk_nag_against_cfn_template(
+            template_path=unevaluatable_template,
+            nag_packs=["AwsSolutionsChecks"],
+            outdir=tmp_path / "cdk-out-unevaluatable",
+        )
+
+        assert response is not None and response.failure is None
+
+        unevaluated = [
+            finding
+            for findings in response.results.values()
+            for finding in findings
+            if (finding.properties.model_extra or {})["cdk_nag_finding"]["compliance"]
+            == NOT_EVALUATED
+        ]
+        assert unevaluated, (
+            "no rule reported as un-evaluated, so this fixture no longer reproduces the "
+            "defect. cdk-nag raises out of NagRules.resolveIfPrimitive when a primitive "
+            "property resolves to an intrinsic; check that the parameter Refs survived."
+        )
+
+        for finding in unevaluated:
+            assert finding.kind == Kind.notApplicable, (
+                f"{finding.ruleId} could not be evaluated but rendered kind={finding.kind}"
+            )
+            assert finding.level == Level.none, (
+                f"{finding.ruleId} could not be evaluated but carries level={finding.level}"
+            )
+            # The message is what most report surfaces show, so the fact has to be legible
+            # there too rather than only in the machine-readable kind.
+            assert "NOT evaluated" in finding.message.root.text
+
+    def test_the_scanner_reports_an_unevaluated_rule_as_a_run_level_condition(
+        self, test_plugin_context, unevaluatable_template: Path
+    ):
+        """End to end through the real scanner, asserting the SARIF invocation.
+
+        This is the only test here that exercises ``CdkNagScanner.scan`` rather than the
+        wrapper, and it is what covers the reporting half of the fix: the rule descriptor's
+        pack and help pointer, and the ``toolExecutionNotifications`` entry.
+
+        SARIF's own definitions are why the notification exists at all --
+        ``toolExecutionNotifications`` is "A list of runtime conditions detected by the tool
+        during the analysis" and ``notification.associatedRule`` is "A reference used to locate
+        the rule descriptor associated with this notification". A rule that raised mid-scan is
+        a runtime condition, and a coverage hole is a property of the run rather than of one
+        result.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "unevaluatable.template.json").write_text(
+            unevaluatable_template.read_text()
+        )
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+
+        assert report is not False, "scanner refused to run"
+        run = report.runs[0]
+
+        notifications = run.invocations[0].toolExecutionNotifications or []
+        notified_rules = {
+            n.associatedRule.root.id for n in notifications if n.associatedRule
+        }
+        assert notified_rules, (
+            "the scan produced no toolExecutionNotifications, so a rule that did not run "
+            "leaves no trace at the run level"
+        )
+
+        # Every notified rule must correspond to a notApplicable result, and vice versa: the
+        # two channels are two views of one fact and must not disagree.
+        from automated_security_helper.schemas.sarif_schema_model import Kind
+
+        unevaluated_rules = {
+            r.ruleId for r in (run.results or []) if r.kind == Kind.notApplicable
+        }
+        assert notified_rules == unevaluated_rules, (
+            f"notifications name {sorted(notified_rules)} but the notApplicable results are "
+            f"{sorted(unevaluated_rules)}"
         )

--- a/tests/unit/core/test_scanner_status_across_targets.py
+++ b/tests/unit/core/test_scanner_status_across_targets.py
@@ -1,0 +1,204 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""An ERROR on any scanned target has to reach the rolled-up scanner status.
+
+WHY THIS FILE EXISTS
+--------------------
+``ScanPhase`` hands each scanner one task carrying two targets -- the source tree and the
+converted tree -- and ``ScanResultProcessor`` writes one serialized container per target under
+``additional_reports[scanner][target_type]``. The rolled-up status a human reads comes from
+``get_unified_scanner_metrics``, whose loudest branch is ``stats["error"]``, and that flag is
+produced by ``get_scanner_status_info``.
+
+``get_scanner_status_info`` read the ``"source"`` report and only the ``"source"`` report. So a
+scanner that passed on the source tree and errored on the converted tree rolled up to PASSED:
+the ERROR container was written, serialized, and never consulted. An ERROR means no rule was
+evaluated on that target, so this is the silent-pass shape the surrounding code was written
+against, arriving through the target dimension instead of through the severity counts.
+
+WHAT WAS ALREADY HANDLED, AND WHY THAT WAS NOT ENOUGH
+-----------------------------------------------------
+Two adjacent guards already existed and neither one covers this:
+
+* ``ScanResultsContainer.determine_status`` returns ERROR when a tracking scanner failed every
+  target it attempted. It did its job here -- the converted container really does carry
+  ``status="ERROR"``. The loss is downstream of it.
+* ``scanner_evaluated_nothing`` reads across EVERY target report, and documents why: only one
+  of the two targets may have been empty. It is the correct quantifier applied to the wrong
+  fact, and the asymmetry between the two functions is exactly where the defect lived.
+
+ASSERTIONS ARE ON THE PRESENCE OF ERROR, NOT ON THE ABSENCE OF PASSED
+--------------------------------------------------------------------
+"The status is no longer PASSED" would also be satisfied by FAILED, SKIPPED or MISSING, and by
+a scanner disappearing from the metrics list altogether. Each test below names the status it
+requires.
+
+WHAT IS DELIBERATELY NOT CHANGED
+--------------------------------
+``excluded`` and ``dependencies_missing`` are still read off the single scanner-level report.
+Both are facts about configuration rather than about a target: a scanner is switched off, or
+its tool is absent, for the whole run. Widening those to "any target" would let one target with
+an unrecognized status -- which ``_status_info_from_report`` maps to ``excluded=True`` for
+backward compatibility -- mark the whole scanner as operator-excluded.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _model_with_target_statuses(source_status: str, converted_status: str):
+    """An AshAggregatedResults stand-in carrying one serialized container per target.
+
+    The report shape is the one ``ScanResultProcessor`` actually writes: it dumps the
+    container with ``exclude_unset=True``, so only fields a scanner assigned are present.
+    That is why ``excluded`` is absent here rather than set to False -- its absence is what
+    makes ``_status_info_from_report`` trust the field.
+
+    ``sarif.runs`` is empty so every severity count is zero. That keeps the ``actionable > 0``
+    branch out of the way, which matters: it is checked before the did-not-run branches, and a
+    fixture that accidentally carried findings would return FAILED and pass a test that is
+    supposed to be about ERROR.
+    """
+    model = MagicMock()
+    model.sarif = MagicMock()
+    model.sarif.runs = []
+    model.scanner_results = {}
+    # Real values, not bare MagicMock attributes. ``ScannerMetrics.threshold`` is typed as a
+    # str and ``get_scanner_threshold_info`` reads it straight off the config, so an
+    # auto-created mock attribute reaches pydantic and raises a validation error before any
+    # status is computed -- a failure that looks like the defect but is the fixture.
+    model.ash_config = MagicMock()
+    model.ash_config.global_settings.severity_threshold = "MEDIUM"
+    model.ash_config.get_plugin_config.return_value = None
+    model.additional_reports = {
+        "cdk-nag": {
+            "source": {
+                "scanner_name": "cdk-nag",
+                "status": source_status,
+                "targets_attempted": 2,
+                "targets_failed": 0,
+                "duration": 1.5,
+            },
+            "converted": {
+                "scanner_name": "cdk-nag",
+                "status": converted_status,
+                "targets_attempted": 1,
+                "targets_failed": 1,
+                "duration": 0.5,
+            },
+        }
+    }
+    return model
+
+
+class TestErrorOnAnyTargetReachesTheRollup:
+    def test_status_info_reports_error_when_only_the_converted_target_errored(self):
+        """The measured shape: source PASSED, converted ERROR.
+
+        This is the narrowest statement of the defect. ``get_scanner_status_info`` returns the
+        ``error`` flag that every rolled-up status ultimately keys on, so if it is False here
+        nothing downstream can recover the fact.
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        excluded, dependencies_missing, error = (
+            ScannerStatisticsCalculator.get_scanner_status_info(model, "cdk-nag")
+        )
+
+        assert error is True, (
+            "an ERROR on the converted target did not set the error flag; the container was "
+            "written and never read"
+        )
+        # Named explicitly so a future change that produces error=True by routing through the
+        # excluded/missing branches instead fails here rather than passing quietly.
+        assert excluded is False
+        assert dependencies_missing is False
+
+    def test_status_info_reports_error_when_only_the_source_target_errored(self):
+        """The mirror case, so the fix cannot be a source-versus-converted swap.
+
+        Reading only ``"converted"`` would satisfy the test above and break this one. Both
+        directions are asserted because "any target" is the property being fixed, not "the
+        other target".
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("ERROR", "PASSED")
+
+        _, _, error = ScannerStatisticsCalculator.get_scanner_status_info(
+            model, "cdk-nag"
+        )
+
+        assert error is True, "an ERROR on the source target did not set the error flag"
+
+    def test_get_scanner_status_returns_error_for_a_converted_target_error(self):
+        """The string status, which is the other public route to the same fact.
+
+        ``get_scanner_status`` and ``get_unified_scanner_metrics`` are two functions answering
+        "what is this scanner's status", and the module's own comments require they not
+        disagree. Asserting both means a fix applied to one of them cannot leave the other
+        reporting PASSED.
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        assert (
+            ScannerStatisticsCalculator.get_scanner_status(model, "cdk-nag") == "ERROR"
+        )
+
+    def test_unified_metrics_rolls_a_converted_target_error_up_to_error(self):
+        """The status a human reads off the summary table, and the ``passed`` flag with it.
+
+        ``ScannerMetrics.passed`` is True for PASSED, SKIPPED and MISSING, so a row that
+        rolled up wrong renders green and is also serialized into ``ash.flat.json`` as
+        ``passed: true``. Both are asserted: the status is what the table shows, and
+        ``passed`` is what a machine consumer gates on.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert "cdk-nag" in metrics, (
+            "the scanner vanished from the metrics list entirely"
+        )
+        assert metrics["cdk-nag"].status == "ERROR"
+        assert metrics["cdk-nag"].passed is False
+
+    @pytest.mark.parametrize("converted_status", ["PASSED", "FAILED", "SKIPPED"])
+    def test_a_non_error_converted_target_does_not_invent_an_error(
+        self, converted_status: str
+    ):
+        """The negative control, without which the fix could be ``error = True``.
+
+        A test suite that only checks ERROR-is-visible is satisfied by a function that always
+        reports an error. FAILED and SKIPPED are included alongside PASSED because both are
+        verdicts a target legitimately reaches, and neither means "nothing was evaluated".
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", converted_status)
+
+        _, _, error = ScannerStatisticsCalculator.get_scanner_status_info(
+            model, "cdk-nag"
+        )
+
+        assert error is False, (
+            f"a converted target reporting {converted_status} was read as an error"
+        )

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -1,0 +1,212 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The SARIF rule descriptor has to name the plugin that owns the rule.
+
+``validation-report.json`` is CDK's shared policy-validation report. Registering any cdk-nag
+pack on an app whose aws-cdk-lib is 2.262.0 or newer also gets the CDK's own
+``CloudFormationValidatePlugin``, whose ``PLUGIN_NAME`` is ``"CloudFormation Validate"``, so a
+single scan produces rules from two different tools. The wrapper keys them apart; the scanner
+flattens them into one result list and then builds one ``ReportingDescriptor`` per rule id.
+
+That descriptor is where a consumer looks up what a rule is and where it is documented, and it
+carried neither fact correctly:
+
+* ``helpUri`` was cdk-nag's RULES.md for every rule. Following it for ``F3017`` lands on a page
+  that does not mention ``F3017`` and does not describe the mechanism that governs it.
+* ``tags`` was built from ``finding_props.get("tags", [])``, and ``finding_props`` is
+  ``_NagFinding.as_dict()``, which has no ``tags`` key. The lookup returned its default on
+  every finding that has ever been scanned, so the pack the wrapper had been writing onto each
+  result never reached the rule.
+
+These tests drive ``_reporting_descriptor_for`` directly. It was inline in ``scan()`` until this
+change, where reaching it meant running a full CDK synthesis -- which is why an always-empty
+``tags`` read survived in it.
+"""
+
+import pytest
+
+from automated_security_helper.schemas.sarif_schema_model import (
+    Message,
+    Message1,
+    PropertyBag,
+    Result,
+)
+
+
+def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
+    """A Result shaped the way the wrapper emits one.
+
+    ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
+    not declare it; ``tags`` is a declared field. The descriptor builder reads both, so the
+    fixture has to populate both or it would be testing a shape the wrapper never produces.
+    """
+    return Result(
+        ruleId=rule_id,
+        message=Message(root=Message1(text=f"{rule_id} description text")),
+        properties=PropertyBag(
+            cdk_nag_finding={
+                "pack": pack,
+                "rule_id": rule_id,
+                "resource_id": "ProbeResource",
+                "compliance": "Non-Compliant",
+                "exception_reason": "N/A",
+                "rule_level": rule_level,
+                "rule_info": f"{rule_id} rule info",
+            },
+            tags=["aws", "cdk", "cdk-nag", pack, rule_id, "ProbeResource"],
+        ),
+    )
+
+
+class TestRuleDescriptorNamesItsPack:
+    def test_the_pack_is_a_labelled_property_on_the_rule(self):
+        """A named field, not a positional entry in a nine-element tag list.
+
+        The pack is in ``tags`` as well, and that is not sufficient on its own: beside it sit
+        the rule id, the resource logical id and the resource type, and nothing tells a
+        consumer which string is which.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("F3017", "CloudFormation Validate", rule_level="Warning"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert descriptor.properties.model_extra["pack"] == "CloudFormation Validate"
+        assert "pack::CloudFormation Validate" in descriptor.properties.tags
+
+    def test_the_findings_own_tags_are_forwarded_onto_the_rule(self):
+        """The always-empty lookup, stated as the tags that must now be present.
+
+        Asserted as a subset rather than an exact list so that adding a tag later does not
+        break this, but every tag the result carried is named -- the previous code forwarded
+        none of them and no test noticed.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert {
+            "aws",
+            "cdk",
+            "cdk-nag",
+            "AwsSolutions",
+            "AwsSolutions-S1",
+            "ProbeResource",
+        }.issubset(set(descriptor.properties.tags))
+
+    def test_a_cdk_nag_rule_still_points_at_cdk_nags_rule_documentation(self):
+        """The behaviour that was already right, pinned so the fix cannot break it.
+
+        The anchor is derived from the rule level, which is the pre-existing convention. Naming
+        the whole URL means a change to either half fails here.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions", rule_level="Error"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        # str(), because ReportingDescriptor.helpUri is typed as a pydantic AnyUrl and
+        # comparing the model object with a string is always False.
+        assert (
+            str(descriptor.helpUri)
+            == "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#errors"
+        )
+
+    def test_a_cloudformation_validate_rule_points_at_the_cdk_validation_guide(self):
+        """The destination that documents the plugin AND how to acknowledge its findings.
+
+        Named as an exact URL rather than "not the cdk-nag one", because "not X" is satisfied
+        by an empty string, by None, and by any wrong page.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("F3017", "CloudFormation Validate", rule_level="Warning"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert (
+            str(descriptor.helpUri)
+            == "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+        )
+
+    def test_a_finding_with_no_recorded_pack_keeps_its_previous_destination(self):
+        """Only findings positively known to be foreign are redirected.
+
+        An absent pack is not evidence of a foreign producer. Inside this scanner's own report
+        the likeliest producer is cdk-nag, so treating "no pack recorded" as "not cdk-nag" would
+        send genuine cdk-nag rules away from their own documentation -- the same misattribution
+        in the opposite direction, introduced by the fix for it.
+
+        The generic ``#rules`` anchor is what a missing ``rule_level`` degrades to, and it
+        claims nothing about a specific rule.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        bare = _result("AwsSolutions-S9", pack="")
+        bare.properties.model_extra["cdk_nag_finding"].pop("rule_level")
+
+        descriptor = _reporting_descriptor_for(
+            bare, tool_name="cdk-nag", tool_type="IAC"
+        )
+
+        assert (
+            str(descriptor.helpUri)
+            == "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#rules"
+        )
+        # The pack is reported as unknown rather than invented, so a reader can tell the
+        # difference between "cdk-nag" and "we do not know".
+        assert descriptor.properties.model_extra["pack"] == ""
+        assert "pack::unknown" in descriptor.properties.tags
+
+
+class TestPackOwnershipIsDerivedNotListed:
+    @pytest.mark.parametrize(
+        ("rule_id", "pack", "owned"),
+        [
+            # cdk-nag mints every rule id as f"{packName}-{ruleSuffix}".
+            ("AwsSolutions-S1", "AwsSolutions", True),
+            ("AwsSolutions-IAM5[Resource::*]", "AwsSolutions", True),
+            ("HIPAASecurity-S1", "HIPAASecurity", True),
+            # A pack cdk-nag has not shipped yet must still be recognised, which is the whole
+            # reason ownership is derived from the id rather than from a list of names.
+            ("SomeFuturePack-XYZ1", "SomeFuturePack", True),
+            # The CDK's own plugin does not prefix its rule ids with its plugin name.
+            ("F3017", "CloudFormation Validate", False),
+            ("W3010", "CloudFormation Validate", False),
+            # A pack that is merely a prefix of another pack's name must not claim its rules.
+            ("AwsSolutionsExtra-S1", "AwsSolutions", False),
+            # No pack recorded at all -- nothing can be claimed.
+            ("AwsSolutions-S1", "", False),
+        ],
+    )
+    def test_ownership_follows_cdk_nags_rule_id_construction(
+        self, rule_id: str, pack: str, owned: bool
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _rule_is_from_pack,
+        )
+
+        assert _rule_is_from_pack(rule_id, pack) is owned

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_scanner_behavior.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_scanner_behavior.py
@@ -62,19 +62,28 @@ def nag_result(
     text="The S3 Bucket has server access logs disabled.",
     rule_level="Error",
     tags=None,
+    pack="AwsSolutions",
 ):
-    """A Result shaped the way cdk_nag_wrapper emits one."""
+    """A Result shaped the way cdk_nag_wrapper emits one.
+
+    ``pack`` is part of that shape. The wrapper records which plugin produced each finding,
+    because ``validation-report.json`` is CDK's shared policy-validation report and from
+    aws-cdk-lib 2.262.0 the CDK's own ``CloudFormationValidatePlugin`` writes into it alongside
+    the nag packs. Leaving it out of this helper would make every test here describe a finding
+    the wrapper cannot emit, and the help-pointer tests below turn on it.
+    """
     return Result(
         ruleId=rule_id,
         level=Level.error,
         message=Message(root=Message1(text=text)),
         properties=PropertyBag(
             cdk_nag_finding={
+                "pack": pack,
                 "rule_id": rule_id,
                 "rule_level": rule_level,
                 "rule_info": text,
             },
-            tags=["aws", "cdk", "cdk-nag", rule_id] + (tags or []),
+            tags=["aws", "cdk", "cdk-nag", pack, rule_id] + (tags or []),
         ),
     )
 
@@ -634,25 +643,28 @@ def test_rule_carries_the_finding_text_and_tool_tags(
     )
 
 
-def test_rule_tags_do_not_include_the_findings_own_tags(
+def test_rule_tags_include_the_findings_own_tags(
     scanner, cdk_available, wrapper_double, template_in_work_dir
 ):
-    """Rule tags come out as only the two tool tags.
+    """Rule tags carry the finding's tags plus the pack and the two tool tags.
 
-    The rule builder reads tags from ``cdk_nag_finding``, but cdk_nag_wrapper
-    puts the finding's tags on ``properties.tags`` and its cdk_nag_finding dict
-    holds only rule_id/resource_id/compliance/exception_reason/rule_level/
-    rule_info. So ``finding_props.get("tags", [])`` is always empty in
-    production and the resource/pack/type tags never reach the rule. The
-    fixture here mirrors the wrapper's real dict shape so the assertion
-    reflects what ships.
+    This test used to assert the opposite, and the behaviour it described was a
+    defect rather than a decision: the rule builder read
+    ``finding_props.get("tags", [])`` out of ``cdk_nag_finding``, which is
+    ``_NagFinding.as_dict()`` and has no ``tags`` key at all. The lookup
+    returned its default on every finding ever scanned, so the resource, type
+    and pack tags the wrapper puts on ``properties.tags`` never reached the
+    rule -- the one place a consumer looks up what a rule is and who owns it.
+
+    The builder now reads the result's own property bag. Every tag is named
+    below rather than counted, because a count passes for the wrong reason as
+    soon as the tag list changes shape, and it was a count that let the empty
+    read look deliberate.
     """
     finding = nag_result(rule_id="AwsSolutions-S1")
     assert "tags" not in finding.properties.model_extra["cdk_nag_finding"], (
-        "fixture must match the wrapper's cdk_nag_finding shape"
-    )
-    assert "AwsSolutions-S1" in finding.properties.tags, (
-        "the finding does carry tags -- just not where the rule builder looks"
+        "fixture must match the wrapper's cdk_nag_finding shape: the tags live "
+        "on properties.tags, not inside the finding record"
     )
     wrapper_double.return_value = CdkNagWrapperResponse(
         results={"AwsSolutions": [finding]}
@@ -661,7 +673,12 @@ def test_rule_tags_do_not_include_the_findings_own_tags(
     report = scanner.scan(target=scanner.context.work_dir, target_type="converted")
 
     tags = report.runs[0].tool.driver.rules[0].properties.tags
-    assert len(tags) == 2, f"expected only the two tool tags, got {tags}"
+    assert {"aws", "cdk", "cdk-nag", "AwsSolutions", "AwsSolutions-S1"}.issubset(
+        set(tags)
+    ), f"the finding's own tags did not reach the rule; got {tags}"
+    assert "pack::AwsSolutions" in tags, (
+        f"the originating pack is not labelled on the rule; got {tags}"
+    )
     assert any(t.startswith("tool_name::") for t in tags)
     assert any(t.startswith("tool_type::") for t in tags)
 

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_unevaluated_notification.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_unevaluated_notification.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A rule that did not run has to be visible as a condition of the RUN, not just a result.
+
+WHY A RESULT IS NOT ENOUGH
+--------------------------
+Marking the individual finding ``kind=notApplicable`` with ``level=none`` is correct and is
+covered by ``tests/unit/utils/test_cdk_nag_unevaluated_rule.py``. It is also easy to miss: that
+result sits in the same array as the findings, at the lowest severity there is, and report
+surfaces routinely sort or filter by severity. The fact an operator needs is coarser -- "part of
+this scan did not run" -- and it belongs where facts about the run live.
+
+SARIF already defines that place, in its own words. ``invocation.toolExecutionNotifications`` is
+"A list of runtime conditions detected by the tool during the analysis", and
+``notification.associatedRule`` is "A reference used to locate the rule descriptor associated
+with this notification". A rule raising mid-evaluation is a runtime condition detected during
+the analysis, and the rule it happened to is the thing to associate it with. So the
+representation is SARIF's rather than a bespoke property bag key.
+
+``tests/integration/scanners/test_cdk_nag_real_pack.py`` asserts the same thing end to end
+through ``CdkNagScanner.scan`` against real cdk-nag; these tests pin the helper's behaviour on
+inputs a live run is awkward to produce on demand, such as one rule raising on several resources.
+"""
+
+from automated_security_helper.schemas.sarif_schema_model import (
+    Kind,
+    Level,
+    Message,
+    Message1,
+    PropertyBag,
+    Result,
+)
+from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+
+def _result(rule_id: str, compliance: str, resource: str = "ProbeResource") -> Result:
+    """A Result shaped the way the wrapper emits one.
+
+    ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
+    not declare it. The helper reads ``compliance`` out of that bag rather than off ``kind``,
+    which is deliberate on its part -- the bag is the wrapper's own record and cannot be changed
+    by a later reporting step.
+    """
+    return Result(
+        ruleId=rule_id,
+        kind=Kind.notApplicable if compliance == NOT_EVALUATED else Kind.fail,
+        level=Level.none if compliance == NOT_EVALUATED else Level.error,
+        message=Message(root=Message1(text=f"{rule_id} message")),
+        properties=PropertyBag(
+            cdk_nag_finding={
+                "pack": "AwsSolutions",
+                "rule_id": rule_id,
+                "resource_id": resource,
+                "compliance": compliance,
+                "exception_reason": "N/A",
+                "rule_level": "Error",
+                "rule_info": f"{rule_id} could not be validated.",
+            },
+            tags=["aws", "cdk", "cdk-nag", "AwsSolutions", rule_id, resource],
+        ),
+    )
+
+
+class TestUnevaluatedRuleNotifications:
+    def test_an_unevaluated_rule_produces_a_notification_naming_that_rule(self):
+        """The positive artifact: a notification whose ``associatedRule`` is the rule id.
+
+        The rule id is asserted rather than just the notification count, because a notification
+        that does not say which rule went unevaluated tells an operator nothing actionable.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [
+                _result("AwsSolutions-EC26", NOT_EVALUATED),
+                _result("AwsSolutions-S1", "Non-Compliant"),
+            ]
+        )
+
+        assert [n.associatedRule.root.id for n in notifications] == [
+            "AwsSolutions-EC26"
+        ]
+        assert "could not be evaluated" in notifications[0].message.root.text
+        assert "AwsSolutions" in notifications[0].message.root.text
+
+    def test_the_notification_is_reported_at_error_level(self):
+        """``error``, overriding the field's ``warning`` default.
+
+        For a security scanner a rule that silently did not run is the more serious of the two
+        things it can report -- a violation at least tells you what to fix. Asserted because
+        ``Notification.level`` defaults to ``warning``, so getting this right requires passing it
+        and a regression here would be invisible.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [_result("AwsSolutions-EC26", NOT_EVALUATED)]
+        )
+
+        assert notifications[0].level == Level.error
+
+    def test_one_rule_raising_on_several_resources_is_reported_once(self):
+        """Deduplicated by rule id.
+
+        A rule that cannot resolve a property raises for every construct sharing that shape, and
+        the run-level statement is about the rule. The per-resource detail is already carried by
+        the results. Two distinct rules must still produce two notifications, which is what stops
+        the deduplication from collapsing everything to one.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [
+                _result("AwsSolutions-EC26", NOT_EVALUATED, resource="VolumeA"),
+                _result("AwsSolutions-EC26", NOT_EVALUATED, resource="VolumeB"),
+                _result("AwsSolutions-EC27", NOT_EVALUATED, resource="SecurityGroup"),
+            ]
+        )
+
+        assert sorted(n.associatedRule.root.id for n in notifications) == [
+            "AwsSolutions-EC26",
+            "AwsSolutions-EC27",
+        ]
+
+    def test_a_scan_with_no_unevaluated_rule_produces_no_notifications(self):
+        """The negative control.
+
+        ``toolExecutionNotifications`` is written unconditionally into the invocation, so this is
+        what keeps an ordinary clean scan from claiming a coverage gap it does not have.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        assert (
+            _unevaluated_rule_notifications(
+                [
+                    _result("AwsSolutions-S1", "Non-Compliant"),
+                    _result("AwsSolutions-S10", "Non-Compliant"),
+                ]
+            )
+            == []
+        )

--- a/tests/unit/utils/test_cdk_nag_pack_attribution.py
+++ b/tests/unit/utils/test_cdk_nag_pack_attribution.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A finding has to name the plugin that produced it, not the tool that ran the scan.
+
+``validation-report.json`` is CDK's policy-validation report, not cdk-nag's. Every plugin
+registered on the app writes into the same ``pluginReports`` array, and from aws-cdk-lib 2.262.0
+the CDK registers one of its own unconditionally: ``CloudFormationValidatePlugin``, whose
+``PLUGIN_NAME`` is the literal string ``"CloudFormation Validate"`` and whose rules are
+``@aws/cloudformation-validate`` ids such as ``F3017`` and ``W3010``. A measured run against a
+template carrying a placeholder KMS key identifier returns both ``"AwsSolutions"`` and
+``"CloudFormation Validate"`` in one report.
+
+The pack name reached ``properties.tags`` as an unlabelled positional entry and reached nothing
+else. So a consumer asking "what produced F3017, and where is it documented" got the answer
+"cdk-nag" -- which is wrong, and is why the rule's help pointer aimed at cdk-nag's RULES.md, a
+document that does not mention F3017 and does not describe the mechanism that governs it.
+
+These tests drive ``_violations_from_validation_report`` against a written report rather than
+through a synthesis, because translating the report is that function's whole job and the report
+is its only input. The fixture is a trimmed copy of a report produced by the installed
+aws-cdk-lib 2.267.0 and cdk-nag 3.0.2; ``TestReportAttribution`` in
+``tests/integration/scanners/test_cdk_nag_real_pack.py`` asserts the same properties against a
+live synthesis, so the fixture cannot drift into fiction without something going red.
+"""
+
+import json
+from pathlib import Path
+
+
+def _write_report(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "validation-report.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# A two-plugin report, which is the ordinary case rather than an edge case: registering any nag
+# pack on an app whose CDK is >= 2.262.0 produces one.
+TWO_PLUGIN_REPORT = {
+    "version": "2.1.0",
+    "title": "Validation Report",
+    "pluginReports": [
+        {
+            "pluginName": "AwsSolutions",
+            "violations": [
+                {
+                    "ruleName": "AwsSolutions-S1",
+                    "description": "The S3 Bucket has server access logs disabled.",
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                }
+            ],
+        },
+        {
+            "pluginName": "CloudFormation Validate",
+            "violations": [
+                {
+                    "ruleName": "F3017",
+                    "description": (
+                        "BucketEncryption.ServerSideEncryptionConfiguration.0."
+                        "ServerSideEncryptionByDefault.KMSMasterKeyID: 'my-kms-key' "
+                        "is not a valid KMS key identifier"
+                    ),
+                    "severity": "warning",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                }
+            ],
+        },
+    ],
+}
+
+
+class TestOriginatingPackIsCarriedOnTheFinding:
+    def test_each_finding_records_the_plugin_that_produced_it(self, tmp_path: Path):
+        """The pack travels on the finding record, not only as a dict key.
+
+        The per-pack mapping this function returns is consumed by a loop in the scanner that
+        binds the key to a variable, logs it, and extends one flat list -- so the key is gone by
+        the time SARIF is assembled. Putting the pack on the finding is what survives that.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        per_pack, failure = _violations_from_validation_report(
+            _write_report(tmp_path, TWO_PLUGIN_REPORT)
+        )
+
+        assert failure is None
+        assert set(per_pack) == {"AwsSolutions", "CloudFormation Validate"}
+
+        for pack_name, findings in per_pack.items():
+            assert findings, f"pack {pack_name!r} produced no findings"
+            for finding in findings:
+                assert finding.pack == pack_name, (
+                    f"finding {finding.rule_id} landed under pack {pack_name!r} but records "
+                    f"its pack as {finding.pack!r}"
+                )
+
+    def test_the_pack_survives_into_the_serialized_finding_record(self, tmp_path: Path):
+        """``as_dict()`` is the property bag the scanner reads back out of SARIF.
+
+        ``cdk_nag_finding`` is indexed by these exact keys downstream, so a pack that exists on
+        the object but not in this dict is a pack the reporting path still cannot see.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, TWO_PLUGIN_REPORT)
+        )
+
+        record = per_pack["CloudFormation Validate"][0].as_dict()
+        assert record["pack"] == "CloudFormation Validate"
+        assert record["rule_id"] == "F3017"
+
+        # The control: the nag pack's own finding must record its own pack, not the foreign one.
+        nag_record = per_pack["AwsSolutions"][0].as_dict()
+        assert nag_record["pack"] == "AwsSolutions"

--- a/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
+++ b/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
@@ -1,0 +1,308 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A rule cdk-nag could not evaluate is a coverage gap, not a violation.
+
+THE MECHANISM
+-------------
+cdk-nag 3.0.2's ``applyRule`` wraps each rule in a try/catch and, on an exception, calls the
+same ``addViolation`` a real violation goes through -- passing the exception message as a third
+argument. ``addViolation`` turns that into a description prefixed "Rule threw an error during
+validation.", and leaves the severity as whatever the rule declared. Reached in practice
+whenever a rule calls ``NagRules.resolveIfPrimitive`` on a property that resolves to a
+non-primitive, which throws "therefore the rule could not be validated" -- a ``Ref`` to a
+CloudFormation Parameter is exactly that.
+
+So there is no structural marker in the report: the description prefix is the only thing that
+separates "this rule found a problem" from "this rule never ran". A rule that never ran arrived
+as ``severity: "error"``, which this module normalizes to ``"Error"``, which the SARIF mapping
+rendered ``level=error, kind=fail`` -- CRITICAL on ASH's severity ladder. Two rules that did not
+run were reported as two critical security findings, and the gap in coverage they represent was
+invisible.
+
+WHY notApplicable AND NOT open
+------------------------------
+SARIF 2.1.0 defines both, and the difference decides which one is a true statement. Quoting the
+OASIS Standard incorporating Approved Errata 01, section 3.27.9:
+
+  "notApplicable" : The rule specified by ruleId was not evaluated, because it does not apply
+  to the analysis target.
+
+  "open" : The specified rule was evaluated, and the tool concluded that there was insufficient
+  information to decide whether a problem exists.
+
+``open`` opens with "was evaluated", and its NOTE 1 scopes the value to proof-based tools that
+completed an analysis and could not prove either direction. cdk-nag's rule did not complete --
+it raised partway through -- so "was not evaluated" is the accurate half. Section 3.27.9's own
+example for ``notApplicable`` is a result whose message reads "<target> was not evaluated for
+rule <id> because <reason>", which is the shape this path now produces.
+
+``level`` follows rather than being chosen: section 3.27.10 defines ``"none"`` as "The concept of
+'severity' does not apply to this result because the kind property (3.27.9) has a value other
+than 'fail'". ASH's ladder maps ``none`` to INFO, so the count inflation stops as a consequence
+of getting the SARIF right rather than as a separate adjustment that could drift away from it.
+
+The live-synthesis counterpart is ``TestRuleThatCouldNotBeEvaluated`` in
+``tests/integration/scanners/test_cdk_nag_real_pack.py``, which makes real cdk-nag rules raise
+and asserts the same properties -- so the fixture below cannot drift away from what cdk-nag
+actually emits without something going red.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _write_report(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "validation-report.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# cdk-nag's not-evaluated shape beside a genuine violation, in one report. Having both is
+# load-bearing: every assertion below names what must change AND what must not, so a change that
+# rewrites every finding cannot pass.
+UNEVALUATED_REPORT = {
+    "version": "2.1.0",
+    "title": "Validation Report",
+    "pluginReports": [
+        {
+            "pluginName": "AwsSolutions",
+            "violations": [
+                {
+                    "ruleName": "AwsSolutions-EC26",
+                    "description": (
+                        "Rule threw an error during validation. The parameter resolved "
+                        'to to a non-primitive value "{\\"Ref\\":\\"VolumeEncrypted\\"}", '
+                        "therefore the rule could not be validated."
+                    ),
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeVolume"}
+                    ],
+                },
+                {
+                    "ruleName": "AwsSolutions-S1",
+                    "description": "The S3 Bucket has server access logs disabled.",
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+
+class TestARuleThatCouldNotBeEvaluatedIsNotAViolation:
+    def test_end_to_end_the_unevaluated_rule_does_not_render_as_a_critical_failure(
+        self, tmp_path: Path
+    ):
+        """The whole defect in one assertion, using only names that already existed.
+
+        Deliberately written without importing anything added by this change, so that its red
+        state on the unfixed tree is a behavioural difference rather than a missing symbol. It
+        composes the two functions exactly as ``run_cdk_nag_against_cfn_template`` does -- read
+        the report, then map each finding's compliance and level onto SARIF -- and checks what a
+        consumer of that SARIF sees.
+
+        On the unfixed tree this returns ``(Level.error, Kind.fail)``, which ASH's severity
+        ladder reads as CRITICAL. The pair is asserted rather than each field separately,
+        because section 3.27.10 makes them dependent: ``level`` is only meaningful once ``kind``
+        is known.
+        """
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _level_and_kind,
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+        rendered = {
+            finding.rule_id: _level_and_kind(
+                compliance=finding.compliance,
+                rule_level=finding.rule_level,
+                exception_reason=finding.exception_reason,
+            )
+            for finding in per_pack["AwsSolutions"]
+        }
+
+        assert rendered["AwsSolutions-EC26"] == (Level.none, Kind.notApplicable), (
+            "a rule cdk-nag could not evaluate rendered as an evaluated result; "
+            f"got {rendered['AwsSolutions-EC26']}"
+        )
+        # The rule that really did fire, from the same report, must be untouched.
+        assert rendered["AwsSolutions-S1"] == (Level.error, Kind.fail)
+
+    def test_the_unevaluated_rule_is_marked_as_its_own_compliance_state(
+        self, tmp_path: Path
+    ):
+        """ "Not-Evaluated" is a third state alongside Non-Compliant and Suppressed.
+
+        Asserted on the record rather than only on the rendered level, because the scanner reads
+        ``compliance`` back out of the property bag -- that is how the run-level notification
+        finds its rules -- and a reader of the raw report needs the same distinction the SARIF
+        carries.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _violations_from_validation_report,
+        )
+
+        per_pack, failure = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+
+        assert failure is None
+        by_rule = {f.rule_id: f for f in per_pack["AwsSolutions"]}
+
+        assert by_rule["AwsSolutions-EC26"].compliance == NOT_EVALUATED
+        assert by_rule["AwsSolutions-S1"].compliance == "Non-Compliant"
+
+    def test_the_message_says_the_rule_was_not_evaluated(self, tmp_path: Path):
+        """``kind`` is the machine-readable half; the message is the half people read.
+
+        Plenty of report surfaces render only the message, so a reader looking at one of those
+        would still see a rule that did not run described as a problem that was found. The
+        wording follows the example section 3.27.9 gives for ``notApplicable``.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _result_message_text,
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+        by_rule = {f.rule_id: f for f in per_pack["AwsSolutions"]}
+
+        unevaluated = _result_message_text(by_rule["AwsSolutions-EC26"], "tpl.yaml")
+        assert "'tpl.yaml' was NOT evaluated for rule AwsSolutions-EC26" in unevaluated
+
+        # A real finding's message is unchanged, including the historical Exception Reason line.
+        violation = _result_message_text(by_rule["AwsSolutions-S1"], "tpl.yaml")
+        assert violation == (
+            "The S3 Bucket has server access logs disabled.\n\nException Reason: N/A"
+        )
+
+    def test_an_unevaluated_rule_renders_as_notapplicable_with_no_severity(self):
+        """The mapping in isolation, so a failure points at the mapping and not the reader."""
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _level_and_kind,
+        )
+
+        level, kind = _level_and_kind(
+            compliance=NOT_EVALUATED, rule_level="Error", exception_reason="N/A"
+        )
+
+        assert kind == Kind.notApplicable
+        assert level == Level.none
+
+    def test_a_real_violation_still_renders_as_a_failure(self):
+        """The control that stops the fix from demoting every finding.
+
+        ``Error``/``Non-Compliant`` has to stay ``level=error, kind=fail``. Without this, a
+        one-line change returning ``notApplicable`` unconditionally would pass every other test
+        in this class while silencing the scanner completely.
+        """
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import _level_and_kind
+
+        level, kind = _level_and_kind(
+            compliance="Non-Compliant", rule_level="Error", exception_reason="N/A"
+        )
+
+        assert kind == Kind.fail
+        assert level == Level.error
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Rule threw an error during validation. Something specific went wrong.",
+            # verbose=False is not what ASH passes today, but _build_nag_pack is the only thing
+            # making that true and the prefix is identical either way.
+            (
+                "Rule threw an error during validation. This is generally caused by a "
+                "parameter referencing an intrinsic function."
+            ),
+        ],
+    )
+    def test_the_marker_is_recognized_in_both_of_cdk_nags_message_forms(
+        self, tmp_path: Path, description: str
+    ):
+        """cdk-nag builds the description differently under verbose and non-verbose.
+
+        Only the prefix is shared, which is why detection keys on the prefix. Pinning the whole
+        string would work today and silently stop working the moment ``verbose`` changes -- and
+        the failure mode is the defect coming back, not a red test.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _violations_from_validation_report,
+        )
+
+        report = {
+            "pluginReports": [
+                {
+                    "pluginName": "AwsSolutions",
+                    "violations": [
+                        {
+                            "ruleName": "AwsSolutions-EC26",
+                            "description": description,
+                            "severity": "error",
+                            "violatingConstructs": [{"constructPath": "s/t/R"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, report)
+        )
+
+        assert per_pack["AwsSolutions"][0].compliance == NOT_EVALUATED
+
+    def test_a_description_that_merely_mentions_an_error_is_still_a_violation(
+        self, tmp_path: Path
+    ):
+        """The prefix is anchored at the start, not searched for anywhere in the text.
+
+        A rule whose own explanation happens to contain the words "an error during validation"
+        must not be demoted. Without this, a substring search would look identical to the
+        anchored one on every fixture above while silently suppressing real findings.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        report = {
+            "pluginReports": [
+                {
+                    "pluginName": "AwsSolutions",
+                    "violations": [
+                        {
+                            "ruleName": "AwsSolutions-APIG1",
+                            "description": (
+                                "The API does not log. Without logs you cannot tell whether "
+                                "a Rule threw an error during validation."
+                            ),
+                            "severity": "error",
+                            "violatingConstructs": [{"constructPath": "s/t/R"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, report)
+        )
+
+        assert per_pack["AwsSolutions"][0].compliance == "Non-Compliant"


### PR DESCRIPTION
Three reporting defects on the cdk-nag path. None of them changes what the scanner finds; all
three change what the report says about what it found. Measured against the versions the `[cdk]`
extra installs today: **aws-cdk-lib 2.267.0, cdk-nag 3.0.2**.

Base: `origin/main` at `882b4b2a3bb9c0be3e046a5eab74eebcb16ec2bc`.

Every claim below was reproduced before it was fixed, and each fix has a test that fails on
`origin/main` and passes here. Failure text is quoted verbatim.

---

## Defect 1 — findings from a different tool were attributed to cdk-nag

**Verified.** With one important correction to the original report, in the last subsection.

### Mechanism

`validation-report.json` is CDK's *shared* policy-validation report. Every registered
`IPolicyValidationPlugin` writes into the same `pluginReports` array, and from aws-cdk-lib
2.262.0 the CDK registers one of its own unconditionally — `CloudFormationValidatePlugin`:

```js
// aws-cdk-lib 2.267.0, core/lib/validation/cloudformation-validate-plugin.js
class CloudFormationValidatePlugin {
  static PLUGIN_NAME = "CloudFormation Validate";
```

Its rules come from the bundled `@aws/cloudformation-validate` and are ids like `F3017`,
`W3010`, `W2001`, `E1151`. A live run through the wrapper against a template with a placeholder
KMS key identifier returns two packs in one report:

```
wrapper pack keys: ['AwsSolutions', 'CloudFormation Validate']
  pack 'AwsSolutions': 4 result(s)
  pack 'CloudFormation Validate': 3 result(s)
     ruleId='F3017' level=warning kind=informational
```

`level=warning` maps to MEDIUM on ASH's ladder, which is where the reported "16 MEDIUM `F3017`
findings" comes from — one violation fanning out across `violatingConstructs`.

The wrapper did key the packs apart, but the scanner discards the key:

```python
for pack, findings in nag_result_dict.results.items():
    ASH_LOGGER.debug(f"Found {len(findings)} findings for {pack} on template {cfn_file}")
    sarif_results.extend(findings)
```

`pack` is used for a debug line and nothing else. The pack name did reach
`result.properties.tags` as an unlabelled positional entry, but it never reached the **rule
descriptor** — the object a consumer reads to find out what a rule is and who owns it. Two
things were wrong there:

```python
helpUri=f"https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#{str(finding_props.get('rule_level', 'rule')).lower()}s",
tags=finding_props.get("tags", []) + [ ... ],
```

* `helpUri` was cdk-nag's RULES.md for **every** rule. Following it for `F3017` opens a page
  that does not mention `F3017` and does not describe the mechanism that governs it.
* `finding_props` is `_NagFinding.as_dict()`, which has keys
  `rule_id / resource_id / compliance / exception_reason / rule_level / rule_info` — and no
  `tags` key. So `finding_props.get("tags", [])` returned its default on every finding ever
  scanned. It looked like it forwarded the finding's tags and forwarded none.

### Fix

The pack is recorded on each `_NagFinding`, travels through `as_dict()` into the SARIF property
bag, and is written onto the rule as a labelled `pack` property plus a `pack::` tag. `helpUri`
routes on it. Ownership is *derived* from cdk-nag's own id construction — `applyRule` builds
`f"{packName}-{ruleSuffix}"` — rather than from a list of pack names that would go stale
silently and start treating a new cdk-nag pack as foreign.

A finding with **no** pack recorded keeps its previous destination. Redirecting only findings
positively known to be foreign means missing data cannot move a help link; guessing "foreign"
from an absent pack would send genuine cdk-nag rules away from their own documentation, which is
the same misattribution in reverse.

The findings are **not** filtered out. They are real CloudFormation Validate findings and stay
in the report; only their attribution changes.

### Before / after

```
FAILED tests/unit/utils/test_cdk_nag_pack_attribution.py::TestOriginatingPackIsCarriedOnTheFinding::test_each_finding_records_the_plugin_that_produced_it - AttributeError: '_NagFinding' object has no attribute 'pack'
FAILED tests/unit/utils/test_cdk_nag_pack_attribution.py::TestOriginatingPackIsCarriedOnTheFinding::test_the_pack_survives_into_the_serialized_finding_record - KeyError: 'pack'
FAILED tests/integration/scanners/test_cdk_nag_real_pack.py::TestReportAttribution::test_a_cdk_plugin_that_is_not_a_nag_pack_is_named_as_its_own_pack - KeyError: 'pack'
FAILED tests/integration/scanners/test_cdk_nag_real_pack.py::TestReportAttribution::test_the_scanner_documents_a_foreign_rule_against_the_right_guide - KeyError: 'pack'
FAILED tests/unit/plugin_modules/ash_builtin/test_cdk_nag_scanner_behavior.py::test_rule_tags_include_the_findings_own_tags - AssertionError: the finding's own tags did not reach the rule; got ['tool_n...
```

All pass after. The integration tests run the real scanner against real cdk-nag, so the
end-to-end path is covered and not just the extracted helper.

### What a user sees differently

An `F3017` finding is labelled `pack: CloudFormation Validate` and tagged
`pack::CloudFormation Validate`, and its help link points at
`https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html` — which documents
the plugin, the shared report, and `Validations.of(scope).acknowledge()`. Genuine cdk-nag rules
are unchanged and still point at RULES.md with the level-derived anchor. Rule descriptors now
carry the finding's own tags (resource id, resource type, pack) instead of only the two tool
tags.

### Correction: these findings were NOT unsuppressable

The original report said these 16 are "permanently unsuppressable" because a cdk-nag suppression
can never match them. **That part is not real, and I did not build anything on it.** Measured
directly: an in-template `Metadata.cdk_nag.rules_to_suppress` entry with `id: F3017` **does**
suppress the finding, because `_template_suppression_reason` matches the reported rule id
regardless of which plugin produced it.

```
pack='CloudFormation Validate' ruleId='F3017' level=warning suppressed=YES
    justification: (ASH cdk-nag in-template suppression) Placeholder KMS key identifier is intentional in this fixture.
```

So the real defect is the attribution, not the suppressibility. Worth knowing that the mechanism
which governs such a finding *upstream* is CDK's own — `Validations.of(scope).acknowledge({id:
'CloudFormation-Validate::F3017', reason: ...})`, stored as the `aws:cdk:acknowledged-rules`
construct metadata key — which ASH neither reads nor previously pointed the user toward. The new
`helpUri` is what points there. Reading that key is a separate feature and is not in this PR.

---

## Defect 2 — "rule could not be evaluated" was rendered as a violation

**Verified**, and worse than reported: the finding came out **CRITICAL**, not merely as a
violation.

### Mechanism

`CdkNagValidationFailure`, the 2.x concept, is **removed** in cdk-nag 3.x. In 3.0.2 the state
arrives with no structural marker at all — `applyRule` catches the exception and calls the *same*
`addViolation` a real violation goes through:

```js
// cdk-nag 3.0.2, lib/nag-pack.js
catch (error) {
    if (!this.isAcknowledged(params.node, ruleId)) {
        this.addViolation(ruleId, params, error.message);
    }
}
...
const description = errorMessage
    ? `Rule threw an error during validation. ${this.verbose ? errorMessage : 'This is generally caused by a parameter referencing an intrinsic function.'}`
```

The description prefix is the only thing separating the two. It is reached whenever a rule calls
`NagRules.resolveIfPrimitive` on a property that resolves to a non-primitive, which is what a
`Ref` to a CloudFormation Parameter resolves to:

```js
// cdk-nag 3.0.2, lib/nag-rules.js
if (resolvedValue === Object(resolvedValue)) {
    throw Error(`The parameter resolved to to a non-primitive value "...", therefore the rule could not be validated.`);
}
```

Reproduced with an EC2 SecurityGroup whose `GroupDescription` and an EBS Volume whose `Encrypted`
both come from parameters:

```
  pack 'AwsSolutions': 2 result(s)
     ruleId='AwsSolutions-EC27' level=error kind=fail
     ruleId='AwsSolutions-EC26' level=error kind=fail
  pluginName='AwsSolutions' violations=2
     ruleName='AwsSolutions-EC27' severity='error' desc='Rule threw an error during validation. The parameter resolved to to a '
```

`severity: "error"` → `_normalize_rule_level` → `"Error"` → `level=error, kind=fail`, which
`_SARIF_LEVEL_TO_SEVERITY` maps to **CRITICAL**. Two rules that never ran were two critical
security findings, and the coverage gap they represent was invisible.

### Fix — using SARIF's representation, not a new convention

SARIF 2.1.0 defines two candidate kinds and only one is a true statement. Quoting the OASIS
Standard incorporating Approved Errata 01, §3.27.9:

> `"notApplicable"` : The rule specified by ruleId was not evaluated, because it does not apply
> to the analysis target.

> `"open"` : The specified rule was evaluated, and the tool concluded that there was insufficient
> information to decide whether a problem exists.

`"open"` opens with "was evaluated", and its NOTE 1 scopes the value to proof-based tools that
completed an analysis and could not prove either direction. cdk-nag's rule raised partway
through, so "was not evaluated" is the accurate half. §3.27.9's own example for `notApplicable`
is a result whose message reads `"<target> was not evaluated for rule <id> because <reason>"` —
the shape emitted here.

`level` follows rather than being chosen. §3.27.10:

> `"none"` : The concept of "severity" does not apply to this result because the kind property
> (§3.27.9) has a value other than `"fail"`.

ASH maps `none` to INFO, so the count inflation stops as a consequence of getting the SARIF
right rather than as a separate adjustment that could drift apart from it.

The coverage gap is *also* reported at the run level, in the place SARIF defines for exactly
this. From the official schema: `invocation.toolExecutionNotifications` is "A list of runtime
conditions detected by the tool during the analysis", and `notification.associatedRule` is "A
reference used to locate the rule descriptor associated with this notification". Emitted at
`level=error` — overriding the field's `warning` default, because for a security scanner a rule
that silently did not run is more serious than a violation it did find — and deduplicated by
rule id, since one unresolvable property raises for every construct sharing its shape.

Detection anchors on the prefix rather than the full string (the remainder differs under
`verbose`), and matches at the start rather than anywhere in the text, so a rule whose own
explanation happens to mention an error is not demoted.

### Before / after

```
FAILED tests/unit/utils/test_cdk_nag_unevaluated_rule.py::...::test_end_to_end_the_unevaluated_rule_does_not_render_as_a_critical_failure - AssertionError: a rule cdk-nag could not evaluate rendered as an evaluated result; got (<Level.error: 'error'>, <Kind.fail: 'fail'>)
FAILED tests/integration/scanners/test_cdk_nag_real_pack.py::TestRuleThatCouldNotBeEvaluated::test_the_scanner_reports_an_unevaluated_rule_as_a_run_level_condition - AssertionError: the scan produced no toolExecutionNotifications, so a rule ...
```

The first is written deliberately without importing anything new, so its red state is a
behavioral difference rather than a missing symbol. Each test names the state that must be
present and, from the same report, a genuine violation that must stay `fail`/`error` — so a
change that demoted everything cannot pass.

### What a user sees differently

`AwsSolutions-EC26` on a parameter-driven property is no longer a CRITICAL finding. It appears as
`kind: notApplicable`, `level: none`, with the message `'<template>' was NOT evaluated for rule
AwsSolutions-EC26, so this result says nothing about whether the template complies with it.` The
run's invocation carries a `toolExecutionNotifications` entry at `error` level naming that rule
via `associatedRule`. A reader can now tell "this rule fired" from "this rule did not run", and
the finding count no longer includes rules that produced no verdict.

---

## Defect 3 — a converted target's ERROR rolled up to PASSED

**Verified.** It does fall through a gap between the two existing guards, as suspected.

### Mechanism

`ScanPhase` gives each scanner one task carrying both trees, and `ScanResultProcessor` writes one
serialized container per target under `additional_reports[scanner][target_type]`.
`get_scanner_status_info` derived its `error` flag from one report:

```python
elif (
    scanner_name in asharp_model.additional_reports
    and "source" in asharp_model.additional_reports[scanner_name]
    and asharp_model.additional_reports[scanner_name]["source"]["scanner_name"]
    and asharp_model.additional_reports[scanner_name]["source"]["status"]
):
    excluded, dependencies_missing, error = (
        ScannerStatisticsCalculator._status_info_from_report(
            asharp_model.additional_reports[scanner_name]["source"]
        )
    )
```

The `"converted"` entry is never read. That flag is what every rolled-up status keys on —
`get_unified_scanner_metrics` checks `stats["error"]` first, `get_scanner_status` returns
`"ERROR"` off the same tuple, and `ScannerMetrics.passed` is True for PASSED, so the row rendered
green *and* serialized as `passed: true` into `ash.flat.json`.

Both adjacent guards did their own job correctly, which is why this survived:

* `ScanResultsContainer.determine_status` returned ERROR for the converted container as designed.
  The loss is downstream of it.
* `scanner_evaluated_nothing` already reads across **every** target report and documents why —
  "only one of the two targets may have been empty". Correct quantifier, different fact. The
  asymmetry between those two functions is precisely where the defect lived.

### Fix

`error` is ORed across every target report via a new `any_target_errored`. `excluded` and
`dependencies_missing` deliberately stay on the single scanner-level report: both are facts about
configuration rather than about a target, and widening them would let one target with an
unrecognized status — which `_status_info_from_report` maps to `excluded=True` for backward
compatibility — claim the operator had switched the scanner off.

### Before / after

```
FAILED tests/unit/core/test_scanner_status_across_targets.py::...::test_status_info_reports_error_when_only_the_converted_target_errored - AssertionError: an ERROR on the converted target did not set the error flag...
FAILED tests/unit/core/test_scanner_status_across_targets.py::...::test_get_scanner_status_returns_error_for_a_converted_target_error - AssertionError: assert 'PASSED' == 'ERROR'
FAILED tests/unit/core/test_scanner_status_across_targets.py::...::test_unified_metrics_rolls_a_converted_target_error_up_to_error - AssertionError: assert 'PASSED' == 'ERROR'
```

`assert 'PASSED' == 'ERROR'` is the reported shape exactly. The mirror case (source ERROR,
converted PASSED) is asserted too, so the fix cannot be a source-for-converted swap, and three
parametrized negative controls (`PASSED`, `FAILED`, `SKIPPED` on the converted target) keep
`error = True` from being a valid implementation.

### What a user sees differently

`source PASSED, converted ERROR` now rolls up to `ERROR` with `passed: false`, in the summary
table, in `get_scanner_status`, and in `ash.flat.json`. A conversion step that failed outright is
visible instead of averaging away against a passing sibling.

---

## Checked against the live CI failure, which turns out to be something else

ASH's `scan-validation` and `install-validation` jobs are currently red with output that
looks like Defect 2 in production:

```
ERROR    cdk-nag failed to scan .../deploy/cdk/tsconfig.json: ScannerError: while scanning for the next token
ERROR    cdk-nag failed to scan .../mkdocs.yml: ConstructorError: could not determine a constructor for the tag
ERROR (2) Exiting due to 1 actionable findings found in ASH scan
```

The natural reading is that two parse failures became one actionable finding. **They did
not.** From the same job's own summary table (attempt 1, no re-run substitution):

```
┃ Scanner      ┃ S   ┃ C ┃ H ┃ M ┃ L ┃ I ┃ Time   ┃ Action ┃ Result  ┃ Thresh  ┃
│ cdk-nag      │ 437 │ 0 │ 0 │ 0 │ 0 │ 0 │ 1m 16s │ 0      │ PASSED  │ MED (g) │
│ detect-secr… │ 55  │ 1 │ 0 │ 0 │ 0 │ 0 │ 1m 0s  │ 1      │ FAILED  │ MED (g) │
```

The one actionable finding is a **detect-secrets CRITICAL**. cdk-nag is on `Action 0 /
PASSED`. Two unrelated facts printed near each other, which is why the arithmetic never
lined up.

Reproduced locally against the same two file shapes, on this branch:

```
targets_attempted = 3
targets_failed    = 2
SARIF results = 2
   by kind: {'fail': 2}
   results attributed to a target that failed to parse: []
exitCodeDescription (the error channel):
   .../mkdocs.yml: ConstructorError: could not determine a constructor for the tag ...
   .../tsconfig.json: ParserError: while parsing a flow mapping
```

A target-level parse failure produces **zero** findings and is recorded only in the error
channel. `actionable` is derived from SARIF severity counts, so it cannot receive one. The
error-to-finding conversion does not exist, so there is nothing to fix — and the fourth
commit pins that property, which nothing asserted before.

**Would this branch still print "1 actionable findings"? Yes, and correctly** — that count
is a genuine detect-secrets CRITICAL that should fail the build. Nothing here adds to or
removes from it. Two separate defects are visible in that job and neither is fixed here:

1. **Target selection hands cdk-nag files outside its domain.** `mkdocs.yml` and
   `tsconfig.json` are not CloudFormation. The `ConstructorError` / `ScannerError` are the
   YAML and JSON readers failing, upstream of anything attribution can help with.
2. **Partial coverage loss is invisible in the rolled-up status.** cdk-nag reported `PASSED`
   with `executionSuccessful: True` and `exitCode: 0` while 2 of 3 targets were never
   evaluated (in CI, also with a `cdk-nag produced no validation report at ...`).
   `determine_status` only reports ERROR once `targets_failed >= targets_attempted`, so
   *total* coverage loss is loud and *partial* coverage loss is silent. Defect 3 above is
   the adjacent case — an ERROR on one target being dropped — not this one.

Both deserve their own change. Neither is widened into this PR.

## Verification

**Full suite, as CI runs it** (`uv sync --extra cdk` then `uv run pytest`):

| | base `882b4b2a` | this branch |
|---|---|---|
| passed | 6571 | 6605 |
| failed | 1 | 1 |
| skipped | 119 | 124 |
| xfailed | 3 | 3 |

The single failure is identical on both sides and unrelated to this change:
`tests/unit/test_agent_plugin_ash_version.py::TestInstallRefsTrackPackagedVersion::test_every_install_ref_names_the_packaged_version`,
an install-reference/version-drift check. It is pre-existing on `main`.

The +5 skips are the five new integration tests, which the default invocation skips for every
integration test in the repository (`Need --run-integration option to run`). No pre-existing test
changed skip status. CI runs them explicitly, and so did I:

**Integration, as CI runs it**
(`ASH_REQUIRE_CDK_EXTRA=1 uv run pytest tests/integration/scanners/test_cdk_nag_real_pack.py --run-integration -p no:randomly --no-cov`):
**3 passed on base → 8 passed here.** The new tests were deliberately added to this existing file
rather than a new one, because that file path is what the CI step names and `.github/**` is owned
by another open PR.

Of the five, four fail on base for the behavioral reasons quoted above. The fifth
(`test_an_unparseable_target_is_an_error_not_a_finding`) passes on base too, and is labelled as
what it is: a regression test pinning a property that was already correct, added because the CI
output above made it look broken and nothing asserted it either way.

**Lint.** `ruff check --statistics` over the four modified files, run against the `origin/main`
blobs and the branch under the same ruff: **53 findings before, 53 after, zero delta on every
rule**. All 53 are pre-existing. Under ruff's documented default rule set the only findings are
two pre-existing unused imports, present identically on both sides. `ruff format --check` is
byte-identical per file before and after — the two files that were already non-clean on `main`
remain so with zero new hunks, and all five new files are clean.

**Python coverage.** 93.16% → **93.18%** (+0.02pp). Gate is 80%.

**No test was weakened, skipped, or deleted.** One test was rewritten:
`test_rule_tags_do_not_include_the_findings_own_tags` →
`test_rule_tags_include_the_findings_own_tags`. It was a characterization test whose own docstring
described the always-empty `finding_props.get("tags", [])` as a production defect ("So
`finding_props.get("tags", [])` is always empty in production and the resource/pack/type tags
never reach the rule"). The replacement is strictly stronger: it names every tag that must be
present instead of asserting `len(tags) == 2`. The `nag_result()` helper in the same file gained a
`pack` key so it keeps matching the shape the wrapper emits — that file already asserts the
fixture must do so.
