### PR TITLE
feat(reporting): surface how much of its input each scanner evaluated

### DIFF
--- a/automated_security_helper/core/metrics_table.py
+++ b/automated_security_helper/core/metrics_table.py
@@ -8,6 +8,7 @@ from rich.panel import Panel
 
 from automated_security_helper.models.asharp_model import AshAggregatedResults
 from automated_security_helper.core.unified_metrics import (
+    coverage_shortfalls,
     get_unified_scanner_metrics,
     format_duration,
 )
@@ -156,6 +157,41 @@ def generate_metrics_table_from_unified_data(
     return table
 
 
+def print_coverage_shortfalls(
+    asharp_model: AshAggregatedResults, console: Console
+) -> None:
+    """Name every scanner that could not evaluate part of its input, with the counts.
+
+    Printed BESIDE the table rather than added to it. A twelfth column would change the table's
+    geometry for every scan including the ones with nothing to report, and the responsive
+    narrow-terminal layout already carries eleven; the shortfall is also exceptional rather than
+    per-row data. Emitting nothing when there is nothing to say is what keeps this from becoming
+    noise -- see the negative control in
+    ``tests/unit/core/test_partial_target_coverage_visibility.py``.
+
+    Why it exists at all: ``determine_status`` only returns ERROR once every attempted target
+    failed, so a scanner that lost some of its input reports whatever the severity gate gives it.
+    Measured on this repository, cdk-nag attempts 10 targets, fails 4, and reports PASSED -- and
+    two of those four were real CloudFormation templates rather than files that were never
+    templates. Nothing in the rendered output said so.
+
+    The status and the exit code are deliberately not touched. At the measured rate, failing on
+    any unevaluated target would turn a routine condition into a permanent red; whether it should
+    fail is a policy question about pipelines and not one this rendering decides.
+    """
+    shortfalls = coverage_shortfalls(asharp_model)
+    if not shortfalls:
+        return
+    for scanner_name, attempted, failed in shortfalls:
+        evaluated = attempted - failed
+        console.print(
+            f"[bold yellow]Incomplete coverage:[/bold yellow] {scanner_name} evaluated "
+            f"{evaluated} of {attempted} target(s); {failed} could not be evaluated and "
+            f"contributed no findings. See the scanner's exitCodeDescription in its SARIF "
+            f"report for the reason per target."
+        )
+
+
 def display_metrics_table(
     asharp_model: AshAggregatedResults,
     source_dir: str | Path | None = None,
@@ -248,6 +284,10 @@ def display_metrics_table(
             console.print()
             console.print(table)
             console.print()
+            # After the table, so the counts sit next to the status they qualify. Inside the same
+            # guarded block because it writes to the same console: a closed stdout has to be
+            # handled identically for both, and a shortfall notice is not worth failing a scan.
+            print_coverage_shortfalls(asharp_model, console)
         except (ValueError, OSError, BrokenPipeError) as io_error:
             # stdout/stderr may be closed (e.g., in MCP server context)
             # Log the error but don't fail the scan

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -74,6 +74,26 @@ class ScannerMetrics(ScannerSeverityCount):
     excluded: bool = False  # Whether the scanner was explicitly excluded
     dependencies_missing: bool = False  # Whether the scanner has missing dependencies
 
+    # How much of its input the scanner actually evaluated, summed over every target it reported
+    # under. Present here because this class is the only model the summary table and every
+    # reporter read: the counters existed on ``ScanResultsContainer`` and in the serialized
+    # per-target reports, and had no route to any human-facing output at all.
+    #
+    # That mattered because ``determine_status`` only returns ERROR once
+    # ``targets_failed >= targets_attempted``. A scanner that failed on some of its targets keeps
+    # whatever status the severity gate gives it, so partial coverage loss renders exactly like a
+    # clean scan. Measured against cdk-nag on this repository: 10 targets attempted, 4 failed,
+    # reported PASSED -- and two of those four were CloudFormation templates that genuinely went
+    # unscanned rather than files that were never templates.
+    #
+    # ``targets_attempted`` keeps the container's tri-state meaning rather than defaulting to 0.
+    # None means the scanner does not track per-target outcomes and is making no claim; bandit,
+    # checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag and npm-audit are all in
+    # that state. Reading them as "attempted zero" would report every one of them as having
+    # evaluated nothing.
+    targets_attempted: int | None = None
+    targets_failed: int = 0
+
     @computed_field
     @property
     def passed(self) -> bool:
@@ -107,6 +127,69 @@ class ScannerMetrics(ScannerSeverityCount):
         field mean the stricter thing is a report-schema change, not a bug fix.
         """
         return self.status in ("PASSED", "SKIPPED", "MISSING")
+
+
+def target_counts(
+    asharp_model: AshAggregatedResults, scanner_name: str
+) -> tuple[int | None, int]:
+    """``(targets_attempted, targets_failed)`` summed over every target the scanner reported.
+
+    Summed rather than read off ``"source"``, because ``ScanPhase`` gives each scanner one task
+    carrying both the source tree and the converted tree and either of them can lose coverage.
+    Reading one report would under-report by whatever the other did, which is the same
+    single-target mistake that made a converted-target failure invisible in the first place.
+
+    Returns None for the attempt count when NO target report carries one. That is the
+    scanner-does-not-track state, and it must not collapse to 0: ``0`` is a claim -- "I tracked
+    targets and attempted none" -- while absence is the absence of a claim. ``targets_failed``
+    stays a plain int because it has no independent meaning; a failure count with no attempt count
+    is a producer bug rather than a third state.
+
+    ``bool`` is rejected explicitly even though it is an ``int`` subclass. A True/False counter is
+    a producer bug, and reading it as 1/0 would silently invent a target.
+    """
+    reports = asharp_model.additional_reports.get(scanner_name)
+    if not isinstance(reports, dict):
+        return None, 0
+
+    attempted: int | None = None
+    failed = 0
+    for target_report in reports.values():
+        if not isinstance(target_report, dict):
+            continue
+        raw_attempted = target_report.get("targets_attempted")
+        if isinstance(raw_attempted, int) and not isinstance(raw_attempted, bool):
+            attempted = (attempted or 0) + raw_attempted
+        raw_failed = target_report.get("targets_failed")
+        if isinstance(raw_failed, int) and not isinstance(raw_failed, bool):
+            failed += raw_failed
+    return attempted, failed
+
+
+def coverage_shortfalls(
+    asharp_model: AshAggregatedResults,
+) -> list[tuple[str, int, int]]:
+    """``(scanner, attempted, failed)`` for every scanner that could not evaluate some input.
+
+    The structured form on purpose. The renderer formats these, and a test that asserted the
+    rendered sentence would keep passing through a change that got the numbers wrong -- so the
+    numbers are pinned here, where they are data, and the renderer is only checked for whether it
+    emits at all.
+
+    Includes the total-loss case as well as the partial one. Total loss already reaches the status
+    column as ERROR, but the count of what went unevaluated is exactly as absent from the table
+    there as it is when only some targets failed.
+
+    A scanner making no claim is never a shortfall: absent counters mean the scanner does not
+    track targets, not that it lost all of them.
+    """
+    shortfalls: list[tuple[str, int, int]] = []
+    for scanner_name in sorted(asharp_model.additional_reports or {}):
+        attempted, failed = target_counts(asharp_model, scanner_name)
+        if attempted is None or failed <= 0:
+            continue
+        shortfalls.append((scanner_name, attempted, failed))
+    return shortfalls
 
 
 def format_duration(duration_seconds: Optional[float]) -> str:
@@ -236,6 +319,14 @@ def get_unified_scanner_metrics(
                 scan_result.status if scan_result and scan_result.status else "PASSED"
             )
 
+        # Read straight off the serialized per-target reports rather than through
+        # ``extract_scanner_statistics``. These two are the only values here that describe how
+        # much input was consumed rather than what was found in it, and they are the reason the
+        # summary table could not previously say a scan was partial -- see ScannerMetrics.
+        scanner_targets_attempted, scanner_targets_failed = target_counts(
+            asharp_model, scanner_name
+        )
+
         # Create metrics entry. total and passed are computed, so we do not pass
         # them in explicitly — they're derived from severity fields and status.
         metrics = ScannerMetrics(
@@ -253,6 +344,8 @@ def get_unified_scanner_metrics(
             threshold_source=stats["threshold_source"],
             excluded=stats["excluded"],
             dependencies_missing=stats["dependencies_missing"],
+            targets_attempted=scanner_targets_attempted,
+            targets_failed=scanner_targets_failed,
         )
 
         metrics_list.append(metrics)

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -18,6 +18,7 @@ from automated_security_helper.plugin_modules.ash_builtin.reporters.report_conte
 from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
     markdown_workspace_section,
 )
+from automated_security_helper.core.unified_metrics import coverage_shortfalls
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
 
@@ -225,6 +226,37 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
                 )
 
             md_parts.append("")
+
+            # Scanners that could not evaluate part of their input, listed after the table rather
+            # than as an extra column. The table has a fixed ten-column shape that several tests
+            # and any downstream consumer parse positionally, and a shortfall is exceptional
+            # rather than per-row data.
+            #
+            # This is the artifact a human is most likely to read -- it gets pasted into pull
+            # requests -- and the status column cannot carry the fact: ``determine_status`` only
+            # reports ERROR once every attempted target failed, so a scanner that lost some of its
+            # targets appears here as PASSED. Measured on this repository, cdk-nag attempts 10
+            # targets, fails 4, and reports PASSED.
+            #
+            # Emitted only when there is something to report, and NOT suppressed in compact mode.
+            # Compact mode exists to drop noise -- clean rows and skipped scanners -- and an
+            # incomplete-coverage notice is the opposite of noise. Hiding it there would remove it
+            # from precisely the rendering that gets pasted into a pull request.
+            shortfalls = coverage_shortfalls(model)
+            if shortfalls:
+                md_parts.append("### Incomplete coverage")
+                md_parts.append("")
+                md_parts.append(
+                    "These scanners could not evaluate part of their input. The findings they "
+                    "did report are real, but the set is known to be partial:"
+                )
+                md_parts.append("")
+                for scanner_name, attempted, failed in shortfalls:
+                    md_parts.append(
+                        f"- **{scanner_name}**: evaluated {attempted - failed} of {attempted} "
+                        f"target(s); {failed} could not be evaluated"
+                    )
+                md_parts.append("")
 
             # Add top hotspots (files with most findings)
             top_hotspots = emitter.get_top_hotspots(

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
@@ -119,6 +119,18 @@ class ReportContentEmitter:
                     "status": metrics.status,
                     "excluded": metrics.excluded,
                     "dependencies_missing": metrics.dependencies_missing,
+                    # How much of its input the scanner actually evaluated. Every other key here
+                    # describes what was found; these two describe how much was looked at, and
+                    # without them a report cannot distinguish a clean scan from one that
+                    # examined a fraction of its targets. ``determine_status`` only reports ERROR
+                    # once every attempted target failed, so a partial loss reaches ``status`` as
+                    # PASSED and reached these rows as nothing at all.
+                    #
+                    # ``targets_attempted`` is None for a scanner that does not track per-target
+                    # outcomes, and is serialized as null rather than 0 so a consumer can tell
+                    # "made no claim" from "attempted none".
+                    "targets_attempted": metrics.targets_attempted,
+                    "targets_failed": metrics.targets_failed,
                 }
             )
 

--- a/tests/unit/core/test_partial_target_coverage_visibility.py
+++ b/tests/unit/core/test_partial_target_coverage_visibility.py
@@ -1,0 +1,354 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How much of a scanner's input it actually evaluated has to reach the output.
+
+WHAT WAS MEASURED
+-----------------
+A scanner reports per-target counters -- ``targets_attempted`` and ``targets_failed`` -- and
+``ScanResultsContainer.determine_status`` only returns ERROR once ``targets_failed >=
+targets_attempted``. So total coverage loss is loud and partial coverage loss is silent. Measured
+end to end with the real cdk-nag scanner over four trees of three targets each, with the findings
+gate off so the exit code reflects coverage alone:
+
+    failing   determine_status   executionSuccessful   exit   summary status
+    0/3       PASSED             True                  0      PASSED
+    1/3       PASSED             True                  0      PASSED
+    2/3       PASSED             True                  0      PASSED
+    3/3       ERROR              False                 0      ERROR
+
+The cliff is exactly at "all failed", and 1/3 and 2/3 are indistinguishable from 0/3 in every
+status channel. ``scanner_evaluated_nothing`` does not cover this: it keys on
+``targets_attempted <= 0``, and here three targets were attempted every time.
+
+On ASH's own repository cdk-nag attempts 10 targets and fails 4 -- a 40% loss reported as a clean
+scan. Two of those four are genuine CloudFormation templates that went unscanned; the other two
+are a ``mkdocs.yml`` and a ``tsconfig.json`` that were never templates. The signal is hidden among
+the noise, which is the reason the counts have to be legible rather than merely present.
+
+WHY THIS FIXES VISIBILITY AND NOT THE VERDICT
+---------------------------------------------
+``ScannerMetrics`` is the single model the summary table and every reporter read, and it had no
+field for either counter. So the counters existed in ``ash_aggregated_results.json`` and in the
+scanner's own SARIF and could not reach the table, ``ash.flat.json``, or any human-facing report
+even in principle. That is the half of the defect that is purely additive to fix.
+
+Whether a partially-covered scan should FAIL is a separate question with a real blast radius --
+at a 40% rate on this repository, "ERROR on any failed target" would turn a routine condition
+into a permanent red -- so the status and the exit code are deliberately unchanged here. The
+tests below assert that they are unchanged, so that a later change to them is a visible decision
+rather than a side effect.
+
+ASSERTIONS ARE ON COUNTS AND CHANNELS, NEVER ON WORDING
+-------------------------------------------------------
+A test that checked the output mentions unevaluated targets would pass on a cosmetic change while
+the numbers stayed wrong. So the counts are asserted through ``coverage_shortfalls``, which
+returns structured tuples, and the rendering is asserted only for presence-versus-absence -- the
+channel. Each status assertion names the status it requires rather than "not PASSED", which any
+wrong status would also satisfy, and every case has a matching negative control.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _model(reports: dict):
+    """An AshAggregatedResults stand-in carrying the serialized per-target reports.
+
+    ``ScanResultProcessor`` dumps each container with ``exclude_unset=True``, so a scanner that
+    does not track targets has no counter keys at all rather than zeroes. That distinction is the
+    subject of one of the tests below, so the fixture has to be able to express it.
+
+    ``sarif.runs`` is empty, which keeps every severity count at zero. Without that the findings
+    gate would decide the status and the coverage assertions would be measuring the wrong thing.
+    """
+    model = MagicMock()
+    model.sarif = MagicMock()
+    model.sarif.runs = []
+    model.scanner_results = {}
+    model.ash_config = MagicMock()
+    model.ash_config.global_settings.severity_threshold = "MEDIUM"
+    model.ash_config.get_plugin_config.return_value = None
+    model.additional_reports = reports
+    return model
+
+
+def _report(status: str, attempted=None, failed=None, name="cdk-nag") -> dict:
+    report = {"scanner_name": name, "status": status, "duration": 1.0}
+    if attempted is not None:
+        report["targets_attempted"] = attempted
+    if failed is not None:
+        report["targets_failed"] = failed
+    return report
+
+
+PARTIAL = {
+    "cdk-nag": {
+        # Two of three source targets could not be evaluated; the converted tree was clean.
+        "source": _report("PASSED", attempted=3, failed=2),
+        "converted": _report("PASSED", attempted=1, failed=0),
+    }
+}
+
+
+class TestTargetCountsReachTheMetrics:
+    def test_counts_are_summed_across_every_target_report(self):
+        """Both targets contribute, because a scanner gets two and either can lose coverage.
+
+        Exact totals are asserted rather than "greater than zero": summing only the source report
+        would give (3, 2) and reading only the converted one (1, 0), and both would satisfy a
+        loose assertion while dropping half the input.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        metrics = {
+            m.scanner_name: m for m in get_unified_scanner_metrics(_model(PARTIAL))
+        }
+
+        assert metrics["cdk-nag"].targets_attempted == 4
+        assert metrics["cdk-nag"].targets_failed == 2
+
+    def test_a_scanner_that_does_not_track_targets_makes_no_claim(self):
+        """None, not zero. The distinction is load-bearing.
+
+        ``targets_attempted`` is tri-state in the container for a documented reason: absent means
+        "this scanner does not track targets", and 0 means "it tracked and attempted none". bandit,
+        checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag and npm-audit are all in
+        the first state. Collapsing them to 0 would report every one of them as having evaluated
+        nothing.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["bandit"].targets_attempted is None
+        assert metrics["bandit"].targets_failed == 0
+
+    def test_the_counts_are_serialized_with_the_rest_of_the_metrics(self):
+        """``ash.flat.json`` is a verbatim dump of these rows, so presence here is user-visible.
+
+        Asserted on the dump rather than on the attributes, because a field excluded from
+        serialization would satisfy the attribute assertions above and still never reach a file.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        dumped = get_unified_scanner_metrics(_model(PARTIAL))[0].model_dump()
+
+        assert dumped["targets_attempted"] == 4
+        assert dumped["targets_failed"] == 2
+
+
+class TestTheCountsReachTheMachineReadableReports:
+    """``ReportContentEmitter.get_scanner_results()`` is a hand-built dict, not a model dump.
+
+    Worth its own test because assuming otherwise was wrong. Adding the fields to
+    ``ScannerMetrics`` made them serializable but did NOT put them in ``ash.flat.json``: that
+    reporter goes through this emitter, which enumerates its keys explicitly, so a new field on
+    the model reaches the file only if it is listed here too. Measured before the fix --
+    ``targets_attempted`` was absent from a real ``ash.flat.json`` even with the model field
+    populated.
+    """
+
+    def test_the_emitted_scanner_row_carries_both_counts(self):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
+            ReportContentEmitter,
+        )
+
+        emitter = ReportContentEmitter(_model(PARTIAL))
+        rows = {r["scanner_name"]: r for r in emitter.get_scanner_results()}
+
+        assert rows["cdk-nag"]["targets_attempted"] == 4
+        assert rows["cdk-nag"]["targets_failed"] == 2
+
+    def test_a_non_tracking_scanner_emits_null_rather_than_zero(self):
+        """null and 0 are different claims, and a consumer has to be able to tell them apart."""
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
+            ReportContentEmitter,
+        )
+
+        emitter = ReportContentEmitter(
+            _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        )
+        rows = {r["scanner_name"]: r for r in emitter.get_scanner_results()}
+
+        assert rows["bandit"]["targets_attempted"] is None
+        assert rows["bandit"]["targets_failed"] == 0
+
+
+class TestCoverageShortfallsAreEnumerated:
+    def test_a_scanner_that_lost_targets_is_reported_with_its_counts(self):
+        """The structured channel the renderer formats, asserted as data rather than as prose."""
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        assert coverage_shortfalls(_model(PARTIAL)) == [("cdk-nag", 4, 2)]
+
+    def test_a_scanner_that_lost_nothing_is_absent(self):
+        """The negative control that stops the fix from warning about every scan."""
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+        assert coverage_shortfalls(_model(clean)) == []
+
+    def test_a_non_tracking_scanner_is_absent(self):
+        """No claim is not a shortfall.
+
+        Without this, a fix reading the absent counters as zeroes would list every non-tracking
+        scanner as having lost coverage.
+        """
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        model = _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        assert coverage_shortfalls(model) == []
+
+    def test_a_total_loss_is_reported_too(self):
+        """The all-failed case is a shortfall as well, not only the partial one.
+
+        Its status already says ERROR, but the count of what went unevaluated is exactly as
+        absent from the table there as it is in the partial case.
+        """
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        total = {"cdk-nag": {"source": _report("ERROR", attempted=3, failed=3)}}
+        assert coverage_shortfalls(_model(total)) == [("cdk-nag", 3, 3)]
+
+
+class TestTheVerdictIsDeliberatelyUnchanged:
+    @pytest.mark.parametrize("failed", [1, 2])
+    def test_partial_coverage_loss_still_reports_passed(self, failed: int):
+        """Named as PASSED, not as "not ERROR".
+
+        This change makes the loss legible and does not turn it into a failure, because at the
+        measured 40% rate on this repository that would make a routine condition a permanent red.
+        Asserting the exact status means a later decision to fail on partial coverage has to
+        change this test, which is where such a decision should be visible.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model(
+            {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=failed)}}
+        )
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["cdk-nag"].status == "PASSED"
+        assert metrics["cdk-nag"].passed is True
+
+    def test_total_coverage_loss_still_reports_error(self):
+        """The existing cliff is preserved, so the fix cannot flatten it either."""
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model({"cdk-nag": {"source": _report("ERROR", attempted=3, failed=3)}})
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["cdk-nag"].status == "ERROR"
+        assert metrics["cdk-nag"].passed is False
+
+
+class TestTheShortfallReachesTheMarkdownSummary:
+    """``ash.summary.md`` is the artifact a human pastes into a pull request.
+
+    Presence, absence, and the counts -- but not the sentence around them. The scanner table in
+    that report keeps its fixed ten-column shape, which is asserted elsewhere and parsed
+    positionally, so the shortfall is appended after it rather than added to it.
+    """
+
+    def _render(self, reports: dict, test_plugin_context, compact: bool = False) -> str:
+        """Constructed with ``context=`` because the reporter is a pydantic model whose
+        ``AshAggregatedResults`` annotation is a TYPE_CHECKING forward reference; without a
+        context it is not fully defined and instantiation raises. Every existing reporter test
+        uses the same form.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+        )
+
+        reporter = MarkdownReporter(context=test_plugin_context)
+        reporter.report(_model(reports))  # resolves self.config from defaults
+        reporter.config.options.compact = compact
+        return reporter.report(_model(reports))
+
+    def test_a_shortfall_is_listed_with_its_counts(self, test_plugin_context):
+        out = self._render(PARTIAL, test_plugin_context)
+
+        assert "cdk-nag" in out
+        # 2 of 4 evaluated, 2 failed -- the arithmetic, not the phrasing.
+        assert "2 of 4" in out
+        assert "2 could not be evaluated" in out
+
+    def test_nothing_is_listed_when_no_coverage_was_lost(self, test_plugin_context):
+        """The negative control. Without it, a section emitted unconditionally would pass above."""
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+
+        assert "Incomplete coverage" not in self._render(clean, test_plugin_context)
+
+    def test_compact_mode_still_reports_it(self, test_plugin_context):
+        """Compact mode drops noise; a coverage gap is signal.
+
+        Asserted because compact is the rendering most likely to be pasted into a pull request,
+        so suppressing the notice there would remove it from the place it matters most.
+        """
+        out = self._render(PARTIAL, test_plugin_context, compact=True)
+
+        assert "2 of 4" in out
+
+    def test_the_scanner_table_keeps_its_column_count(self, test_plugin_context):
+        """The shortfall must not have been implemented as an extra column after all.
+
+        Counts the pipes in the header row. A test asserting only that the shortfall appears
+        would pass either way, and a twelfth column would silently break every positional
+        consumer of this table.
+        """
+        out = self._render(PARTIAL, test_plugin_context)
+        header = [line for line in out.splitlines() if line.startswith("| Scanner")]
+        assert header, f"no scanner table header found in:\n{out[:600]}"
+        assert header[0].count("|") == 11, (
+            f"the ten-column scanner table changed shape: {header[0]}"
+        )
+
+
+class TestTheShortfallReachesTheConsole:
+    """Presence versus absence only -- the channel, not the wording.
+
+    The counts are already pinned by ``TestCoverageShortfallsAreEnumerated`` against structured
+    output. Asserting the rendered sentence here as well would be asserting prose, which is what
+    passes on a cosmetic change while a miscount survives.
+    """
+
+    def _render(self, model) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+
+        from automated_security_helper.core.metrics_table import (
+            print_coverage_shortfalls,
+        )
+
+        buffer = StringIO()
+        print_coverage_shortfalls(
+            model, Console(file=buffer, width=200, color_system=None)
+        )
+        return buffer.getvalue()
+
+    def test_a_shortfall_is_printed_and_names_the_scanner_and_both_counts(self):
+        out = self._render(_model(PARTIAL))
+
+        assert out.strip(), "a scanner lost coverage and the console said nothing"
+        assert "cdk-nag" in out
+        # The numbers, so a renderer that printed a bare warning without them fails here.
+        assert "4" in out and "2" in out
+
+    def test_nothing_is_printed_when_no_coverage_was_lost(self):
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+
+        assert self._render(_model(clean)) == ""


