### PR TITLE
fix(config): cover the second file holding the hex git-ref fixture

### DIFF
--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -2085,6 +2085,29 @@ global_settings:
         of the literals they describe. Deliberately not citing a line number: this
         file argues against that a few entries above, and the number had already
         gone stale by the next commit.
+    - rule_id: SECRET-HEX-HIGH-ENTROPY-STRING
+      path: deploy/cdk-constructs/test/ash-scan-step.test.ts
+      reason: >-
+        The same 40-character git-ref placeholder as the entry above, reached by a
+        second file. Here it is the `commit` const in the jest test "PIP pins the
+        given git ref", which passes it to ASHScanStep as `version` and asserts
+        the synthesized buildspec carries it into the pip install URL. It stands
+        in for a commit rather than naming one -- the digits 0-9 followed by a-f,
+        repeated to length -- so it identifies nothing, grants nothing, and there
+        is nothing to revoke.
+        HexHighEntropyString fires on entropy alone here, with no keyword or
+        pattern component to corroborate it: the string spends all sixteen hex
+        digits across 40 characters, putting its Shannon entropy at 3.97 against
+        the plugin's limit of 3.0. Measured, not inferred -- any 40-character hex
+        string clears that limit, which is why a git SHA and a key are
+        indistinguishable to this detector.
+        A second entry rather than a widened first one because the two files sit
+        in different packages, deploy/cdk and deploy/cdk-constructs, and neither
+        path pattern reaches the other. One path per file and no
+        `deploy/cdk-constructs/**` glob, so a hex string added elsewhere in that
+        package still fails loudly instead of inheriting this argument.
+        Value DESCRIBED rather than quoted, and no line number cited, for the two
+        reasons the entry above records from having got both of those wrong.
     # === semgrep/opengrep Python compatibility (ASH requires 3.10+) ===
     - rule_id: "python.lang.compatibility.*"
       path: "automated_security_helper/**/*.py"


### PR DESCRIPTION
## What

Adds one `global_settings.suppressions` entry to `.ash/.ash.yaml` for
`SECRET-HEX-HIGH-ENTROPY-STRING` on `deploy/cdk-constructs/test/ash-scan-step.test.ts`.

## Why

`.ash/.ash.yaml` already carries this exact suppression for
`deploy/cdk/test/ash-image-build.test.ts`, where a 40-character placeholder stands in for
a git SHA so a test can assert how an image tag is derived. That entry is keyed by path,
and the same placeholder is now reached by a second file:
`deploy/cdk-constructs/test/ash-scan-step.test.ts` uses it as the `commit` const in the
jest test "PIP pins the given git ref", which asserts the synthesized buildspec carries
`version` into the pip install URL.

The second path is not covered by the first entry, so the finding stays actionable and
both `scan-validation` and `install-validation` exit 2 on `1 actionable findings`.

`main` is green only because the second occurrence does not exist there yet. It arrives
with #553, which makes that test pin a commit rather than a release tag. Without this
entry #553 cannot go green, and `main` turns red the moment it lands — so this wants to
merge first.

## Not a credential

The value is the digits 0-9 followed by a-f repeated to length. It names no commit and
grants nothing, so there is nothing to revoke.

`HexHighEntropyString` flags it on entropy alone, with no keyword or pattern component to
corroborate it: 40 characters spending all sixteen hex digits measure 3.97 against the
plugin's limit of 3.0. Any 40-character hex string clears that limit, which is why this
detector cannot tell a git SHA from a key.

Per the convention the neighboring entry records, the reason describes the value rather
than quoting it — a reason that pastes a hex literal becomes a hex-string finding on its
own line — and cites no line number.

## Why a second entry rather than widening the first

The two files sit in different packages, `deploy/cdk` and `deploy/cdk-constructs`, so
neither path pattern reaches the other. A `deploy/cdk-constructs/**` glob would also let a
later hex string anywhere in that package inherit an argument nobody made about it. One
path per file keeps that failing loudly, which is the convention the rest of the file uses
for entries justified by inspection.

## Verification

`ash scan --scanners detect-secrets`, three trees:

| tree | suppressed | critical | actionable | exit |
| --- | --- | --- | --- | --- |
| #553 head, without this entry | 55 | 1 | 1 | 2, FAILED |
| #553 head, with this entry | 56 | 0 | 0 | 0, PASSED |
| this branch (main + this entry) | 55 | 0 | 0 | 0, PASSED |

The first row reproduces CI's own table byte for byte, so the local harness can see the
failure before it is asked to see the fix.

Comparing the two SARIF reports as sets rather than as counts: the finding sets are
identical, no finding appears or disappears, and exactly one changes state — the one this
entry names. The other 55 are untouched. On this branch the entry is simply unused, which
the unused-suppressions reporter records and no gate reads; 22 such entries already exist.

`ash config lint` is clean on both trees, and `pre-commit run --files .ash/.ash.yaml`
passes with no tracked file modified.

## Scope

One file, 23 added lines, data only. No detector disabled, no severity threshold changed,
no test touched.
