### PR TITLE
fix: land the CDK ref fixture change with the suppression it requires

### DIFF
--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -2085,6 +2085,29 @@ global_settings:
         of the literals they describe. Deliberately not citing a line number: this
         file argues against that a few entries above, and the number had already
         gone stale by the next commit.
+    - rule_id: SECRET-HEX-HIGH-ENTROPY-STRING
+      path: deploy/cdk-constructs/test/ash-scan-step.test.ts
+      reason: >-
+        The same 40-character git-ref placeholder as the entry above, reached by a
+        second file. Here it is the `commit` const in the jest test "PIP pins the
+        given git ref", which passes it to ASHScanStep as `version` and asserts
+        the synthesized buildspec carries it into the pip install URL. It stands
+        in for a commit rather than naming one -- the digits 0-9 followed by a-f,
+        repeated to length -- so it identifies nothing, grants nothing, and there
+        is nothing to revoke.
+        HexHighEntropyString fires on entropy alone here, with no keyword or
+        pattern component to corroborate it: the string spends all sixteen hex
+        digits across 40 characters, putting its Shannon entropy at 3.97 against
+        the plugin's limit of 3.0. Measured, not inferred -- any 40-character hex
+        string clears that limit, which is why a git SHA and a key are
+        indistinguishable to this detector.
+        A second entry rather than a widened first one because the two files sit
+        in different packages, deploy/cdk and deploy/cdk-constructs, and neither
+        path pattern reaches the other. One path per file and no
+        `deploy/cdk-constructs/**` glob, so a hex string added elsewhere in that
+        package still fails loudly instead of inheriting this argument.
+        Value DESCRIBED rather than quoted, and no line number cited, for the two
+        reasons the entry above records from having got both of those wrong.
     # === semgrep/opengrep Python compatibility (ASH requires 3.10+) ===
     - rule_id: "python.lang.compatibility.*"
       path: "automated_security_helper/**/*.py"