### PR DESCRIPTION
A scanner that evaluated one file in three reports a clean scan, and nothing in the output says
two thirds went unchecked. This makes the coverage legible. It deliberately does **not** change
any status or exit code — that part is a policy decision and is handed back below.

Base: `origin/main` at `882b4b2a3bb9c0be3e046a5eab74eebcb16ec2bc`.

## The behavior, measured across the range

Real `ash scan` runs, cdk-nag isolated with `--exclude-scanners`, four source trees of exactly
three targets each so only `targets_failed` varies. `--no-fail-on-findings` so the exit code
reflects coverage rather than the findings that happen to come back from the targets that worked.

| targets failing | `determine_status` | `targets_failed` | SARIF `executionSuccessful` | exit (default) | exit (`--fail-on-incomplete-scanners`) | summary status | actionable | `incomplete_scanners()` |
|---|---|---|---|---|---|---|---|---|
| 0/3 | PASSED | 0 | True | 0 | 0 | PASSED | 6 | none |
| 1/3 | PASSED | 1 | True | 0 | 0 | PASSED | 4 | none |
| 2/3 | PASSED | 2 | True | 0 | 0 | PASSED | 2 | none |
| 3/3 | ERROR | 3 | False | 0 | **1** | ERROR | 0 | `cdk-nag=ERROR` |

The cliff is exactly at "all failed". 1/3 and 2/3 are indistinguishable from 0/3 in every status
channel.

Three things worth naming that the table shows:

1. **`scanner_evaluated_nothing` does not partly handle this.** It keys on
   `targets_attempted <= 0`; three targets were attempted in every row.
2. **The existing opt-in completeness gate is blind to it too.**
   `_INCOMPLETE_SCANNER_STATUSES` is `{ERROR, MISSING}` and `incomplete_scanners()` selects on
   status, so `--fail-on-incomplete-scanners` sees only the 3/3 row. The mechanism built for
   "tell me when scanners did not run" does not cover "a scanner ran on a third of its input".
3. **With the default gate off, even 3/3 exits 0.** The status, the summary table and the SARIF
   all correctly say ERROR / `executionSuccessful: False`, and the process still exits 0 because
   `fail_on_incomplete_scanners` defaults off and there are no findings to trip the other gate.
   That is documented default behavior rather than a new defect, but it means total coverage loss
   is loud in the report and silent in the exit code.

One measurement was confounded and is reported as such: running the same matrix with `--scanners
cdk-nag` instead of `--exclude-scanners` made **all four** rows exit 1, because an allowlist does
not mark the unselected scanners as excluded and their absent tools report MISSING on their own.
That is a documented limitation of `incomplete_scanners()`, not data about coverage, so the table
above uses `--exclude-scanners` as that docstring directs.