--- a/deploy/cdk-constructs/test/ash-scan-step.test.ts
+++ b/deploy/cdk-constructs/test/ash-scan-step.test.ts
@@ -291,15 +291,31 @@ describe('install modes', () => {
   });
 
   test('PIP pins the given git ref', () => {
+    // A commit, not a release tag, and the choice is load bearing twice over.
+    //
+    // This test only proves anything if the ref differs from the default one
+    // above, so naming the packaged version would make it pass whether or not
+    // `version` ever reached the buildspec. And a release tag here is
+    // indistinguishable, to anything reading the file as text, from an install
+    // command a user pastes: the tree-wide pin walk in
+    // tests/unit/test_agent_plugin_ash_version.py matches
+    // `automated-security-helper.git@v<semver>` wherever it appears and cannot
+    // tell a jest assertion from a real one, so a tag here either goes stale at
+    // the next release or costs that guard an exemption covering the whole
+    // file -- including the two live `@v3.7.0` pins it should keep watching.
+    // A commit is unambiguous, and it covers the third ref kind `version`
+    // documents; the default above already covers the tag case.
+    const commit = '0123456789abcdef0123456789abcdef01234567';
+
     const { template } = synthesizeWithStep({
       installMode: ASHInstallMode.PIP,
-      version: 'v3.6.0',
+      version: commit,
     });
 
     template.hasResourceProperties('AWS::CodeBuild::Project', {
       Source: Match.objectLike({
         BuildSpec: Match.stringLikeRegexp(
-          'git\\+https://github.com/awslabs/automated-security-helper.git@v3.6.0',
+          `git\\+https://github.com/awslabs/automated-security-helper.git@${commit}`,
         ),
       }),
     });


### PR DESCRIPTION
## Summary

Consolidates #553 and #556 into one pull request, because neither is green alone and `main`
stays red until both land. Two commits, one per concern, cherry-picked unchanged:

- `fix(test): stop a CDK ref fixture reading as a stale ASH install pin` — the jest test
  "PIP pins the given git ref" in `deploy/cdk-constructs/test/ash-scan-step.test.ts` now
  pins a commit instead of a release tag.
- `fix(config): cover the second file holding the hex git-ref fixture` — one
  `global_settings.suppressions` entry in `.ash/.ash.yaml` for
  `SECRET-HEX-HIGH-ENTROPY-STRING` on that path.

Two files, 41 added lines and 2 removed. No test weakened or skipped, no detector disabled,
no severity threshold moved, nothing under `.github/` touched.

## Why one pull request

`main` is red on
`tests/unit/test_agent_plugin_ash_version.py::TestInstallRefsTrackPackagedVersion::test_every_install_ref_names_the_packaged_version`:

```
AssertionError: These install references do not name the packaged version 3.7.0:
    deploy/cdk-constructs/test/ash-scan-step.test.ts:302 pins v3.6.0
assert not [('deploy/cdk-constructs/test/ash-scan-step.test.ts', 302, '3.6.0')]
```

The first commit fixes that, and in fixing it creates a second failure. The replacement ref
is a 40-character hex string, and `detect-secrets`'s `HexHighEntropyString` classifies any
such string as a secret on entropy alone — no keyword or pattern component corroborates it.
The fixture measures 3.97 against the plugin's limit of 3.0, so a `SECRET-HEX-HIGH-ENTROPY-STRING`
CRITICAL lands at `deploy/cdk-constructs/test/ash-scan-step.test.ts:308` and both
scan-validation and install-validation exit 2 on one actionable finding.

The second commit fixes that, and cannot ship alone either: on `main` the hex fixture does
not exist yet, so the entry matches nothing while the unit test stays red.

Their CI runs say the same thing. Every failing job in the Unified CI run at #553's head
(`1814b5f5`) is a `scan` or container cell, and not one is a `unit-test` cell. Every failing
job in the run at #556's head (`5528a6f1`) is a `unit-test` cell, and not one is a `scan`
cell. The two failure sets are disjoint and each pull request repairs the other's.

## Why a suppression, and why a second entry

`.ash/.ash.yaml` already suppresses this rule for the same placeholder in
`deploy/cdk/test/ash-image-build.test.ts`, where it stands in for a git SHA so a test can
assert how an image tag is derived. Suppression is keyed by path, so a second file needs a
second entry: `deploy/cdk` and `deploy/cdk-constructs` are different packages and neither
path pattern reaches the other. A `deploy/cdk-constructs/**` glob was rejected — it would
let a later hex string anywhere in that package inherit an argument nobody made about it.

The value names no commit and grants nothing, so there is nothing to revoke. Following the
convention the neighboring entry records, the reason describes the value rather than quoting
it, and cites no line number.

Two alternatives to the fixture change itself were rejected upstream in #553 and are worth
restating, because both would have avoided the suppression by costing coverage. Rewriting the
ref to the packaged version would make the assertion pass whether or not `version` ever
reached the buildspec, since it would then equal `DEFAULT_ASH_REF`. Adding the file to
`_ALLOWED_STALE` would stop the walk watching this file's two live `@v3.7.0` pins as well.

## Verification

**The unit test.** On plain `origin/main` at `882b4b2a`, one item collected, `1 failed`:

```
E       AssertionError: These install references do not name the packaged version 3.7.0:
E           deploy/cdk-constructs/test/ash-scan-step.test.ts:302 pins v3.6.0
E       assert not [('deploy/cdk-constructs/test/ash-scan-step.test.ts', 302, '3.6.0')]
```

On this branch, same invocation, one item collected, `1 passed`.

**detect-secrets.** `ash scan --scanners detect-secrets`:

| tree | suppressed | critical | actionable | exit |
| --- | --- | --- | --- | --- |
| the fixture change alone (#553's head) | 55 | 1 | 1 | 2, FAILED |
| both changes (this branch) | 56 | 0 | 0 | 0, PASSED |

**The suppression is used, not merely present.** The finding at
`deploy/cdk-constructs/test/ash-scan-step.test.ts:308` is still reported on this branch, and
carries an `inSource` suppression quoting the new entry's reason. ASH's own
`used_suppressions` list records the entry as matched:

```
deploy/cdk-constructs/test/ash-scan-step.test.ts|SECRET-HEX-HIGH-ENTROPY-STRING|*|*
```

**The other findings are untouched as a set, not as a count.** Comparing the two SARIF
reports by finding identity — rule, path, line span, message — rather than by tally:

```
BEFORE: 56 findings (55 suppressed, 1 not suppressed)
AFTER : 56 findings (56 suppressed, 0 not suppressed)

DISAPPEARED (in BEFORE only): 0
APPEARED (in AFTER only): 0
STATE CHANGED (in both, suppression differs): 1
  suppressed False -> True
    ruleId    : SECRET-HEX-HIGH-ENTROPY-STRING
    uri       : deploy/cdk-constructs/test/ash-scan-step.test.ts
    startLine : 308
UNCHANGED (in both, same state): 55
```

Exactly one member changes state and it is the one this entry names. Nothing appears,
nothing disappears, and the remaining 55 are identical on both sides. The comparison was
run against itself as a control first, where it correctly reports zero changed and fails.

**Everything else.** `ash config lint` reports the configuration clean. `ruff check` and
`ruff format --check` produce output byte-identical to an `origin/main` baseline, which is
expected of a change touching one TypeScript file and one YAML file, and measured rather
than assumed.