## Blast radius, measured on this repository

cdk-nag over ASH's own tree: **10 targets attempted, 4 failed — 40%** — reported `PASSED`, with
163 findings from the 6 that succeeded.

The 4 are not one kind of thing, and that is the crux:

- `deploy/cdk/tsconfig.json` — JSON with comments and backticks; never a template
- `mkdocs.yml` — `!!python/name:pymdownx.emoji.twemoji`; never a template
- `tests/.../test-yaml.template.json` — a real template, `cdk-nag produced no validation report`
- `tests/.../cfn-and-python-test-yaml.template.json` — same

So two of the four are routine noise and two are **CloudFormation templates that genuinely went
unscanned**. The signal is hidden among the noise. A file that parses and simply is not
CloudFormation is *not* counted as a failure — the wrapper returns None and the scanner decrements
`targets_attempted` back — so this population is specifically "could not be parsed" plus "no
report produced", which is exactly the set a reader needs to see.

## Were the counts visible anywhere?

Present in `ash_aggregated_results.json` and `scanners/<name>/<target>/ASH.ScanResults.json` as
raw counters; the failed filenames reach `ash.log` and both SARIF files' `exitCodeDescription`.

Absent from **`ScannerMetrics`** — the single model the summary table and every reporter read. Its
fields were suppressed / critical / high / medium / low / info / scanner_name / actionable /
duration / status / threshold / threshold_source / excluded / dependencies_missing / passed. No
target counters, so the summary table, `ash.flat.json` and the markdown, HTML and text reporters
could not show them even in principle. That is the half of the defect that is purely additive.

Adding the model field was **not** sufficient, and assuming it would be was wrong.
`ReportContentEmitter.get_scanner_results()` builds its dict by enumerating keys explicitly, and
flatjson, markdown, HTML and text all go through it. Measured after adding the field and before
touching the emitter: `targets_attempted` still absent from a real `ash.flat.json`. There is a
test for that specifically, because the mistake was mine.

## What this PR changes

- `ScannerMetrics.targets_attempted` / `.targets_failed`, summed across **every** target report
  rather than read off `"source"` — a scanner gets two targets and either can lose coverage.
  `targets_attempted` keeps the container's tri-state meaning: `None` means the scanner does not
  track targets (bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag,
  npm-audit) and must not collapse to `0`, which is the different claim "tracked and attempted
  none".
- `coverage_shortfalls()` — `(scanner, attempted, failed)` for scanners that lost input, so the
  counts are assertable as data rather than as prose.
- Both counters in `get_scanner_results()`, so they reach `ash.flat.json` and every reporter built
  on it. `null` rather than `0` for a non-tracking scanner.
- A console line after the summary table, and a section after the markdown summary's scanner
  table, naming each scanner and its counts. Emitted only when something was lost.

Verified end to end on a 2-of-3 tree:

```
Incomplete coverage: cdk-nag evaluated 1 of 3 target(s); 2 could not be evaluated ...

### Incomplete coverage
- **cdk-nag**: evaluated 1 of 3 target(s); 2 could not be evaluated
```

Beside the table rather than a twelfth column: `len(table.columns) == 11` is asserted, the
narrow-terminal layout already carries eleven, consumers parse it positionally, and a shortfall is
exceptional rather than per-row. The markdown section is **not** suppressed in compact mode —
compact drops noise, and this is signal in the rendering most likely to be pasted into a PR.

## The design fork, handed back

`ERROR on any failed target` is **clearly wrong** and I am not proposing it. At the measured 40%
rate it turns a routine condition into a permanent red for any repository containing a `mkdocs.yml`
with a pymdownx tag or a `tsconfig.json` with comments, and it conflates the two routine parse
failures with the two genuinely-unscanned templates. That one does not need a decision.

The remaining options all turn on how you want pipelines to behave, so none is implemented:

| option | effect | blast radius |
|---|---|---|
| **E. Teach `incomplete_scanners()` about partial coverage** | The existing `--fail-on-incomplete-scanners` opt-in starts covering 1/3 and 2/3, not just 3/3 | Default unchanged. Anyone already using that flag flips from green to exit 1 — including ASH's own repo at 40%. Smallest new surface: no enum change, no new config, reuses the switch that already means "tell me when scanners did not run" |
| **B. A distinct status (e.g. `PARTIAL`)** | Visible in the status column itself, and gateable | New `ScannerStatus` member touches every status consumer — reporters, junitxml, ocsf, the table, `_INCOMPLETE_SCANNER_STATUSES`, and the `passed` property, whose value for it is the same policy question again. Downstream parsers see an unknown status |
| **D. A configurable threshold** | Fail above N% or N targets unevaluated | New config surface, and its default *is* the policy question. Most flexible, most to document, and silently does nothing until someone sets it |

**My recommendation if you want a failure mode: E.** It reuses an opt-in that already expresses
exactly this intent, changes no default, and adds no schema. The cost is real and worth stating
plainly: operators who set `--fail-on-incomplete-scanners` today would start failing on
repositories they currently pass on, which is why it is a decision and not a fix.

Whichever way that goes, the visibility in this PR stands on its own and does not need to be
revisited.

## Verification

Both directions. The new tests on `origin/main`: **9 failed, 3 passed** — behavioral reds
`AttributeError: 'ScannerMetrics' object has no attribute 'targets_attempted'` and
`KeyError: 'targets_attempted'`, the rest missing symbols. After: **18 passed**.

The 3 that pass on both sides are the deliberate controls asserting the status and `passed` are
**unchanged** (`PASSED`/`True` for partial, `ERROR`/`False` for total). They are labelled as such:
they exist so a later change to the verdict has to edit them.

Per-assertion discipline, since a coverage fix is easy to fake:

- Counts asserted as exact totals through `coverage_shortfalls`, never "greater than zero" —
  reading only the source report gives `(3, 2)` and only the converted `(1, 0)`, and a loose
  assertion accepts both while dropping half the input.
- Renderers asserted for emit-versus-silence only, never for wording.
- A negative control per channel: nothing printed, and no markdown section, when no coverage was
  lost. Without those, a fix that warned on every scan would pass.
- `None`-not-`0` asserted for non-tracking scanners in both the metrics and the emitted dict.
- The markdown scanner table's column count asserted, so the shortfall cannot have been
  implemented as an extra column after all.

**Full suite**, as CI runs it (`uv sync --extra cdk` then `uv run pytest`):

| | base `882b4b2a` | this branch |
|---|---|---|
| passed | 6571 | 6589 |
| failed | 1 | 1 |
| skipped | 119 | 119 |
| xfailed | 3 | 3 |

Skips unchanged — no integration tests added. The single failure is identical on both sides and
unrelated: `test_every_install_ref_names_the_packaged_version`, an install-reference/version-drift
check, addressed in a separate PR.

**Lint.** `ruff check --statistics` over the four modified files against the `origin/main` blobs
under the same ruff: **30 before, 30 after, zero delta on every rule.** The new test file has zero
findings. `ruff format`: **zero new hunk lines** in any modified file (three already drift on
`main` and drift identically here); the new file is clean.

**Python coverage.** 93.16% → **93.18%**.

No test weakened, skipped or deleted. No file touched that the cdk-nag reporting PR also touches —
that PR owns `scanner_statistics_calculator.py`, `cdk_nag_scanner.py` and `cdk_nag_wrapper.py`, and
this one owns `unified_metrics.py`, `metrics_table.py`, `report_content_emitter.py` and
`markdown_reporter.py`. The intersection is empty, so the two can land in either order.

One thing deliberately left out for that reason: a SARIF notification per unevaluated target would
belong in `cdk_nag_scanner.py`'s invocation, which the other PR already edits to add
`toolExecutionNotifications` for a related purpose. Adding a second writer to the same object from
a second branch buys a conflict for no benefit, so it belongs on top of that PR rather than beside
it.
