### PR TITLE
fix(reporting): make a scanner's report tell the truth about what it scanned

### DIFF
--- a/.ash/.ash.yaml
+++ b/.ash/.ash.yaml
@@ -2085,6 +2085,29 @@ global_settings:
         of the literals they describe. Deliberately not citing a line number: this
         file argues against that a few entries above, and the number had already
         gone stale by the next commit.
+    - rule_id: SECRET-HEX-HIGH-ENTROPY-STRING
+      path: deploy/cdk-constructs/test/ash-scan-step.test.ts
+      reason: >-
+        The same 40-character git-ref placeholder as the entry above, reached by a
+        second file. Here it is the `commit` const in the jest test "PIP pins the
+        given git ref", which passes it to ASHScanStep as `version` and asserts
+        the synthesized buildspec carries it into the pip install URL. It stands
+        in for a commit rather than naming one -- the digits 0-9 followed by a-f,
+        repeated to length -- so it identifies nothing, grants nothing, and there
+        is nothing to revoke.
+        HexHighEntropyString fires on entropy alone here, with no keyword or
+        pattern component to corroborate it: the string spends all sixteen hex
+        digits across 40 characters, putting its Shannon entropy at 3.97 against
+        the plugin's limit of 3.0. Measured, not inferred -- any 40-character hex
+        string clears that limit, which is why a git SHA and a key are
+        indistinguishable to this detector.
+        A second entry rather than a widened first one because the two files sit
+        in different packages, deploy/cdk and deploy/cdk-constructs, and neither
+        path pattern reaches the other. One path per file and no
+        `deploy/cdk-constructs/**` glob, so a hex string added elsewhere in that
+        package still fails loudly instead of inheriting this argument.
+        Value DESCRIBED rather than quoted, and no line number cited, for the two
+        reasons the entry above records from having got both of those wrong.
     # === semgrep/opengrep Python compatibility (ASH requires 3.10+) ===
     - rule_id: "python.lang.compatibility.*"
       path: "automated_security_helper/**/*.py"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,34 @@
 - [1.0.1-e-10Jan2023](#101-e-10jan2023)
 
 
+## Unreleased
+
+### Behavior changes
+
+- **`--fail-on-incomplete-scanners` now also fails a scan that lost only part of
+  its input.** The flag selected on scanner status, and a scanner that failed on
+  some of its targets keeps the status the severity gate gives it — normally
+  `PASSED` — because `determine_status` returns `ERROR` only once
+  `targets_failed >= targets_attempted`. The flag therefore reported total
+  coverage loss and stayed silent on partial loss, which is the more common case
+  and the one operators turn it on to catch.
+
+  **This can turn an existing exit 0 into an exit 1 with no change to your own
+  code.** It affects only runs that pass `--fail-on-incomplete-scanners` (or set
+  `fail_on_incomplete_scanners: true`); the default path is unchanged. On this
+  repository's own tree the flag now exits 1, because cdk-nag attempts 10 targets
+  and cannot evaluate 4 of them.
+
+  A scanner that reports no target counts at all is unaffected — absent counters
+  mean the scanner does not track targets, not that it lost them, so the nine
+  scanners in that state cannot trip the gate. Scanner statuses themselves are
+  unchanged, so no report or summary table reads differently.
+
+  To restore the previous behavior, drop the flag (or set
+  `fail_on_incomplete_scanners: false`) to accept a partial scan. To keep the
+  flag and clear the failure, fix or exclude the targets the scanner could not
+  read; the failure message names each scanner with the counts.
+
 ## v3.7.0 (2026-08-27)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,9 +169,13 @@
     `ash.ghas.sarif` has no `invocations` key at all. A pipeline that uploads
     `ash.sarif` itself rather than `ash.ghas.sarif` will surface them.
   - A cdk-nag rule that could not be evaluated is now `kind: notApplicable` at
-    `level: none`, which ASH maps to INFO. It was previously reported as a
-    finding at the rule's declared severity, so some scans will show fewer
-    critical cdk-nag findings and gain the same number of informational ones.
+    `level: none`, which ASH maps to INFO. It was previously reported as a finding
+    at the rule's declared severity. Measured on this repository, the aggregated
+    SARIF holds the same 453 results before and after, of which 15 move to
+    `notApplicable`/`none` — 10 that were `error`/`fail` and 5 that were
+    `warning`/`informational`. The actionable counts do not move here because those
+    15 were already suppressed; on a tree where they are not, the scanner's
+    high-severity count drops by however many of its rules raised.
 
 ## v3.7.0 (2026-08-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,11 +56,26 @@
   coverage loss and stayed silent on partial loss, which is the more common case
   and the one operators turn it on to catch.
 
-  **This can turn an existing exit 0 into an exit 1 with no change to your own
-  code.** It affects only runs that pass `--fail-on-incomplete-scanners` (or set
-  `fail_on_incomplete_scanners: true`); the default path is unchanged. On this
-  repository's own tree the flag now exits 1, because cdk-nag attempts 10 targets
-  and cannot evaluate 4 of them.
+  **If you already pass `--fail-on-incomplete-scanners`, a build that was green
+  will now exit 1 with no diff of your own.** Nothing about your code changed and
+  nothing newly broke: the flag was blind to partial loss, and the coverage it was
+  silently accepting is now reported. Expect to hit this in CI without warning the
+  first time you upgrade. It affects only runs that pass the flag (or set
+  `fail_on_incomplete_scanners: true`); the default path is unchanged.
+
+  Measured on this repository's own tree, so the scale is concrete rather than
+  hypothetical: cdk-nag **attempts 10 targets and cannot evaluate 4** of them, a
+  40% loss that previously reported as a clean scan. ASH's own scan therefore now
+  exits 1 under the flag.
+
+  That 40% is not entirely spurious, and it is worth knowing the split before
+  dismissing it. Two of the four are real CloudFormation templates that genuinely
+  went unscanned (`test-yaml.template.json` and
+  `cfn-and-python-test-yaml.template.json`). The other two — a `tsconfig.json` and
+  a `mkdocs.yml` — were never templates at all and reach cdk-nag through a
+  separate target-selection bug, not fixed here. So half the number is real lost
+  coverage and half is noise, which is precisely why the counts are reported
+  rather than folded into a single percentage.
 
   A scanner that reports no target counts at all is unaffected — absent counters
   mean the scanner does not track targets, not that it lost them, so the nine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,11 +50,13 @@
 
 - **`--fail-on-incomplete-scanners` now also fails a scan that lost only part of
   its input.** The flag selected on scanner status, and a scanner that failed on
-  some of its targets keeps the status the severity gate gives it — normally
-  `PASSED` — because `determine_status` returns `ERROR` only once
-  `targets_failed >= targets_attempted`. The flag therefore reported total
-  coverage loss and stayed silent on partial loss, which is the more common case
-  and the one operators turn it on to catch.
+  some of its targets keeps whatever status the severity gate gives it — `PASSED`
+  or `FAILED`, decided only by what the targets it *did* read contained — because
+  `determine_status` returns `ERROR` only once
+  `targets_failed >= targets_attempted`. Neither value says anything about the
+  targets that went unread, so the flag reported total coverage loss and stayed
+  silent on partial loss, which is the more common case and the one operators turn
+  it on to catch.
 
   **If you already pass `--fail-on-incomplete-scanners`, a build that was green
   will now exit 1 with no diff of your own.** Nothing about your code changed and
@@ -68,12 +70,12 @@
   40% loss that nothing in the rendered output mentioned. ASH's own scan therefore
   now exits 1 under the flag.
 
-  Not "reported as a clean scan", which an earlier draft of this entry said. On
-  this repository cdk-nag rolls up to `FAILED`, on 16 actionable findings at the
-  `MEDIUM` threshold — identical before and after this change. What it reported was
-  a **complete** scan, not a clean one, and that is the claim being corrected: the
-  40% shortfall was absent from the summary table, from every report and from the
-  exit code, regardless of what the status column said.
+  Note that cdk-nag's status here is `FAILED`, on 16 actionable findings at the
+  `MEDIUM` threshold, both before and after this change. The point is not that a
+  passing row hid a problem; it is that the shortfall was absent from the summary
+  table, from every report and from the exit code no matter which status the row
+  carried. A scanner reports a **complete** scan of its input whether it passed or
+  failed on the part it read.
 
   That 40% is not entirely spurious, and it is worth knowing the split before
   dismissing it. Two of the four are real CloudFormation templates that genuinely
@@ -105,9 +107,9 @@
   scan, with nothing to opt into.** This is wider than the flag change above and
   wants reading first.
 
-  `ScanPhase` gives each scanner one task carrying two targets — the source tree
-  and the converted tree — and `ScanResultProcessor` writes one serialized
-  container per target. `determine_status` already returned `ERROR` for a tree
+  `ScanPhase` gives each scanner one task carrying the source tree and, where the
+  convert phase produced one, the converted tree, and `ScanResultProcessor` writes
+  one serialized container per target. `determine_status` already returned `ERROR` for a tree
   whose every attempted target failed, but `get_scanner_status_info` never
   consulted it: it read the scanner-level `"None"` report, else the
   `scanner_results` entry, else the `"source"` report. In a real run the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,8 +65,15 @@
 
   Measured on this repository's own tree, so the scale is concrete rather than
   hypothetical: cdk-nag **attempts 10 targets and cannot evaluate 4** of them, a
-  40% loss that previously reported as a clean scan. ASH's own scan therefore now
-  exits 1 under the flag.
+  40% loss that nothing in the rendered output mentioned. ASH's own scan therefore
+  now exits 1 under the flag.
+
+  Not "reported as a clean scan", which an earlier draft of this entry said. On
+  this repository cdk-nag rolls up to `FAILED`, on 16 actionable findings at the
+  `MEDIUM` threshold — identical before and after this change. What it reported was
+  a **complete** scan, not a clean one, and that is the claim being corrected: the
+  40% shortfall was absent from the summary table, from every report and from the
+  exit code, regardless of what the status column said.
 
   That 40% is not entirely spurious, and it is worth knowing the split before
   dismissing it. Two of the four are real CloudFormation templates that genuinely
@@ -79,13 +86,92 @@
 
   A scanner that reports no target counts at all is unaffected — absent counters
   mean the scanner does not track targets, not that it lost them, so the nine
-  scanners in that state cannot trip the gate. Scanner statuses themselves are
-  unchanged, so no report or summary table reads differently.
+  scanners in that state cannot trip the gate.
+
+  Partial coverage loss does **not** change a scanner's status. That is a
+  deliberate limit on this entry and not a claim about the release: the separate
+  breaking change below does change statuses, with no flag to opt into. Read the
+  two together.
 
   To restore the previous behavior, drop the flag (or set
   `fail_on_incomplete_scanners: false`) to accept a partial scan. To keep the
   flag and clear the failure, fix or exclude the targets the scanner could not
-  read; the failure message names each scanner with the counts.
+  read; the failure message names each scanner with the counts, whatever its
+  status.
+
+### Breaking changes
+
+- **A scanner that lost every target on any one tree now reports `ERROR`, on every
+  scan, with nothing to opt into.** This is wider than the flag change above and
+  wants reading first.
+
+  `ScanPhase` gives each scanner one task carrying two targets — the source tree
+  and the converted tree — and `ScanResultProcessor` writes one serialized
+  container per target. `determine_status` already returned `ERROR` for a tree
+  whose every attempted target failed, but `get_scanner_status_info` never
+  consulted it: it read the scanner-level `"None"` report, else the
+  `scanner_results` entry, else the `"source"` report. In a real run the
+  `scanner_results` branch wins, so a per-target `ERROR` was written to disk,
+  serialized into the aggregated results, and never read by anything. A scanner
+  that passed on the source tree and evaluated nothing at all on the converted one
+  rolled up to `PASSED`.
+
+  It now rolls up to `ERROR`, and `error` is the first branch in both
+  `get_scanner_status` and `get_unified_scanner_metrics`. So for an affected
+  scanner:
+
+  - the console summary table's status column changes;
+  - the markdown, text and HTML reports change with it;
+  - `ash.flat.json`'s `passed` flips from `true` to `false`, which is the field a
+    machine consumer gates on.
+
+  **What is not affected**, because the distinction is the useful part:
+
+  - **The default exit code.** `_compute_exit_code` consults `incomplete_scanners`
+    only once `--fail-on-incomplete-scanners` resolves true, so a default run's
+    exit code is unchanged by either half of this release. A scanner rolling up to
+    `ERROR` does affect the exit code under that flag — but it did already, since
+    `ERROR` was always a status the flag selected on.
+  - **`ash merge`'s shard verification.** `_completed` reads the raw
+    `ScannerTargetStatusInfo.status` off `scanner_results`, not the derived rollup,
+    so a partial-coverage scanner still counts as having run and no healthy shard
+    is refused.
+
+  Measured on this repository, this change alters nothing: cdk-nag's only target
+  report is the source tree, it carries `PASSED`, and the scanner rolls up to
+  `FAILED` on its findings both before and after. A repository is affected only
+  when some tree lost *all* of its targets, which is why the flag change above is
+  the one ASH's own scan feels.
+
+  There is no flag. To keep a previously-green pipeline green you must fix or
+  exclude the targets the scanner could not read on the affected tree, or exclude
+  the scanner. Reverting to the previous behavior means accepting a report that
+  states coverage it does not have.
+
+### Reporting changes
+
+- **Reports now say how much of its input each scanner evaluated.** Additive, but
+  it does change bytes, so it is listed rather than left to be discovered:
+
+  - `ScannerMetrics` gained `targets_attempted` and `targets_failed`, and
+    `ash.flat.json` carries both. `targets_attempted` is `null` — not `0` — for a
+    scanner that does not track per-target outcomes, so a consumer can tell "made
+    no claim" from "attempted none".
+  - The console table and the markdown report gained an "Incomplete coverage"
+    section, emitted only when there is something to report. Measured on this
+    repository, `ash.summary.md` gained `### Incomplete coverage` naming cdk-nag's
+    6 of 10.
+  - cdk-nag's SARIF gained `runs[].invocations[].toolExecutionNotifications`, one
+    per rule that raised instead of returning a verdict, at `level: error`.
+    Measured on this repository: 11 notifications where there were previously
+    none. These do **not** reach GitHub Advanced Security — the `github-ghas`
+    reporter assembles a fresh run carrying only `tool.driver` and `results`, so
+    `ash.ghas.sarif` has no `invocations` key at all. A pipeline that uploads
+    `ash.sarif` itself rather than `ash.ghas.sarif` will surface them.
+  - A cdk-nag rule that could not be evaluated is now `kind: notApplicable` at
+    `level: none`, which ASH maps to INFO. It was previously reported as a
+    finding at the rule's declared severity, so some scans will show fewer
+    critical cdk-nag findings and gain the same number of informational ones.
 
 ## v3.7.0 (2026-08-27)
 

--- a/automated_security_helper/cli/merge.py
+++ b/automated_security_helper/cli/merge.py
@@ -1249,9 +1249,15 @@ def _print_merge_summary(
 
         incomplete = incomplete_scanners(merged)
         if incomplete:
+            # "did not complete" reads as "never ran", which is only one of the two
+            # cases this list now carries: a scanner that evaluated some of its
+            # targets and not others also lands here, with its counts in the status
+            # string. Distinct from _completed() above, which still asks the
+            # narrower did-it-run-at-all question that shard refusal depends on.
             print(
                 f"[bold red]ERROR (1) Exiting because {len(incomplete)} scanner(s) "
-                f"in the merged scan did not complete[/bold red]"
+                f"in the merged scan did not evaluate everything they were given"
+                f"[/bold red]"
             )
             for name, status in incomplete:
                 print(f"  [red]{name}: {status}[/red]")

--- a/automated_security_helper/core/metrics_table.py
+++ b/automated_security_helper/core/metrics_table.py
@@ -8,6 +8,7 @@ from rich.panel import Panel
 
 from automated_security_helper.models.asharp_model import AshAggregatedResults
 from automated_security_helper.core.unified_metrics import (
+    coverage_shortfalls,
     get_unified_scanner_metrics,
     format_duration,
 )
@@ -156,6 +157,41 @@ def generate_metrics_table_from_unified_data(
     return table
 
 
+def print_coverage_shortfalls(
+    asharp_model: AshAggregatedResults, console: Console
+) -> None:
+    """Name every scanner that could not evaluate part of its input, with the counts.
+
+    Printed BESIDE the table rather than added to it. A twelfth column would change the table's
+    geometry for every scan including the ones with nothing to report, and the responsive
+    narrow-terminal layout already carries eleven; the shortfall is also exceptional rather than
+    per-row data. Emitting nothing when there is nothing to say is what keeps this from becoming
+    noise -- see the negative control in
+    ``tests/unit/core/test_partial_target_coverage_visibility.py``.
+
+    Why it exists at all: ``determine_status`` only returns ERROR once every attempted target
+    failed, so a scanner that lost some of its input reports whatever the severity gate gives it.
+    Measured on this repository, cdk-nag attempts 10 targets, fails 4, and reports PASSED -- and
+    two of those four were real CloudFormation templates rather than files that were never
+    templates. Nothing in the rendered output said so.
+
+    The status and the exit code are deliberately not touched. At the measured rate, failing on
+    any unevaluated target would turn a routine condition into a permanent red; whether it should
+    fail is a policy question about pipelines and not one this rendering decides.
+    """
+    shortfalls = coverage_shortfalls(asharp_model)
+    if not shortfalls:
+        return
+    for scanner_name, attempted, failed in shortfalls:
+        evaluated = attempted - failed
+        console.print(
+            f"[bold yellow]Incomplete coverage:[/bold yellow] {scanner_name} evaluated "
+            f"{evaluated} of {attempted} target(s); {failed} could not be evaluated and "
+            f"contributed no findings. See the scanner's exitCodeDescription in its SARIF "
+            f"report for the reason per target."
+        )
+
+
 def display_metrics_table(
     asharp_model: AshAggregatedResults,
     source_dir: str | Path | None = None,
@@ -248,6 +284,10 @@ def display_metrics_table(
             console.print()
             console.print(table)
             console.print()
+            # After the table, so the counts sit next to the status they qualify. Inside the same
+            # guarded block because it writes to the same console: a closed stdout has to be
+            # handled identically for both, and a shortfall notice is not worth failing a scan.
+            print_coverage_shortfalls(asharp_model, console)
         except (ValueError, OSError, BrokenPipeError) as io_error:
             # stdout/stderr may be closed (e.g., in MCP server context)
             # Log the error but don't fail the scan

--- a/automated_security_helper/core/metrics_table.py
+++ b/automated_security_helper/core/metrics_table.py
@@ -171,13 +171,21 @@ def print_coverage_shortfalls(
 
     Why it exists at all: ``determine_status`` only returns ERROR once every attempted target
     failed, so a scanner that lost some of its input reports whatever the severity gate gives it.
-    Measured on this repository, cdk-nag attempts 10 targets, fails 4, and reports PASSED -- and
-    two of those four were real CloudFormation templates rather than files that were never
-    templates. Nothing in the rendered output said so.
+    Measured on this repository, cdk-nag attempts 10 targets and cannot evaluate 4, and its status
+    column reads FAILED -- on findings, which say nothing about the four it never read. Two of
+    those four were real CloudFormation templates rather than files that were never templates.
+    Nothing in the rendered output said so, whatever the status happened to be, which is the
+    point: no status value carries this fact, so the status column cannot be where a reader looks
+    for it.
 
-    The status and the exit code are deliberately not touched. At the measured rate, failing on
-    any unevaluated target would turn a routine condition into a permanent red; whether it should
-    fail is a policy question about pipelines and not one this rendering decides.
+    This rendering does not touch the status or the exit code, and neither claim generalizes past
+    this function. A sibling change ORs ``any_target_errored`` into the ``error`` flag, so a tree
+    that lost ALL its targets does now move the rolled-up status to ERROR -- see the CHANGELOG's
+    breaking-change entry. What is genuinely untouched by the whole change is the DEFAULT exit
+    code: ``_compute_exit_code`` reaches the coverage list only once
+    ``--fail-on-incomplete-scanners`` resolves true. Whether a partial scan should fail is a
+    policy question about pipelines, it is answered by that flag, and it is not one this rendering
+    decides.
     """
     shortfalls = coverage_shortfalls(asharp_model)
     if not shortfalls:

--- a/automated_security_helper/core/scanner_statistics_calculator.py
+++ b/automated_security_helper/core/scanner_statistics_calculator.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, Optional, Tuple
 
 from automated_security_helper.config.default_config import get_default_config
 from automated_security_helper.core.constants import ASH_DEFAULT_SEVERITY_LEVEL
+from automated_security_helper.core.enums import ScannerStatus
 from automated_security_helper.models.asharp_model import (
     AshAggregatedResults,
     ScannerSeverityCount,
@@ -592,6 +593,45 @@ class ScannerStatisticsCalculator:
         return excluded, dependencies_missing, error
 
     @staticmethod
+    def any_target_errored(
+        asharp_model: AshAggregatedResults, scanner_name: str
+    ) -> bool:
+        """True when ANY target this scanner reported under came back ERROR.
+
+        ``ScanPhase`` gives each scanner one task carrying both the source tree and the
+        converted tree, and ``ScanResultProcessor`` writes one serialized container per target
+        under ``additional_reports[scanner][target_type]``. ERROR is what
+        ``ScanResultsContainer.determine_status`` returns when a tracking scanner failed every
+        target it attempted -- so an ERROR here means no rule was evaluated against that tree.
+
+        ``get_scanner_status_info`` used to derive its ``error`` flag from the ``"source"``
+        report alone. A cdk-nag that passed on the source tree and errored on the converted one
+        therefore rolled up to PASSED: the ERROR container was written to disk, serialized into
+        the aggregated results, and never read. Nothing downstream could recover the fact,
+        because ``error`` is the flag every rolled-up status keys on.
+
+        "Any", not "all", and the asymmetry with the severity gate is the point. A finding count
+        of zero is ambiguous, so the guards in ``determine_status`` are careful about which
+        zero they are looking at. An ERROR is not ambiguous: one target that evaluated nothing
+        is a hole in the scan whether or not its sibling was fine, and a report that averages
+        it away against a passing sibling is asserting coverage it does not have.
+
+        Modelled on ``scanner_evaluated_nothing``, which already reads across every target for
+        the same structural reason. That function existed with that quantifier and this one did
+        not, and the gap between them is exactly where the defect lived.
+        """
+        reports = asharp_model.additional_reports.get(scanner_name)
+        if not isinstance(reports, dict):
+            return False
+
+        for target_report in reports.values():
+            if not isinstance(target_report, dict):
+                continue
+            if target_report.get("status") == ScannerStatus.ERROR.value:
+                return True
+        return False
+
+    @staticmethod
     def scanner_evaluated_nothing(
         asharp_model: AshAggregatedResults, scanner_name: str
     ) -> bool:
@@ -662,6 +702,15 @@ class ScannerStatisticsCalculator:
         genuinely different fact, and it is answered by ``scanner_evaluated_nothing`` rather than
         folded into ``excluded`` here -- see ``_status_info_from_report`` for what folding it in
         used to cost.
+
+        ``error`` is the one of the three read across every target rather than off a single
+        report, and that asymmetry is deliberate. A scanner is switched off, or its tool is
+        absent, for the whole run -- those are facts about configuration, and the scanner-level
+        report states them correctly. Whether a rule was evaluated is a fact about one tree, and
+        a scanner gets two. See ``any_target_errored`` for what reading only the source report
+        cost. Widening ``excluded`` the same way would be actively wrong: one target carrying an
+        unrecognized status makes ``_status_info_from_report`` return ``excluded=True`` for
+        backward compatibility, which would then claim the operator had switched the scanner off.
         """
         excluded = False
         dependencies_missing = False
@@ -703,6 +752,14 @@ class ScannerStatisticsCalculator:
         else:
             # If the scanner is not found in the dictionary, check for errors
             error = True
+
+        # ORed in after the branches above rather than replacing them. Those branches also
+        # produce ``excluded`` and ``dependencies_missing``, which stay scanner-level, and the
+        # first branch reads a report keyed ``"None"`` -- a scanner that never reached a target
+        # at all -- which ``any_target_errored`` covers as well since it walks every key.
+        error = error or ScannerStatisticsCalculator.any_target_errored(
+            asharp_model, scanner_name
+        )
 
         return excluded, dependencies_missing, error
 

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -74,6 +74,26 @@ class ScannerMetrics(ScannerSeverityCount):
     excluded: bool = False  # Whether the scanner was explicitly excluded
     dependencies_missing: bool = False  # Whether the scanner has missing dependencies
 
+    # How much of its input the scanner actually evaluated, summed over every target it reported
+    # under. Present here because this class is the only model the summary table and every
+    # reporter read: the counters existed on ``ScanResultsContainer`` and in the serialized
+    # per-target reports, and had no route to any human-facing output at all.
+    #
+    # That mattered because ``determine_status`` only returns ERROR once
+    # ``targets_failed >= targets_attempted``. A scanner that failed on some of its targets keeps
+    # whatever status the severity gate gives it, so partial coverage loss renders exactly like a
+    # clean scan. Measured against cdk-nag on this repository: 10 targets attempted, 4 failed,
+    # reported PASSED -- and two of those four were CloudFormation templates that genuinely went
+    # unscanned rather than files that were never templates.
+    #
+    # ``targets_attempted`` keeps the container's tri-state meaning rather than defaulting to 0.
+    # None means the scanner does not track per-target outcomes and is making no claim; bandit,
+    # checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag and npm-audit are all in
+    # that state. Reading them as "attempted zero" would report every one of them as having
+    # evaluated nothing.
+    targets_attempted: int | None = None
+    targets_failed: int = 0
+
     @computed_field
     @property
     def passed(self) -> bool:
@@ -107,6 +127,69 @@ class ScannerMetrics(ScannerSeverityCount):
         field mean the stricter thing is a report-schema change, not a bug fix.
         """
         return self.status in ("PASSED", "SKIPPED", "MISSING")
+
+
+def target_counts(
+    asharp_model: AshAggregatedResults, scanner_name: str
+) -> tuple[int | None, int]:
+    """``(targets_attempted, targets_failed)`` summed over every target the scanner reported.
+
+    Summed rather than read off ``"source"``, because ``ScanPhase`` gives each scanner one task
+    carrying both the source tree and the converted tree and either of them can lose coverage.
+    Reading one report would under-report by whatever the other did, which is the same
+    single-target mistake that made a converted-target failure invisible in the first place.
+
+    Returns None for the attempt count when NO target report carries one. That is the
+    scanner-does-not-track state, and it must not collapse to 0: ``0`` is a claim -- "I tracked
+    targets and attempted none" -- while absence is the absence of a claim. ``targets_failed``
+    stays a plain int because it has no independent meaning; a failure count with no attempt count
+    is a producer bug rather than a third state.
+
+    ``bool`` is rejected explicitly even though it is an ``int`` subclass. A True/False counter is
+    a producer bug, and reading it as 1/0 would silently invent a target.
+    """
+    reports = asharp_model.additional_reports.get(scanner_name)
+    if not isinstance(reports, dict):
+        return None, 0
+
+    attempted: int | None = None
+    failed = 0
+    for target_report in reports.values():
+        if not isinstance(target_report, dict):
+            continue
+        raw_attempted = target_report.get("targets_attempted")
+        if isinstance(raw_attempted, int) and not isinstance(raw_attempted, bool):
+            attempted = (attempted or 0) + raw_attempted
+        raw_failed = target_report.get("targets_failed")
+        if isinstance(raw_failed, int) and not isinstance(raw_failed, bool):
+            failed += raw_failed
+    return attempted, failed
+
+
+def coverage_shortfalls(
+    asharp_model: AshAggregatedResults,
+) -> list[tuple[str, int, int]]:
+    """``(scanner, attempted, failed)`` for every scanner that could not evaluate some input.
+
+    The structured form on purpose. The renderer formats these, and a test that asserted the
+    rendered sentence would keep passing through a change that got the numbers wrong -- so the
+    numbers are pinned here, where they are data, and the renderer is only checked for whether it
+    emits at all.
+
+    Includes the total-loss case as well as the partial one. Total loss already reaches the status
+    column as ERROR, but the count of what went unevaluated is exactly as absent from the table
+    there as it is when only some targets failed.
+
+    A scanner making no claim is never a shortfall: absent counters mean the scanner does not
+    track targets, not that it lost all of them.
+    """
+    shortfalls: list[tuple[str, int, int]] = []
+    for scanner_name in sorted(asharp_model.additional_reports or {}):
+        attempted, failed = target_counts(asharp_model, scanner_name)
+        if attempted is None or failed <= 0:
+            continue
+        shortfalls.append((scanner_name, attempted, failed))
+    return shortfalls
 
 
 def format_duration(duration_seconds: Optional[float]) -> str:
@@ -236,6 +319,14 @@ def get_unified_scanner_metrics(
                 scan_result.status if scan_result and scan_result.status else "PASSED"
             )
 
+        # Read straight off the serialized per-target reports rather than through
+        # ``extract_scanner_statistics``. These two are the only values here that describe how
+        # much input was consumed rather than what was found in it, and they are the reason the
+        # summary table could not previously say a scan was partial -- see ScannerMetrics.
+        scanner_targets_attempted, scanner_targets_failed = target_counts(
+            asharp_model, scanner_name
+        )
+
         # Create metrics entry. total and passed are computed, so we do not pass
         # them in explicitly — they're derived from severity fields and status.
         metrics = ScannerMetrics(
@@ -253,6 +344,8 @@ def get_unified_scanner_metrics(
             threshold_source=stats["threshold_source"],
             excluded=stats["excluded"],
             dependencies_missing=stats["dependencies_missing"],
+            targets_attempted=scanner_targets_attempted,
+            targets_failed=scanner_targets_failed,
         )
 
         metrics_list.append(metrics)

--- a/automated_security_helper/core/unified_metrics.py
+++ b/automated_security_helper/core/unified_metrics.py
@@ -82,9 +82,11 @@ class ScannerMetrics(ScannerSeverityCount):
     # That mattered because ``determine_status`` only returns ERROR once
     # ``targets_failed >= targets_attempted``. A scanner that failed on some of its targets keeps
     # whatever status the severity gate gives it, so partial coverage loss renders exactly like a
-    # clean scan. Measured against cdk-nag on this repository: 10 targets attempted, 4 failed,
-    # reported PASSED -- and two of those four were CloudFormation templates that genuinely went
-    # unscanned rather than files that were never templates.
+    # scan that read everything. Measured against cdk-nag on this repository: 10 targets
+    # attempted, 4 failed, rolled up to FAILED on its findings -- and two of those four were
+    # CloudFormation templates that genuinely went unscanned rather than files that were never
+    # templates. FAILED is as silent about the four as PASSED would have been, which is the
+    # reason these are fields rather than a status.
     #
     # ``targets_attempted`` keeps the container's tri-state meaning rather than defaulting to 0.
     # None means the scanner does not track per-target outcomes and is making no claim; bandit,

--- a/automated_security_helper/interactions/run_ash_scan.py
+++ b/automated_security_helper/interactions/run_ash_scan.py
@@ -244,13 +244,24 @@ def incomplete_scanners(
     2. The scanner ran, reported a status, and could not evaluate some of the
        targets it was given.
 
-    Only (1) was selected on, because that is a status test and (2) does not
-    change the status. ``ScanResultsContainer.determine_status`` returns ERROR
-    only once ``targets_failed >= targets_attempted``, so a scanner that lost some
-    of its input keeps whatever the severity gate gave it -- normally PASSED --
-    and the gate could not see it. Measured on this repository: cdk-nag attempts
-    10 targets, fails 4, reports PASSED, and the gate exited 0. Two of those four
-    are real CloudFormation templates that went unscanned.
+    Only (1) was selected on, because that is a status test and (2) does not move
+    a target's status. ``ScanResultsContainer.determine_status`` returns ERROR only
+    once ``targets_failed >= targets_attempted``, so a scanner that lost some of
+    its input keeps whatever the severity gate gave it and the gate could not see
+    it. Measured on this repository under its own config: cdk-nag attempts 10
+    targets and fails 4, its per-target container still reports PASSED, and the
+    gate exited 0. Two of those four are real CloudFormation templates that went
+    unscanned.
+
+    Do not read "(2) does not change the status" as "nothing in this change
+    touches a status". A sibling commit ORs ``any_target_errored`` into the
+    ``error`` flag, so a target tree that lost ALL of its targets -- which
+    ``determine_status`` does report as ERROR -- now reaches the rolled-up status
+    where previously only the ``"source"`` report was consulted, and even that only
+    when the scanner was absent from ``scanner_results``. That is a status change,
+    it is not opted in, and it is the thing the CHANGELOG's "Behavior changes"
+    entry describes. The two arms are separable: partial loss stays out of the
+    status and is expressed here; total loss on any tree is a status.
 
     Case (2) is expressed HERE and not as a status, and not by widening
     ``_INCOMPLETE_SCANNER_STATUSES``. The reason is a caller rather than taste.
@@ -263,21 +274,43 @@ def incomplete_scanners(
     the code that caused it. That is the concrete cost of adding a
     ``ScannerStatus`` member for this, and the reason none was added.
 
-    Worth being precise about the residual risk, because an earlier version of
-    this comment overstated it: ``_completed`` inspects a
-    ``ScannerTargetStatusInfo``, which declares no target counters, so it cannot
-    read coverage today by any route -- the protection is structural, not merely
-    conventional. Since the status a scanner reports is unchanged, no reporter, no
-    summary table and no consumer of ``ScannerStatus`` sees anything new; the only
-    behavior that changes is this gate's own verdict, and only when the operator
-    opted in. ``tests/unit/cli/test_merge.py`` pins the boundary from the merge
-    side.
+    Worth being precise about the residual risk, because two earlier versions of
+    this comment got it wrong in opposite directions. One said ``_completed``
+    inspects a ``ScannerTargetStatusInfo``, which declares no target counters, so
+    the protection is structural rather than conventional. That is false, and
+    measurably so: the model sets ``extra="allow"``, so counters written into
+    ``scanner_results`` land in ``model_extra`` and a ``getattr`` for them
+    succeeds. Nothing structural stops ``_completed`` reading coverage; what stops
+    it is that it does not, which is a behavior and therefore something a test can
+    hold. ``tests/unit/interactions/test_fail_on_partial_target_coverage.py``
+    holds it, and mutating ``_completed`` to consult the counters reddens it.
 
-    Status precedence between the two arms is explicit. Total loss satisfies the
-    coverage condition too -- ``failed >= attempted`` implies ``failed > 0`` -- so
-    an ERROR scanner would otherwise gain a parenthetical it never had and break
-    every existing assertion on that message. (1) wins and reports the bare
-    status.
+    The other claimed no reporter and no summary table sees anything new, and this
+    change is the reason both do. ``ScannerMetrics`` gained ``targets_attempted``
+    and ``targets_failed``; the console table, the markdown report and
+    ``ash.flat.json`` all carry them, and the first two grew an "Incomplete
+    coverage" section. Measured on this repository, ``ash.summary.md`` gained
+    ``### Incomplete coverage`` and ``ash.flat.json`` gained the two keys. What is
+    genuinely untouched is narrower and worth naming exactly: ``_completed``, and
+    the DEFAULT exit code, which reaches this function only once
+    ``_resolve_fail_on_incomplete_scanners`` returns true.
+    ``tests/unit/cli/test_merge.py`` pins the boundary from the merge side.
+
+    Precedence between the two arms is on TOTALITY, not on status. Total loss
+    satisfies the coverage condition too -- ``failed >= attempted`` implies
+    ``failed > 0`` -- and appending counts there would give an ERROR row a
+    parenthetical it never had while saying nothing the status does not already
+    say, so total loss reports the bare status.
+
+    A PARTIAL shortfall reports its counts whatever the status is, and that is a
+    correction rather than a preference. Selecting the bare-status arm on status
+    alone made this function unable to deliver what it exists for in the case it
+    was written for: an ERROR scanner that is only partly incomplete took the bare
+    arm and printed ``cdk-nag: ERROR``, never ``cdk-nag: ERROR (4 of 10 targets
+    unevaluated)``, so the counts the operator needs to tell "the tool is absent"
+    from "the tool ran and skipped four templates" were dropped by the routing.
+    An ERROR with no counters available still falls to the bare form, because there
+    is no honest denominator to print.
 
     Read through ``get_unified_scanner_metrics`` rather than off
     ``results.scanner_results`` directly, so the gate and the report cannot
@@ -313,18 +346,32 @@ def incomplete_scanners(
 
     listed: list[tuple[str, str]] = []
     for metric in get_unified_scanner_metrics(asharp_model=results):
-        if metric.status in _INCOMPLETE_SCANNER_STATUSES:
+        status_is_incomplete = metric.status in _INCOMPLETE_SCANNER_STATUSES
+        shortfall = _partial_coverage(metric)
+
+        # No usable counters. The status is the only thing there is to report, so
+        # this is the arm an ERROR or MISSING with no denominator falls to.
+        if shortfall is None:
+            if status_is_incomplete:
+                listed.append((metric.scanner_name, metric.status))
+            continue
+
+        attempted, failed = shortfall
+        # Total loss, and a status that already says so. The counts would add a
+        # parenthetical that repeats the status.
+        if status_is_incomplete and failed >= attempted:
             listed.append((metric.scanner_name, metric.status))
             continue
-        shortfall = _partial_coverage(metric)
-        if shortfall is not None:
-            attempted, failed = shortfall
-            listed.append(
-                (
-                    metric.scanner_name,
-                    f"{metric.status} ({failed} of {attempted} targets unevaluated)",
-                )
+
+        # A partial shortfall against a known denominator, whatever the status.
+        # Selecting on status ahead of this is what dropped the counts from the
+        # measured case.
+        listed.append(
+            (
+                metric.scanner_name,
+                f"{metric.status} ({failed} of {attempted} targets unevaluated)",
             )
+        )
     return listed
 
 

--- a/automated_security_helper/interactions/run_ash_scan.py
+++ b/automated_security_helper/interactions/run_ash_scan.py
@@ -252,15 +252,26 @@ def incomplete_scanners(
     10 targets, fails 4, reports PASSED, and the gate exited 0. Two of those four
     are real CloudFormation templates that went unscanned.
 
-    ``_INCOMPLETE_SCANNER_STATUSES`` is deliberately NOT widened to express (2),
-    and the reason is a caller rather than taste. ``cli.merge._completed`` imports
-    that set to answer a different question -- whether a shard's scanner ran at
-    all -- and ``_verify_shard_contributions`` refuses a merge where a shard
+    Case (2) is expressed HERE and not as a status, and not by widening
+    ``_INCOMPLETE_SCANNER_STATUSES``. The reason is a caller rather than taste.
+    ``cli.merge._completed`` keys on status against that same set to answer a
+    different question -- whether a shard's scanner ran at all -- and
+    ``_verify_shard_contributions`` refuses a merge outright where a shard
     completed none of the scanners it owned. A scanner that lost one target of ten
-    ran, so widening the set would start refusing healthy shards. The status a
-    scanner reports is also unchanged, so no reporter, no summary table and no
-    consumer of ``ScannerStatus`` sees anything new; the only behavior that
-    changes is this gate's own verdict, and only when the operator opted in.
+    ran, so any status-shaped expression of partial coverage would propagate into
+    shard refusal and start rejecting healthy shards, failing the merge far from
+    the code that caused it. That is the concrete cost of adding a
+    ``ScannerStatus`` member for this, and the reason none was added.
+
+    Worth being precise about the residual risk, because an earlier version of
+    this comment overstated it: ``_completed`` inspects a
+    ``ScannerTargetStatusInfo``, which declares no target counters, so it cannot
+    read coverage today by any route -- the protection is structural, not merely
+    conventional. Since the status a scanner reports is unchanged, no reporter, no
+    summary table and no consumer of ``ScannerStatus`` sees anything new; the only
+    behavior that changes is this gate's own verdict, and only when the operator
+    opted in. ``tests/unit/cli/test_merge.py`` pins the boundary from the merge
+    side.
 
     Status precedence between the two arms is explicit. Total loss satisfies the
     coverage condition too -- ``failed >= attempted`` implies ``failed > 0`` -- so

--- a/automated_security_helper/interactions/run_ash_scan.py
+++ b/automated_security_helper/interactions/run_ash_scan.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
 # ScanOptions — bundles all 40+ parameters; eliminates 7 None-rebinding stanzas
 # ---------------------------------------------------------------------------
 
+
 class ScanOptions(BaseModel):
     """All parameters for a single run_ash_scan invocation."""
 
@@ -140,9 +141,15 @@ class ScanOptions(BaseModel):
     def _coerce_absolute_path(cls, v):
         return Path(v).absolute()
 
-    @field_validator("scanners", "excluded_scanners", "output_formats",
-                     "config_overrides", "custom_build_arg", "ash_plugin_modules",
-                     mode="before")
+    @field_validator(
+        "scanners",
+        "excluded_scanners",
+        "output_formats",
+        "config_overrides",
+        "custom_build_arg",
+        "ash_plugin_modules",
+        mode="before",
+    )
     @classmethod
     def _none_to_empty_list(cls, v):
         return v if v is not None else []
@@ -185,15 +192,89 @@ _INCOMPLETE_SCANNER_STATUSES = frozenset(
 )
 
 
+def _partial_coverage(metric) -> tuple[int, int] | None:
+    """``(attempted, failed)`` when *metric* lost some of its input, else None.
+
+    The tri-state on ``targets_attempted`` is the whole content of this function.
+    ``None`` means the scanner does not track per-target outcomes and is making no
+    claim -- bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep,
+    cfn-nag and npm-audit are all in that state. Reading absence as "attempted 0,
+    therefore lost everything" would fail every scan on every repository the
+    moment the flag was turned on, which is the inverse of the defect being fixed
+    here.
+
+    Both counters are type-checked rather than trusted, matching what
+    ``unified_metrics.target_counts`` already does to the serialized counters it
+    reads. Two reasons, one of them load-bearing:
+
+    * ``bool`` is an ``int`` subclass, so ``True`` would otherwise read as one
+      attempted target and invent coverage that was never claimed.
+    * This function is reached through whatever ``get_unified_scanner_metrics``
+      returns, and the sibling test module patches that with MagicMocks whose
+      every attribute is present and truthy. Without the check, a PASSED bandit
+      built as a MagicMock would start reporting as a coverage failure and
+      ``test_helper_lists_only_incomplete_scanners_with_statuses`` would break --
+      a test asserting the correct thing, broken by the gate reading a mock's
+      auto-attribute as a count.
+
+    A failure count with no attempt count is a producer bug, not a third state:
+    there is no honest denominator to print, so it is not reported rather than
+    rendered as "3 of None".
+    """
+    attempted = getattr(metric, "targets_attempted", None)
+    failed = getattr(metric, "targets_failed", None)
+    if isinstance(attempted, bool) or not isinstance(attempted, int):
+        return None
+    if isinstance(failed, bool) or not isinstance(failed, int):
+        return None
+    if failed <= 0:
+        return None
+    return attempted, failed
+
+
 def incomplete_scanners(
     results: Optional[AshAggregatedResults],
 ) -> List[tuple[str, str]]:
     """(name, status) for every scanner that was selected and did not complete.
 
+    "Did not complete" covers two distinct failures, and it did not always cover
+    the second:
+
+    1. The scanner never produced a result -- status ERROR or MISSING.
+    2. The scanner ran, reported a status, and could not evaluate some of the
+       targets it was given.
+
+    Only (1) was selected on, because that is a status test and (2) does not
+    change the status. ``ScanResultsContainer.determine_status`` returns ERROR
+    only once ``targets_failed >= targets_attempted``, so a scanner that lost some
+    of its input keeps whatever the severity gate gave it -- normally PASSED --
+    and the gate could not see it. Measured on this repository: cdk-nag attempts
+    10 targets, fails 4, reports PASSED, and the gate exited 0. Two of those four
+    are real CloudFormation templates that went unscanned.
+
+    ``_INCOMPLETE_SCANNER_STATUSES`` is deliberately NOT widened to express (2),
+    and the reason is a caller rather than taste. ``cli.merge._completed`` imports
+    that set to answer a different question -- whether a shard's scanner ran at
+    all -- and ``_verify_shard_contributions`` refuses a merge where a shard
+    completed none of the scanners it owned. A scanner that lost one target of ten
+    ran, so widening the set would start refusing healthy shards. The status a
+    scanner reports is also unchanged, so no reporter, no summary table and no
+    consumer of ``ScannerStatus`` sees anything new; the only behavior that
+    changes is this gate's own verdict, and only when the operator opted in.
+
+    Status precedence between the two arms is explicit. Total loss satisfies the
+    coverage condition too -- ``failed >= attempted`` implies ``failed > 0`` -- so
+    an ERROR scanner would otherwise gain a parenthetical it never had and break
+    every existing assertion on that message. (1) wins and reports the bare
+    status.
+
     Read through ``get_unified_scanner_metrics`` rather than off
     ``results.scanner_results`` directly, so the gate and the report cannot
     disagree: that function is what every reporter and the metrics table already
-    use, and it is where excluded-versus-missing precedence is decided.
+    use, and it is where excluded-versus-missing precedence is decided. The target
+    counters are read from the same rows for the same reason -- ``ScannerMetrics``
+    is what the summary table prints, so the gate fails on exactly the numbers the
+    operator was shown rather than on a second, independently-derived count.
 
     Known limitation, measured rather than assumed. An allowlist narrowing --
     ``--scanners bandit`` -- does not mark the unselected scanners as excluded, so
@@ -211,14 +292,29 @@ def incomplete_scanners(
 
     Returns:
         Pairs in scanner-name order, empty when every selected scanner completed.
+        The second element is the scanner's own status for a status-based
+        incompleteness, and that status followed by the unevaluated-target counts
+        for a coverage-based one. It is a display string, not a status token:
+        both callers interpolate it into a message and neither parses it.
     """
     if results is None:
         return []
-    return [
-        (metric.scanner_name, metric.status)
-        for metric in get_unified_scanner_metrics(asharp_model=results)
-        if metric.status in _INCOMPLETE_SCANNER_STATUSES
-    ]
+
+    listed: list[tuple[str, str]] = []
+    for metric in get_unified_scanner_metrics(asharp_model=results):
+        if metric.status in _INCOMPLETE_SCANNER_STATUSES:
+            listed.append((metric.scanner_name, metric.status))
+            continue
+        shortfall = _partial_coverage(metric)
+        if shortfall is not None:
+            attempted, failed = shortfall
+            listed.append(
+                (
+                    metric.scanner_name,
+                    f"{metric.status} ({failed} of {attempted} targets unevaluated)",
+                )
+            )
+    return listed
 
 
 def _resolve_fail_on_incomplete_scanners(
@@ -267,6 +363,7 @@ def _severity_filters_finding(result, min_sev_rank: int) -> bool:
 # ---------------------------------------------------------------------------
 # Helper: resolve final AshLogLevel
 # ---------------------------------------------------------------------------
+
 
 def _load_config_file(opts: ScanOptions):
     """Load the config file a scan of *opts* would use, or None.
@@ -330,9 +427,11 @@ def _resolve_log_level(opts: ScanOptions) -> AshLogLevel:
         return AshLogLevel.VERBOSE
     if opts.debug:
         return AshLogLevel.DEBUG
-    if opts.quiet or opts.simple or opts.log_level in [
-        AshLogLevel.QUIET, AshLogLevel.ERROR, AshLogLevel.SIMPLE
-    ]:
+    if (
+        opts.quiet
+        or opts.simple
+        or opts.log_level in [AshLogLevel.QUIET, AshLogLevel.ERROR, AshLogLevel.SIMPLE]
+    ):
         return AshLogLevel.ERROR
     return opts.log_level
 
@@ -340,6 +439,7 @@ def _resolve_log_level(opts: ScanOptions) -> AshLogLevel:
 # ---------------------------------------------------------------------------
 # _setup_logger
 # ---------------------------------------------------------------------------
+
 
 def _setup_logger(opts: ScanOptions):
     from automated_security_helper.utils.log import get_logger
@@ -355,7 +455,8 @@ def _setup_logger(opts: ScanOptions):
             opts.progress
             and not opts.quiet
             and not opts.simple
-            and os.environ.get("ASH_IN_CONTAINER", "NO").upper() not in ["YES", "1", "TRUE"]
+            and os.environ.get("ASH_IN_CONTAINER", "NO").upper()
+            not in ["YES", "1", "TRUE"]
         ),
         use_color=opts.color,
         simple_format=simple_logging,
@@ -420,7 +521,9 @@ def _run_container_mode(
     # the config file on the host.  Passing the resolved value avoids a race where the
     # user mutates the config file between the host read and the container's own read.
     effective_fail_on_findings = (
-        opts.fail_on_findings if opts.fail_on_findings is not None else resolved_fail_on_findings
+        opts.fail_on_findings
+        if opts.fail_on_findings is not None
+        else resolved_fail_on_findings
     )
     effective_fail_on_incomplete_scanners = (
         opts.fail_on_incomplete_scanners
@@ -484,14 +587,20 @@ def _run_container_mode(
         )
 
     if hasattr(container_result, "returncode") and container_result.returncode != 0:
-        logger.error(f"Container execution failed with code {container_result.returncode}")
+        logger.error(
+            f"Container execution failed with code {container_result.returncode}"
+        )
         if hasattr(container_result, "stderr") and container_result.stderr:
             logger.error(f"Container stderr:\n{container_result.stderr}")
-            print(f"\n[bold red]Container Error Output:[/bold red]\n{container_result.stderr}")
+            print(
+                f"\n[bold red]Container Error Output:[/bold red]\n{container_result.stderr}"
+            )
         if hasattr(container_result, "stdout") and container_result.stdout:
             logger.debug(f"Container stdout:\n{container_result.stdout}")
             if opts.debug:
-                print(f"\n[bold blue]Container Standard Output:[/bold blue]\n{container_result.stdout}")
+                print(
+                    f"\n[bold blue]Container Standard Output:[/bold blue]\n{container_result.stdout}"
+                )
 
     if not opts.run:
         if hasattr(container_result, "returncode") and container_result.returncode != 0:
@@ -515,6 +624,7 @@ def _run_container_mode(
 # ---------------------------------------------------------------------------
 # _run_nix_mode
 # ---------------------------------------------------------------------------
+
 
 def _run_nix_mode(opts: ScanOptions, logger) -> AshAggregatedResults:
     """Run the scan inside a Nix shell that supplies the pinned scanner toolchain.
@@ -559,7 +669,10 @@ def _run_nix_mode(opts: ScanOptions, logger) -> AshAggregatedResults:
 # _run_local_mode
 # ---------------------------------------------------------------------------
 
-def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Optional[bool]]:
+
+def _run_local_mode(
+    opts: ScanOptions, logger
+) -> tuple[AshAggregatedResults, Optional[bool]]:
     from automated_security_helper.core.orchestrator import ASHScanOrchestrator
 
     _offline_was_set = False
@@ -570,6 +683,7 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
     _changed_file_set = None
     if opts.changed_files_only:
         from automated_security_helper.utils.get_scan_set import get_changed_files
+
         changed_paths = get_changed_files(base_ref=opts.base_ref, cwd=opts.source_dir)
         if changed_paths is not None:
             _changed_file_set = {
@@ -592,7 +706,9 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
                 ]
                 for def_path in def_paths:
                     if def_path.exists():
-                        logger.info(f"Using config file found at: {def_path.as_posix()}")
+                        logger.info(
+                            f"Using config file found at: {def_path.as_posix()}"
+                        )
                         config = def_path.as_posix()
                         break
                 if config is not None:
@@ -601,24 +717,34 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
             logger.info(f"Using config file specified at: {config}")
 
         if opts.config_overrides:
-            logger.info(f"Applying {len(opts.config_overrides or [])} configuration overrides")
+            logger.info(
+                f"Applying {len(opts.config_overrides or [])} configuration overrides"
+            )
 
         final_log_level = _resolve_log_level(opts)
         final_scanners = list(opts.scanners or [])
         if opts.mode == RunMode.precommit:
-            fast_scanners = ["bandit", "detect-secrets", "checkov", "cdk-nag", "npm-audit"]
+            fast_scanners = [
+                "bandit",
+                "detect-secrets",
+                "checkov",
+                "cdk-nag",
+                "npm-audit",
+            ]
             final_scanners = list(set(final_scanners + fast_scanners))
 
         final_show_progress = (
             opts.progress
-            and final_log_level not in [
+            and final_log_level
+            not in [
                 AshLogLevel.QUIET,
                 AshLogLevel.SIMPLE,
                 AshLogLevel.VERBOSE,
                 AshLogLevel.DEBUG,
             ]
             and os.environ.get("CI") is None
-            and os.environ.get("ASH_IN_CONTAINER", "NO").upper() not in ["YES", "1", "TRUE"]
+            and os.environ.get("ASH_IN_CONTAINER", "NO").upper()
+            not in ["YES", "1", "TRUE"]
         )
 
         orchestrator = ASHScanOrchestrator.create(
@@ -642,7 +768,11 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
             simple_mode=opts.simple,
             show_summary=opts.show_summary,
             color_system=(
-                "windows" if platform.system() == "Windows" else "auto" if opts.color else None
+                "windows"
+                if platform.system() == "Windows"
+                else "auto"
+                if opts.color
+                else None
             ),
             offline=(opts.offline if opts.offline is not None else is_offline_mode()),
             existing_results_path=(
@@ -675,13 +805,17 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
         if not opts.quiet and not opts.simple:
             logger.debug(f"Running phases: {phases_to_run}")
 
-        results = orchestrator.execute_scan(phases=cast(List[ExecutionPhaseType], phases_to_run))
+        results = orchestrator.execute_scan(
+            phases=cast(List[ExecutionPhaseType], phases_to_run)
+        )
 
         if opts.simple and not opts.quiet:
             typer.echo("\nASH scan completed.")
 
         if _changed_file_set and results is not None:
-            results = _filter_results_to_changed_files(results, _changed_file_set, opts.source_dir)
+            results = _filter_results_to_changed_files(
+                results, _changed_file_set, opts.source_dir
+            )
             sarif_path = opts.output_dir / "reports" / "ash.sarif"
             if sarif_path.exists() and results.sarif:
                 sarif_path.write_text(
@@ -705,7 +839,9 @@ def _run_local_mode(opts: ScanOptions, logger) -> tuple[AshAggregatedResults, Op
         sys.exit(3)
     except Exception as e:
         logger.exception(e)
-        print(f"[bold red]ERROR (1) Exiting due to exception during ASH scan: {e}[/bold red]")
+        print(
+            f"[bold red]ERROR (1) Exiting due to exception during ASH scan: {e}[/bold red]"
+        )
         sys.exit(1)
     finally:
         if _offline_was_set:
@@ -1000,6 +1136,7 @@ def _print_workspace_summary(
 # scan of a repository a working scan flags at HIGH.
 # ---------------------------------------------------------------------------
 
+
 def _compute_exit_code(
     results: Optional[AshAggregatedResults],
     opts: ScanOptions,
@@ -1069,7 +1206,9 @@ def _compute_exit_code(
                     and hasattr(_cfg.global_settings, "severity_threshold")
                     and _cfg.global_settings.severity_threshold
                 ):
-                    _severity_threshold = _cfg.global_settings.severity_threshold.upper()
+                    _severity_threshold = (
+                        _cfg.global_settings.severity_threshold.upper()
+                    )
 
             # SARIF levels: error -> critical/high, warning -> medium, note -> low, none -> info
             _THRESHOLD_QUALIFYING_LEVELS = {
@@ -1083,10 +1222,18 @@ def _compute_exit_code(
                 _severity_threshold, {"error", "warning"}
             )
             _SEVERITY_RANK_FOR_THRESHOLD = {
-                "CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "INFO": 0,
+                "CRITICAL": 4,
+                "HIGH": 3,
+                "MEDIUM": 2,
+                "LOW": 1,
+                "INFO": 0,
             }
             _THRESHOLD_MIN_RANK = {
-                "ALL": 0, "LOW": 1, "MEDIUM": 2, "HIGH": 3, "CRITICAL": 4,
+                "ALL": 0,
+                "LOW": 1,
+                "MEDIUM": 2,
+                "HIGH": 3,
+                "CRITICAL": 4,
             }
             _min_rank = _THRESHOLD_MIN_RANK.get(_severity_threshold, 2)
 
@@ -1115,7 +1262,7 @@ def _compute_exit_code(
             sarif = getattr(results, "sarif", None)
             if sarif is None or not getattr(sarif, "runs", None):
                 has_qualifying = True
-            for run in (getattr(sarif, "runs", []) if not has_qualifying else []):
+            for run in getattr(sarif, "runs", []) if not has_qualifying else []:
                 for result in getattr(run, "results", []):
                     if _severity_filters_finding(result, min_sev_rank):
                         has_qualifying = True
@@ -1135,6 +1282,7 @@ def _compute_exit_code(
 # ---------------------------------------------------------------------------
 # _print_summary
 # ---------------------------------------------------------------------------
+
 
 def _print_summary(
     results: Optional[AshAggregatedResults],
@@ -1156,7 +1304,9 @@ def _print_summary(
     if not opts.quiet:
         if results and hasattr(results, "validation_checkpoints"):
             config_warnings = [
-                cp for cp in results.validation_checkpoints if cp.get("type") == "config_warning"
+                cp
+                for cp in results.validation_checkpoints
+                if cp.get("type") == "config_warning"
             ]
             if config_warnings:
                 print("\n[bold yellow]⚠️  CONFIGURATION WARNING ⚠️[/bold yellow]")
@@ -1164,7 +1314,9 @@ def _print_summary(
                     print(f"[yellow]  {cw['message']}[/yellow]")
                 print("")
 
-        print(f"\n[cyan]=== ASH Scan Completed in {duration_str}: Next Steps ===[/cyan]")
+        print(
+            f"\n[cyan]=== ASH Scan Completed in {duration_str}: Next Steps ===[/cyan]"
+        )
         print("View detailed findings...")
         print(f"  - SARIF: '{out_dir_alias}/reports/ash.sarif'")
         print(f"  - JUnit: '{out_dir_alias}/reports/ash.junit.xml'")
@@ -1176,7 +1328,9 @@ def _print_summary(
     if actionable_findings > 0:
         print("\n[magenta]=== Actionable findings detected! ===[/magenta]")
         print("To investigate...")
-        print("  1. Open one of the summary reports for a user-friendly table of the findings:")
+        print(
+            "  1. Open one of the summary reports for a user-friendly table of the findings:"
+        )
         print(f"    - HTML report of all findings: '{out_dir_alias}/reports/ash.html'")
         print(f"    - Markdown summary: '{out_dir_alias}/reports/ash.summary.md'")
         print(f"    - Text summary: '{out_dir_alias}/reports/ash.summary.txt'")
@@ -1194,6 +1348,7 @@ def _print_summary(
 # ---------------------------------------------------------------------------
 # _filter_results_to_changed_files (unchanged helper)
 # ---------------------------------------------------------------------------
+
 
 def _filter_results_to_changed_files(
     results: "AshAggregatedResults",
@@ -1233,6 +1388,7 @@ def _filter_results_to_changed_files(
 # ---------------------------------------------------------------------------
 # run_ash_scan — top-level entry point (~50 lines)
 # ---------------------------------------------------------------------------
+
 
 def run_ash_scan(
     source_dir: str | Path | None = None,
@@ -1294,8 +1450,14 @@ def run_ash_scan(
     scan_start_time = time.time()
 
     # Resolve cwd-based defaults at call time (not import time).
-    _source_dir: Path = Path(source_dir).absolute() if source_dir is not None else Path.cwd()
-    _output_dir: Path = Path(output_dir).absolute() if output_dir is not None else Path.cwd().joinpath(".ash", "ash_output")
+    _source_dir: Path = (
+        Path(source_dir).absolute() if source_dir is not None else Path.cwd()
+    )
+    _output_dir: Path = (
+        Path(output_dir).absolute()
+        if output_dir is not None
+        else Path.cwd().joinpath(".ash", "ash_output")
+    )
 
     opts = ScanOptions(
         source_dir=_source_dir,
@@ -1416,17 +1578,23 @@ def run_ash_scan(
     )
 
     if opts.show_summary:
-        scanner_metrics = get_unified_scanner_metrics(asharp_model=results) if results else []
+        scanner_metrics = (
+            get_unified_scanner_metrics(asharp_model=results) if results else []
+        )
         actionable_findings = sum(item.actionable for item in scanner_metrics)
         _print_summary(results, opts, scan_start_time, actionable_findings)
 
         if exit_code == 2 and not opts.quiet:
             actionable_count = sum(
                 item.actionable
-                for item in (get_unified_scanner_metrics(asharp_model=results) if results else [])
+                for item in (
+                    get_unified_scanner_metrics(asharp_model=results) if results else []
+                )
             )
             print("\n[yellow]=== ASH Exit Codes ===[/yellow]")
-            print("  0: Success - No actionable findings or not configured to fail on findings")
+            print(
+                "  0: Success - No actionable findings or not configured to fail on findings"
+            )
             print("  1: Error during execution")
             print(
                 f"  2: Actionable findings detected when configured with `fail_on_findings: true`."
@@ -1449,20 +1617,29 @@ def run_ash_scan(
             else []
         )
         if _incomplete:
+            # "did not run" would be false for the coverage case: that scanner ran,
+            # reported a status, and could not read some of its targets. Sending an
+            # operator to install a tool that is already installed is the specific
+            # wrong turn this wording avoids.
             print(
                 "\n[bold red]ERROR (1) Exiting because the scan was incomplete: "
-                f"{len(_incomplete)} selected scanner(s) did not run[/bold red]"
+                f"{len(_incomplete)} selected scanner(s) did not evaluate "
+                "everything they were given[/bold red]"
             )
             for _name, _status in _incomplete:
                 print(f"  [red]{_name}: {_status}[/red]")
             print(
                 "[yellow]ERROR means the scanner ran and failed; MISSING means its "
-                "dependencies were unavailable. Install the missing tools, exclude "
-                "the scanners with --exclude-scanners, or drop "
-                "--fail-on-incomplete-scanners to accept a partial scan.[/yellow]"
+                "dependencies were unavailable; a target count means the scanner ran "
+                "but could not read that many of its inputs. Install the missing "
+                "tools, fix or exclude the unreadable targets, exclude the scanners "
+                "with --exclude-scanners, or drop --fail-on-incomplete-scanners to "
+                "accept a partial scan.[/yellow]"
             )
         else:
-            print("[bold red]ERROR (1) Exiting due to exception during ASH scan[/bold red]")
+            print(
+                "[bold red]ERROR (1) Exiting due to exception during ASH scan[/bold red]"
+            )
 
     if exit_code != 0:
         sys.exit(exit_code)

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -18,6 +18,7 @@ from automated_security_helper.plugin_modules.ash_builtin.reporters.report_conte
 from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
     markdown_workspace_section,
 )
+from automated_security_helper.core.unified_metrics import coverage_shortfalls
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
 
@@ -225,6 +226,37 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
                 )
 
             md_parts.append("")
+
+            # Scanners that could not evaluate part of their input, listed after the table rather
+            # than as an extra column. The table has a fixed ten-column shape that several tests
+            # and any downstream consumer parse positionally, and a shortfall is exceptional
+            # rather than per-row data.
+            #
+            # This is the artifact a human is most likely to read -- it gets pasted into pull
+            # requests -- and the status column cannot carry the fact: ``determine_status`` only
+            # reports ERROR once every attempted target failed, so a scanner that lost some of its
+            # targets appears here as PASSED. Measured on this repository, cdk-nag attempts 10
+            # targets, fails 4, and reports PASSED.
+            #
+            # Emitted only when there is something to report, and NOT suppressed in compact mode.
+            # Compact mode exists to drop noise -- clean rows and skipped scanners -- and an
+            # incomplete-coverage notice is the opposite of noise. Hiding it there would remove it
+            # from precisely the rendering that gets pasted into a pull request.
+            shortfalls = coverage_shortfalls(model)
+            if shortfalls:
+                md_parts.append("### Incomplete coverage")
+                md_parts.append("")
+                md_parts.append(
+                    "These scanners could not evaluate part of their input. The findings they "
+                    "did report are real, but the set is known to be partial:"
+                )
+                md_parts.append("")
+                for scanner_name, attempted, failed in shortfalls:
+                    md_parts.append(
+                        f"- **{scanner_name}**: evaluated {attempted - failed} of {attempted} "
+                        f"target(s); {failed} could not be evaluated"
+                    )
+                md_parts.append("")
 
             # Add top hotspots (files with most findings)
             top_hotspots = emitter.get_top_hotspots(

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -12,13 +12,13 @@ from automated_security_helper.base.reporter_plugin import (
     ReporterPluginConfigBase,
     ReporterWorkspaceBehaviour,
 )
+from automated_security_helper.core.unified_metrics import coverage_shortfalls
 from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
     ReportContentEmitter,
 )
 from automated_security_helper.plugin_modules.ash_builtin.reporters.workspace_section import (
     markdown_workspace_section,
 )
-from automated_security_helper.core.unified_metrics import coverage_shortfalls
 from automated_security_helper.plugins.decorators import ash_reporter_plugin
 
 
@@ -37,7 +37,9 @@ class MarkdownReporterConfigOptions(ReporterOptionsBase):
     use_collapsible_details: bool = (
         True  # Use HTML details/summary tags for detailed findings
     )
-    compact: bool = False  # When True, produce a shorter report suitable for PR comments
+    compact: bool = (
+        False  # When True, produce a shorter report suitable for PR comments
+    )
 
 
 class MarkdownReporterConfig(ReporterPluginConfigBase):
@@ -217,7 +219,7 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
 
                 threshold_text = f"{result['threshold']} ({result['threshold_source']})"
 
-                safe_scanner = result['scanner_name'].replace("|", "\\|")
+                safe_scanner = result["scanner_name"].replace("|", "\\|")
                 safe_threshold = threshold_text.replace("|", "\\|")
                 md_parts.append(
                     f"| {safe_scanner} | {result['suppressed']} | {result['critical']} | {result['high']} | "

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/markdown_reporter.py
@@ -235,10 +235,13 @@ class MarkdownReporter(ReporterPluginBase[MarkdownReporterConfig]):
             # rather than per-row data.
             #
             # This is the artifact a human is most likely to read -- it gets pasted into pull
-            # requests -- and the status column cannot carry the fact: ``determine_status`` only
-            # reports ERROR once every attempted target failed, so a scanner that lost some of its
-            # targets appears here as PASSED. Measured on this repository, cdk-nag attempts 10
-            # targets, fails 4, and reports PASSED.
+            # requests -- and the status column cannot carry the fact. ``determine_status`` only
+            # reports ERROR once every attempted target failed, so partial loss leaves the status
+            # to the severity gate, and the value it lands on says nothing either way. Measured on
+            # this repository, cdk-nag attempts 10 targets and cannot evaluate 4, and its row reads
+            # FAILED -- on 16 actionable findings from the six it did read. A row reading PASSED
+            # would have been just as silent about the four. That is why this is a separate
+            # section: no status value is the right place to put it.
             #
             # Emitted only when there is something to report, and NOT suppressed in compact mode.
             # Compact mode exists to drop noise -- clean rows and skipped scanners -- and an

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
@@ -119,6 +119,18 @@ class ReportContentEmitter:
                     "status": metrics.status,
                     "excluded": metrics.excluded,
                     "dependencies_missing": metrics.dependencies_missing,
+                    # How much of its input the scanner actually evaluated. Every other key here
+                    # describes what was found; these two describe how much was looked at, and
+                    # without them a report cannot distinguish a clean scan from one that
+                    # examined a fraction of its targets. ``determine_status`` only reports ERROR
+                    # once every attempted target failed, so a partial loss reaches ``status`` as
+                    # PASSED and reached these rows as nothing at all.
+                    #
+                    # ``targets_attempted`` is None for a scanner that does not track per-target
+                    # outcomes, and is serialized as null rather than 0 so a consumer can tell
+                    # "made no claim" from "attempted none".
+                    "targets_attempted": metrics.targets_attempted,
+                    "targets_failed": metrics.targets_failed,
                 }
             )
 

--- a/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/reporters/report_content_emitter.py
@@ -123,8 +123,9 @@ class ReportContentEmitter:
                     # describes what was found; these two describe how much was looked at, and
                     # without them a report cannot distinguish a clean scan from one that
                     # examined a fraction of its targets. ``determine_status`` only reports ERROR
-                    # once every attempted target failed, so a partial loss reaches ``status`` as
-                    # PASSED and reached these rows as nothing at all.
+                    # once every attempted target failed, so a partial loss leaves ``status`` to
+                    # the severity gate -- PASSED or FAILED depending only on what the targets it
+                    # DID read contained -- and reached these rows as nothing at all.
                     #
                     # ``targets_attempted`` is None for a scanner that does not track per-target
                     # outcomes, and is serialized as null rather than 0 so a consumer can tell

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from importlib.metadata import PackageNotFoundError, packages_distributions, requires
-from typing import Annotated, ClassVar, List, Literal
+from typing import Annotated, Any, ClassVar, List, Literal
 from pathlib import Path
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -186,6 +186,78 @@ def _unevaluated_rule_notifications(
     return notifications
 
 
+def _is_unevaluated_result(result: Result) -> bool:
+    """Whether this result records a rule that threw instead of reaching a verdict.
+
+    Reads the structured ``compliance`` field rather than matching on the description's text.
+    The wrapper sets ``compliance`` for exactly this kind of dispatch -- it is what
+    ``_level_and_kind`` branches on -- and a text match would be a second, independent copy of
+    cdk-nag's wording that can drift away from the first.
+    """
+    from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+    finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
+    return finding_props.get("compliance") == NOT_EVALUATED
+
+
+def _rule_scoped_description(finding_props: dict, rule_id: str) -> str:
+    """The rule's description with nothing in it that varies between occurrences.
+
+    ``rule_info`` IS THE REPORT'S DESCRIPTION VERBATIM, AND THAT IS ONLY SOMETIMES RULE-SCOPED
+    ---------------------------------------------------------------------------------------
+    ``rule_info`` is ``violation.description`` from ``validation-report.json``, and cdk-nag
+    3.0.2 builds that field two different ways in ``package/lib/nag-pack.js``'s
+    ``addViolation``::
+
+        const description = errorMessage
+            ? `Rule threw an error during validation. ${this.verbose ? errorMessage : '...'}`
+            : this.verbose ? `${params.info} ${params.explanation}` : params.info;
+
+    The ordinary branch is rule-scoped and safe to reuse: ``info`` and ``explanation`` are
+    static string literals declared once per rule. Measured against the bundled cdk-nag 3.0.2
+    tarball, ``package/lib`` holds 463 ``info:`` and 463 ``explanation:`` occurrences and NONE
+    of them interpolates -- so for a rule that was evaluated, the description cannot carry
+    anything about the template it was evaluated against.
+
+    The error branch is NOT rule-scoped. ``applyRule``'s ``catch`` calls
+    ``addViolation(ruleId, params, error.message)``, and :func:`_build_nag_pack` constructs
+    every pack with ``verbose=True``, so the rule's own exception text is interpolated in rather
+    than the fixed intrinsic-function hint. Every interpolating throw site reachable from that
+    ``catch`` embeds template-derived data:
+
+    * ``nag-rules.js:50`` -- ``JSON.stringify(resolvedValue)``, the parameter value as resolved
+      out of the template being scanned
+    * ``rules/lambda/LambdaLatestVersion.js:24`` and ``:48`` -- the resource's ``runtime``
+    * ``rules/lex/LexBotAliasEncryptedConversationLogs.js:57`` -- a resource LOGICAL ID, which
+      is the same class of value the tags note in :func:`_reporting_descriptor_for` says must
+      never reach a descriptor
+
+    plus any unforeseen exception and anything a third-party pack throws. ASH's own fixture
+    already carries the contamination: ``tests/unit/utils/test_cdk_nag_unevaluated_rule.py``
+    holds a description reading ``non-primitive value "{"Ref":"VolumeEncrypted"}"``, where
+    ``VolumeEncrypted`` is a parameter of the scanned template.
+
+    So a not-evaluated row's description is discarded here and a rule-scoped sentence is
+    constructed instead. Nothing is lost: the error text stays on the result's own message,
+    where it is per-occurrence data sitting in a per-occurrence place, and it is what a reader
+    diagnosing the failure needs. Stripping cdk-nag's ``Rule threw an error during validation.``
+    prefix off the front and keeping that was the alternative, and it was rejected -- it
+    re-derives a rule-scoped string by parsing a string whose shape ``addViolation`` controls,
+    so a wording change upstream would silently start leaking the exception text again.
+
+    Returns ``""`` when the report supplied no description at all, so a caller can tell "the
+    report said nothing" apart from "we constructed this".
+    """
+    from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+    if finding_props.get("compliance") == NOT_EVALUATED:
+        return (
+            f"cdk-nag threw while evaluating {rule_id}, so this scan reached no verdict on it. "
+            "The error text differs per template and is carried on each result's message."
+        )
+    return str(finding_props.get("rule_info") or "").strip()
+
+
 def _reporting_descriptor_for(
     result: Result, tool_name: str, tool_type: str
 ) -> ReportingDescriptor:
@@ -234,26 +306,74 @@ def _reporting_descriptor_for(
     onto every result. Forwarding made both appear in one list, disagreeing; taking the value
     makes the descriptor agree with the results. A plain ``str`` caller is unaffected --
     ``getattr`` falls back to the object itself.
+
+    THE DESCRIPTIONS USED TO FORWARD THE RESULT'S MESSAGE, AND MUST NOT
+    ------------------------------------------------------------------
+    Fixing ``tags`` left the same defect in place two fields below it. ``shortDescription`` and
+    ``fullDescription`` both read ``result.message.root.text``, and ``fullDescription`` also
+    read ``result.message.root.markdown``.
+
+    Before the not-evaluated work that was harmless, which is why it survived the tags review.
+    The message was ``rule_info + "\\n\\nException Reason: " + exception_reason``, and on the
+    validation-report path ``exception_reason`` is the literal ``"N/A"`` for every row, so both
+    halves were rule-scoped and two results for one rule carried the same message.
+
+    ``utils.cdk_nag_wrapper._result_message_text`` broke that. A not-evaluated result now opens
+    its message with the template's own path -- ``f"'{target}' was NOT evaluated for rule ..."``
+    where ``target`` is ``cfn_file_rel_path``, bound per template. One rule that raises while
+    validating two templates therefore produces two results under one ``ruleId`` whose messages
+    differ, exactly one descriptor is built from whichever the aggregation yielded first, and
+    ``rules[].shortDescription.text`` then named one arbitrary template as the DEFINITION of a
+    rule that failed on both.
+
+    The constructing-not-forwarding argument above covered ``tags`` only, and the claim that the
+    descriptor is "a pure function of the rule id, the pack and the tool" was false for this
+    path while these three fields forwarded. It is now a pure function of the rule id, the pack,
+    the rule level, the rule's own description and the tool -- the description being rule-scoped
+    is what :func:`_rule_scoped_description` establishes, and it is NOT simply ``rule_info``,
+    because ``rule_info`` is contaminated on the not-evaluated path as well.
+
+    WHY THE CALLER PICKS THE REPRESENTATIVE RESULT
+    ---------------------------------------------
+    One rule can produce BOTH kinds of row in a single scan -- raising on one template while
+    reaching a verdict on another, or on two constructs of one template. The two rows then carry
+    genuinely different rule-scoped descriptions (the rule's real text versus the constructed
+    not-evaluated sentence), so which one becomes the descriptor would still be an ordering even
+    though neither value is per-occurrence. ``scan()`` removes that last ordering by preferring
+    an evaluated row as the rule's representative, which is also the better answer: the rule's
+    real description is used whenever any template managed to evaluate it.
     """
     finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
     pack = str(finding_props.get("pack", "") or "")
     rule_level = str(finding_props.get("rule_level", "rule"))
+    rule_description = _rule_scoped_description(
+        finding_props, result.ruleId or "unknown"
+    )
 
     return ReportingDescriptor(
         id=result.ruleId,
-        shortDescription=MultiformatMessageString(text=result.message.root.text),
-        fullDescription=MultiformatMessageString(
-            text=result.message.root.text,
-            markdown=result.message.root.markdown,
-        ),
+        # NOT ``result.message.root.text``. See the description note in the docstring: the
+        # message is built per occurrence and names the template, so forwarding it put one
+        # template's path in the definition of a rule that failed on several.
+        shortDescription=MultiformatMessageString(text=rule_description or "unknown"),
+        # ``markdown`` is deliberately not set. It used to forward
+        # ``result.message.root.markdown``, a second per-occurrence channel into the same
+        # object. The wrapper builds its ``Message1`` with ``text`` only, so that read returned
+        # None on every finding ever scanned and the forwarding carried nothing -- but it would
+        # have started carrying the template's path the moment the wrapper set the field.
+        fullDescription=MultiformatMessageString(text=rule_description or "unknown"),
         helpUri=_rule_help_uri(result.ruleId or "", pack, rule_level),
         properties=PropertyBag(
             pack=pack,
             rule_level=finding_props.get("rule_level", "unknown"),
-            rule_info=finding_props.get("rule_info", "unknown"),
+            # The rule-scoped description, not the raw ``rule_info``. On a not-evaluated row
+            # the raw value carries cdk-nag's exception text, which is template-derived, so
+            # this field had the same leak the two descriptions did.
+            rule_info=rule_description or "unknown",
             # Every entry is a fact about the RULE. Listed literally, in a fixed order, so the
-            # descriptor is a pure function of the rule id, the pack and the tool -- which is
-            # what makes two runs over identical input produce identical bytes.
+            # descriptor is a pure function of the rule id, the pack, the rule level, the
+            # rule's own description and the tool -- which is what makes two runs over
+            # identical input produce identical bytes.
             tags=[
                 "aws",
                 "cdk",
@@ -777,20 +897,34 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
             target_type=target_type,
         )
         # Create SARIF report
-        rules: List[ReportingDescriptor] = []
-        rule_map = {}
+        # One descriptor per rule id, built from a chosen representative rather than from
+        # whichever result the flatten above happened to yield first.
+        #
+        # A rule can appear as both an evaluated row and a not-evaluated one in a single scan --
+        # raising on one template while reaching a verdict on another, or on two constructs of
+        # one template. Those two rows carry different descriptions, so under first-wins the
+        # descriptor's text depended on template iteration order. Preferring the evaluated row
+        # makes it depend on a fact instead: the rule's real description is used whenever any
+        # template managed to evaluate it, and the constructed not-evaluated sentence only when
+        # none did.
+        #
+        # Assigning into an existing key leaves its insertion position alone, so the rules list
+        # keeps the first-encounter order it had before.
+        rule_reps: dict[Any, Result] = {}
         for result in sarif_results:
-            if result.ruleId in rule_map:
-                continue
-            rule_map[result.ruleId] = result
-
-            rules.append(
-                _reporting_descriptor_for(
-                    result,
-                    tool_name=self.config.name,
-                    tool_type=self.tool_type or "UNKNOWN",
-                )
+            current = rule_reps.get(result.ruleId)
+            if current is None or (
+                _is_unevaluated_result(current) and not _is_unevaluated_result(result)
+            ):
+                rule_reps[result.ruleId] = result
+        rules: List[ReportingDescriptor] = [
+            _reporting_descriptor_for(
+                representative,
+                tool_name=self.config.name,
+                tool_type=self.tool_type or "UNKNOWN",
             )
+            for representative in rule_reps.values()
+        ]
         tool = Tool(
             driver=ToolComponent(
                 name="ash-cdk-nag-wrapper",

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -196,15 +196,44 @@ def _reporting_descriptor_for(
     nothing in the suite did that. Two of its three defects were invisible for exactly that
     reason.
 
-    ``tags`` reads the result's own property bag. It used to read ``finding_props["tags"]``,
-    and ``finding_props`` is ``_NagFinding.as_dict()``, which has no ``tags`` key -- so that
-    lookup returned its ``[]`` default every single time. It looked like it forwarded the
-    finding's tags and forwarded nothing, which is why the pack name never reached the rule
-    even though the wrapper had been putting it on the result all along.
+    ``tags`` USED TO FORWARD THE RESULT'S OWN TAGS, AND MUST NOT
+    -----------------------------------------------------------
+    A first attempt read ``finding_props["tags"]``, and ``finding_props`` is
+    ``_NagFinding.as_dict()``, which has no ``tags`` key -- so that lookup returned its ``[]``
+    default every single time, and the pack the wrapper had been writing onto each result never
+    reached the rule. The obvious repair, ``list(result.properties.tags or []) + [...]``, fixed
+    the pack and introduced a worse defect, so neither shape is used now.
 
-    ``pack`` is also written as a labelled property. The pack is present in ``tags`` too, but
-    only as one unlabelled string among nine, so a consumer cannot tell it apart from the
-    resource id or the resource type sitting beside it; a named field can be read.
+    The result's tag list is built per occurrence, in ``utils.cdk_nag_wrapper``, and two of its
+    nine entries are per-occurrence values: the resource's logical id and its
+    ``AWS::*::*`` type. A descriptor is built once per unique ``ruleId`` -- ``scan()`` keys a
+    ``rule_map`` and ``continue``s on a repeat -- so forwarding those two stamps ONE resource's
+    identity into the definition of a rule that fired on many. Measured on this repository:
+    ``HIPAA.Security-IAMNoInlinePolicy`` fires on 35 results, and the forwarding put
+    ``ConfigKeyAccessB463082D`` and ``AWS::IAM::Policy`` on its rule descriptor -- whichever
+    result the aggregation happened to yield first. That is wrong for any consumer reading
+    ``rules[].properties``, and because "first" is an ordering rather than a fact, two runs over
+    identical input could disagree. ``tests/unit/plugin_modules/ash_builtin/
+    test_cdk_nag_sarif_attribution.py`` pins byte-identical descriptors across two runs.
+
+    So the tags are CONSTRUCTED from the rule-scoped facts this function already holds rather
+    than inherited and filtered. Filtering was the alternative and was rejected: this function is
+    not given the resource id or the resource type, so it could only drop them positionally, and
+    a positional rule silently stops working the next time the wrapper's list changes shape.
+    Constructing cannot leak a per-occurrence value because it never sees one.
+
+    Dropping the forwarding costs nothing the descriptor needed. The pack is the fact that was
+    supposed to arrive, and it arrives twice over -- as the labelled ``pack`` property and as
+    ``pack::<name>`` -- so a consumer can read it without guessing which unlabelled string it is.
+    The two entries that are genuinely per-occurrence remain on the results, where they belong
+    and where they were never lost.
+
+    ``tool_type`` takes ``.value``. ``ScannerToolType`` subclasses ``str``, but ``Enum.__str__``
+    still wins for a mixin enum, so an interpolated member renders
+    ``tool_type::ScannerToolType.IAC`` while the wrapper writes the literal ``tool_type::IAC``
+    onto every result. Forwarding made both appear in one list, disagreeing; taking the value
+    makes the descriptor agree with the results. A plain ``str`` caller is unaffected --
+    ``getattr`` falls back to the object itself.
     """
     finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
     pack = str(finding_props.get("pack", "") or "")
@@ -222,11 +251,18 @@ def _reporting_descriptor_for(
             pack=pack,
             rule_level=finding_props.get("rule_level", "unknown"),
             rule_info=finding_props.get("rule_info", "unknown"),
-            tags=list(result.properties.tags or [])
-            + [
+            # Every entry is a fact about the RULE. Listed literally, in a fixed order, so the
+            # descriptor is a pure function of the rule id, the pack and the tool -- which is
+            # what makes two runs over identical input produce identical bytes.
+            tags=[
+                "aws",
+                "cdk",
+                "cdk-nag",
+                pack or "unknown",
+                result.ruleId or "unknown",
                 f"pack::{pack}" if pack else "pack::unknown",
                 f"tool_name::{tool_name}",
-                f"tool_type::{tool_type}",
+                f"tool_type::{getattr(tool_type, 'value', tool_type)}",
             ],
         ),
     )

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -17,9 +17,15 @@ from automated_security_helper.core.exceptions import ScannerError
 from automated_security_helper.schemas.sarif_schema_model import (
     ArtifactLocation,
     Invocation,
+    Level,
+    Message,
+    Message1,
     MultiformatMessageString,
+    Notification,
     PropertyBag,
     ReportingDescriptor,
+    ReportingDescriptorReference,
+    ReportingDescriptorReference3,
     Result,
     Run,
     SarifReport,
@@ -98,8 +104,8 @@ def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
 
     The CDK's policy-validation guide is the correct destination for those: it documents the
     plugin, the shared validation report, and the ``Validations.of(scope).acknowledge()``
-    mechanism that governs a CloudFormation Validate finding. It is also the right destination
-    for a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
+    mechanism that governs a CloudFormation Validate finding. It is also the right fallback for
+    a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
     such a plugin implements.
 
     A finding with NO pack recorded keeps the previous destination, and that is deliberately
@@ -113,6 +119,71 @@ def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
     if not pack or _rule_is_from_pack(rule_id, pack):
         return f"{_CDK_NAG_RULES_URL}#{str(rule_level).lower()}s"
     return _CDK_POLICY_VALIDATION_URL
+
+
+def _unevaluated_rule_notifications(
+    results: list[Result],
+) -> list[Notification]:
+    """One SARIF notification per rule that could not be evaluated.
+
+    WHY THE RESULT ALONE IS NOT ENOUGH
+    ----------------------------------
+    A ``notApplicable`` result says "this one rule reached no verdict on this one resource",
+    and that is true but easy to miss: it sits in the same results array as the findings, at a
+    severity of ``none``, and most report surfaces sort or filter by severity. The fact a reader
+    needs is coarser -- "part of this scan did not run" -- and it belongs where a reader looks
+    for facts about the run.
+
+    SARIF has exactly that place, and the schema says so in its own words. ``invocation``'s
+    ``toolExecutionNotifications`` is "A list of runtime conditions detected by the tool during
+    the analysis", and ``notification.associatedRule`` is "A reference used to locate the rule
+    descriptor associated with this notification". A rule raising mid-evaluation is a runtime
+    condition, and the rule it happened to is the thing to associate it with. This is the
+    representation SARIF already defines for the case, so it is used rather than a bespoke
+    property.
+
+    ``level=error`` rather than ``warning``. For a security scanner, a rule that silently did
+    not run is the more serious of the two facts it can report -- a violation at least tells you
+    what to fix. ``warning`` is the field's default, so this is a deliberate override.
+
+    Deduplicated by rule id. One rule that cannot resolve a property will raise for every
+    construct that shares the shape, and the run-level statement is about the rule, not about
+    each occurrence -- the per-resource detail is already carried by the results themselves.
+    """
+    from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+    notifications: list[Notification] = []
+    seen: set[str] = set()
+    for result in results:
+        finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
+        if finding_props.get("compliance") != NOT_EVALUATED:
+            continue
+        rule_id = result.ruleId or ""
+        if rule_id in seen:
+            continue
+        seen.add(rule_id)
+        pack = str(finding_props.get("pack", "") or "unknown")
+        notifications.append(
+            Notification(
+                level=Level.error,
+                message=Message(
+                    root=Message1(
+                        text=(
+                            f"Rule {rule_id} from pack '{pack}' could not be evaluated, so "
+                            "this scan reports nothing about compliance with it. "
+                            f"{finding_props.get('rule_info', '')}".strip()
+                        )
+                    )
+                ),
+                associatedRule=ReportingDescriptorReference(
+                    # The id-bearing variant. ReportingDescriptorReference is a union whose
+                    # other two members require an index or a guid, neither of which exists
+                    # here -- the rule is identified by the id cdk-nag reported it under.
+                    root=ReportingDescriptorReference3(id=rule_id)
+                ),
+            )
+        )
+    return notifications
 
 
 def _reporting_descriptor_for(
@@ -159,6 +230,7 @@ def _reporting_descriptor_for(
             ],
         ),
     )
+
 
 # Matches the ``extra == "cdk"`` half of a PEP 508 marker. importlib.metadata
 # renders the marker with single quotes while pyproject.toml and pip emit double
@@ -717,6 +789,13 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
                             executionSuccessful=scan_succeeded,
                             exitCode=0 if scan_succeeded else 1,
                             exitCodeDescription="\n".join(self.errors),
+                            # Rules cdk-nag could not evaluate, reported as conditions of the
+                            # run rather than only as individual results. A rule that did not
+                            # run is a hole in this scan's coverage, and coverage is a property
+                            # of the run -- see _unevaluated_rule_notifications.
+                            toolExecutionNotifications=_unevaluated_rule_notifications(
+                                sarif_results
+                            ),
                             workingDirectory=ArtifactLocation(
                                 uri=get_shortest_name(input=self.context.source_dir),
                             ),

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -60,6 +60,106 @@ _CDK_EXTRA_FALLBACK_REQUIREMENTS: List[str] = [
     "constructs>=10.8,<11.0.0",
 ]
 
+# Where cdk-nag documents its own rules, and where the CDK documents everything else that can
+# write into the same validation report.
+_CDK_NAG_RULES_URL = "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md"
+_CDK_POLICY_VALIDATION_URL = (
+    "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+)
+
+
+def _rule_is_from_pack(rule_id: str, pack: str) -> bool:
+    """Whether ``rule_id`` was minted by cdk-nag's ``applyRule`` for ``pack``.
+
+    A derived test rather than a hardcoded list of pack names. cdk-nag builds every rule id as
+    ``f"{packName}-{ruleSuffix}"`` -- 3.0.2's ``applyRule`` does so literally, and
+    :func:`~automated_security_helper.utils.cdk_nag_wrapper._rule_id_parts` already relies on
+    the same construction from the other end. So ``AwsSolutions`` owns ``AwsSolutions-S1``,
+    while ``CloudFormation Validate`` demonstrably does not own ``F3017``.
+
+    An allowlist of cdk-nag pack names was the alternative and was rejected: it goes stale the
+    moment cdk-nag adds a pack, and the failure is silent -- a new pack's rules would start
+    being treated as foreign and lose their documentation link, which is a quieter version of
+    the defect this function exists to fix. A denylist naming only the CDK's built-in plugin is
+    worse still, because it is wrong for every third-party plugin a user registers.
+    """
+    return bool(pack) and rule_id.startswith(f"{pack}-")
+
+
+def _rule_help_uri(rule_id: str, pack: str, rule_level: str) -> str:
+    """The document that actually describes ``rule_id``.
+
+    Every rule used to be pointed at cdk-nag's RULES.md, which is right for a cdk-nag rule and
+    wrong for anything else in the report. From aws-cdk-lib 2.262.0 the CDK registers
+    ``CloudFormationValidatePlugin`` on every app unconditionally, so a scan of a template with
+    a placeholder KMS key identifier yields ``F3017`` findings whose help link opened a page
+    that does not mention ``F3017`` -- and, more to the point, does not describe how to
+    acknowledge one.
+
+    The CDK's policy-validation guide is the correct destination for those: it documents the
+    plugin, the shared validation report, and the ``Validations.of(scope).acknowledge()``
+    mechanism that governs a CloudFormation Validate finding. It is also the right destination
+    for a third-party ``IPolicyValidationPlugin``, since that guide is what defines the protocol
+    such a plugin implements.
+
+    A finding with NO pack recorded keeps the previous destination, and that is deliberately
+    narrow. Redirecting only findings positively known to be foreign means the change cannot
+    move the help link on anything it has not identified. An absent pack is not evidence of a
+    foreign producer -- inside this scanner's own report the likeliest producer is cdk-nag, the
+    level-derived anchor degrades to the generic ``#rules`` index which claims nothing about a
+    specific rule, and guessing "foreign" from missing data would send genuine cdk-nag rules
+    away from their own documentation. That is the same misattribution in the other direction.
+    """
+    if not pack or _rule_is_from_pack(rule_id, pack):
+        return f"{_CDK_NAG_RULES_URL}#{str(rule_level).lower()}s"
+    return _CDK_POLICY_VALIDATION_URL
+
+
+def _reporting_descriptor_for(
+    result: Result, tool_name: str, tool_type: str
+) -> ReportingDescriptor:
+    """Build the SARIF rule descriptor for one cdk-nag-path finding.
+
+    Extracted to module level for the same reason ``_build_nag_pack`` and ``_level_and_kind``
+    were: inline in ``scan()`` it could only be exercised by driving a full synthesis, and
+    nothing in the suite did that. Two of its three defects were invisible for exactly that
+    reason.
+
+    ``tags`` reads the result's own property bag. It used to read ``finding_props["tags"]``,
+    and ``finding_props`` is ``_NagFinding.as_dict()``, which has no ``tags`` key -- so that
+    lookup returned its ``[]`` default every single time. It looked like it forwarded the
+    finding's tags and forwarded nothing, which is why the pack name never reached the rule
+    even though the wrapper had been putting it on the result all along.
+
+    ``pack`` is also written as a labelled property. The pack is present in ``tags`` too, but
+    only as one unlabelled string among nine, so a consumer cannot tell it apart from the
+    resource id or the resource type sitting beside it; a named field can be read.
+    """
+    finding_props = (result.properties.model_extra or {}).get("cdk_nag_finding", {})
+    pack = str(finding_props.get("pack", "") or "")
+    rule_level = str(finding_props.get("rule_level", "rule"))
+
+    return ReportingDescriptor(
+        id=result.ruleId,
+        shortDescription=MultiformatMessageString(text=result.message.root.text),
+        fullDescription=MultiformatMessageString(
+            text=result.message.root.text,
+            markdown=result.message.root.markdown,
+        ),
+        helpUri=_rule_help_uri(result.ruleId or "", pack, rule_level),
+        properties=PropertyBag(
+            pack=pack,
+            rule_level=finding_props.get("rule_level", "unknown"),
+            rule_info=finding_props.get("rule_info", "unknown"),
+            tags=list(result.properties.tags or [])
+            + [
+                f"pack::{pack}" if pack else "pack::unknown",
+                f"tool_name::{tool_name}",
+                f"tool_type::{tool_type}",
+            ],
+        ),
+    )
+
 # Matches the ``extra == "cdk"`` half of a PEP 508 marker. importlib.metadata
 # renders the marker with single quotes while pyproject.toml and pip emit double
 # quotes, so neither style can be assumed.
@@ -576,29 +676,11 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
                 continue
             rule_map[result.ruleId] = result
 
-            finding_props = result.properties.model_extra.get("cdk_nag_finding", {})
-
             rules.append(
-                ReportingDescriptor(
-                    id=result.ruleId,
-                    shortDescription=MultiformatMessageString(
-                        text=result.message.root.text,
-                    ),
-                    fullDescription=MultiformatMessageString(
-                        text=result.message.root.text,
-                        markdown=result.message.root.markdown,
-                    ),
-                    helpUri=f"https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#{str(finding_props.get('rule_level', 'rule')).lower()}s",
-                    properties=PropertyBag(
-                        rule_level=finding_props.get("rule_level", "unknown"),
-                        rule_info=finding_props.get("rule_info", "unknown"),
-                        tags=finding_props.get("tags", [])
-                        + [
-                            f"tool_name::{self.config.name}",
-                            f"tool_type::{self.tool_type or 'UNKNOWN'}",
-                        ],
-                    ),
-                    # help,
+                _reporting_descriptor_for(
+                    result,
+                    tool_name=self.config.name,
+                    tool_type=self.tool_type or "UNKNOWN",
                 )
             )
         tool = Tool(

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -61,7 +61,7 @@ except (ImportError, Exception):
 # and can therefore go stale, which is exactly why it is only reached when the
 # metadata read below fails outright.
 _CDK_EXTRA_FALLBACK_REQUIREMENTS: List[str] = [
-    "aws-cdk-lib>=2.267,<3.0.0",
+    "aws-cdk-lib>=2.268.0,<3.0.0",
     "cdk-nag>=3.0,<4.0.0",
     "constructs>=10.8,<11.0.0",
 ]

--- a/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
+++ b/automated_security_helper/plugin_modules/ash_builtin/scanners/cdk_nag_scanner.py
@@ -240,10 +240,27 @@ def _rule_scoped_description(finding_props: dict, rule_id: str) -> str:
     So a not-evaluated row's description is discarded here and a rule-scoped sentence is
     constructed instead. Nothing is lost: the error text stays on the result's own message,
     where it is per-occurrence data sitting in a per-occurrence place, and it is what a reader
-    diagnosing the failure needs. Stripping cdk-nag's ``Rule threw an error during validation.``
-    prefix off the front and keeping that was the alternative, and it was rejected -- it
-    re-derives a rule-scoped string by parsing a string whose shape ``addViolation`` controls,
-    so a wording change upstream would silently start leaking the exception text again.
+    diagnosing the failure needs.
+
+    Stripping cdk-nag's ``Rule threw an error during validation.`` prefix off the front and
+    keeping the remainder was the alternative. It is rejected because a prefix strip keeps the
+    exception text in the buffer it is trying to remove it from -- one wrong slice index and the
+    tail is back -- while branching discards it wholesale. It is NOT rejected for being
+    sensitive to upstream's wording, because THIS FUNCTION IS EQUALLY SENSITIVE TO IT and an
+    earlier draft of this note wrongly claimed otherwise. The branch below reads
+    ``compliance``, and ``compliance`` is itself derived from that same sentence:
+    ``_compliance_for_violation`` returns ``NOT_EVALUATED`` from
+    ``description.startswith(_UNEVALUATED_DESCRIPTION_PREFIX)`` and nothing else. If cdk-nag
+    reworded it, ``compliance`` would come back ``"Non-Compliant"``, this function would take
+    the ``rule_info`` branch, and the exception text would flow into both descriptions and into
+    ``properties.rule_info`` exactly as before.
+
+    That shared dependency is worth stating plainly because the same drift is already the more
+    serious failure elsewhere: ``_level_and_kind`` dispatches on ``compliance`` too, so a
+    reworded prefix would also render a rule that never ran as a real finding at its declared
+    severity. One string in cdk-nag's source is load-bearing for all three behaviours, which is
+    why ``tests/unit/utils/test_cdk_nag_unevaluated_rule.py`` pins that string against the
+    cdk-nag distribution ASH actually installs rather than trusting it to hold.
 
     Returns ``""`` when the report supplied no description at all, so a caller can tell "the
     report said nothing" apart from "we constructed this".
@@ -736,8 +753,15 @@ class CdkNagScanner(ScannerPluginBase[CdkNagScannerConfig]):
             return False
 
         # Find all files to scan from the scan set
+        #
+        # sorted(), because this list decides the order findings are flattened in and therefore
+        # the order of rules[] in the emitted SARIF. Path.glob walks os.scandir, whose order is
+        # filesystem-determined rather than sorted, so two runs over an identical tree could
+        # emit the same rule descriptors in a different order and give ash-cdk-nag.sarif a
+        # non-empty diff. The non-converted branch below already ends in
+        # ``sorted(set(included))`` inside get_scan_set, so only this branch was unordered.
         orig_scannable = (
-            [item for item in self.context.work_dir.glob("**/*.*")]
+            sorted(self.context.work_dir.glob("**/*.*"))
             if target_type == "converted"
             else scan_set(
                 source=self.context.source_dir,

--- a/automated_security_helper/utils/cdk_nag_wrapper.py
+++ b/automated_security_helper/utils/cdk_nag_wrapper.py
@@ -93,6 +93,45 @@ def _build_nag_pack(pack_name: str):
     return pack_type(verbose=True)
 
 
+# The compliance state for a rule that reached no verdict, as opposed to one that reached the
+# verdict "non-compliant". A third value alongside "Non-Compliant" and "Suppressed" rather than
+# a boolean flag, because ``compliance`` is what :func:`_level_and_kind` dispatches on and what
+# the scanner reads back out of the SARIF property bag -- a parallel flag would have to be
+# threaded through both and could disagree with the field beside it.
+#
+# Exported so a test can assert against this constant rather than a repeated string literal.
+NOT_EVALUATED = "Not-Evaluated"
+
+# How cdk-nag 3.0.2 spells "this rule raised instead of returning a verdict".
+#
+# There is no structural marker to key on. ``applyRule`` wraps each rule in a try/catch and, on
+# an exception, calls the SAME ``addViolation`` a real violation goes through -- passing the
+# exception message as a third argument, which ``addViolation`` turns into this description
+# prefix. The severity stays whatever the rule declared, so a rule that never ran arrived as
+# ``severity: "error"`` and rendered CRITICAL.
+#
+# The prefix, not the whole string: ``addViolation`` appends the exception text when the pack was
+# built with ``verbose`` and a fixed hint about intrinsic functions otherwise, so the two forms
+# share only this much. ASH passes ``verbose=True`` in :func:`_build_nag_pack`, and matching the
+# prefix means that stops being load-bearing -- if it ever flips, detection keeps working
+# instead of silently reverting to reporting these as critical findings.
+_UNEVALUATED_DESCRIPTION_PREFIX = "Rule threw an error during validation."
+
+
+def _compliance_for_violation(description: str) -> str:
+    """Whether this report row is a violation or a rule that never produced one.
+
+    Kept as a named function rather than an inline ``startswith`` so the one place that decides
+    this is greppable, and so the marker constant has exactly one reader.
+    """
+    if description.startswith(_UNEVALUATED_DESCRIPTION_PREFIX):
+        return NOT_EVALUATED
+    # The validation report carries violations only, so for everything else "Non-Compliant" is
+    # the sole possible value and ``include_compliant_checks`` has nothing to include -- see the
+    # note in :func:`_violations_from_validation_report`.
+    return "Non-Compliant"
+
+
 class _NagFinding:
     """One cdk-nag violation, exposing the field names the downstream mapping reads.
 
@@ -184,7 +223,38 @@ def _level_and_kind(
     scanner reads ``compliance`` back out of the SARIF property bag, and a report format that
     restores suppression records would need the mapping intact. They are, today, unreachable
     from the report path -- see the note in :func:`_violations_from_validation_report`.
+
+    THE NOT-EVALUATED ROW, AND WHY notApplicable RATHER THAN open
+    ------------------------------------------------------------
+    SARIF 2.1.0 defines two kinds that could plausibly carry "this rule produced no verdict",
+    and the distinction between them is the whole question. Quoting the OASIS Standard
+    incorporating Approved Errata 01, section 3.27.9:
+
+      "notApplicable" : The rule specified by ruleId was not evaluated, because it does not
+      apply to the analysis target.
+
+      "open" : The specified rule was evaluated, and the tool concluded that there was
+      insufficient information to decide whether a problem exists.
+
+    ``open`` opens with "was evaluated", and its NOTE 1 scopes the value to proof-based tools
+    that completed an analysis and could not prove either direction. cdk-nag's rule did not
+    complete -- it raised partway through ``resolveIfPrimitive`` -- so "was not evaluated" is
+    the accurate half. Section 3.27.9's own example for ``notApplicable`` is a result whose
+    message reads "<target> was not evaluated for rule <id> because <reason>", which is the
+    shape this path produces.
+
+    ``Level.none`` is then required rather than chosen. Section 3.27.10 defines it as "The
+    concept of 'severity' does not apply to this result because the kind property (3.27.9) has
+    a value other than 'fail'". ASH's ladder maps ``none`` to INFO, so a rule that did not run
+    stops being counted as a critical finding as a consequence of getting the SARIF right --
+    not as a separate adjustment that could be changed independently and drift apart from it.
+
+    Checked before the ``Non-Compliant`` row on purpose: a not-evaluated row arrives carrying
+    whatever severity the rule declared, which for a cdk-nag error-level rule is ``"Error"``,
+    so falling through to the row below would render it ``fail``/``error`` exactly as before.
     """
+    if compliance == NOT_EVALUATED:
+        return Level.none, Kind.notApplicable
     if compliance == "Non-Compliant":
         if rule_level == "Error":
             return Level.error, Kind.fail
@@ -192,6 +262,26 @@ def _level_and_kind(
     if compliance == "Suppressed" and exception_reason != "N/A":
         return Level.none, Kind.review
     return Level.none, Kind.informational
+
+
+def _result_message_text(finding: "_NagFinding", target: str) -> str:
+    """The human-readable message for one SARIF result.
+
+    A not-evaluated finding gets a message that leads with the fact, because ``kind`` is the
+    machine-readable half and plenty of report surfaces render only the message. The wording
+    follows the example SARIF 2.1.0 section 3.27.9 gives for ``notApplicable`` -- name the
+    target, name the rule, then give the reason -- rather than inventing a phrasing.
+
+    Everything else keeps the previous text verbatim, including the "Exception Reason" line for
+    a value that is almost always ``N/A``. Changing that would move the message on every
+    ordinary finding, which is a report-output change with no defect behind it.
+    """
+    if finding.compliance == NOT_EVALUATED:
+        return (
+            f"'{target}' was NOT evaluated for rule {finding.rule_id}, so this result says "
+            f"nothing about whether the template complies with it.\n\n{finding.rule_info}"
+        )
+    return f"{finding.rule_info}\n\nException Reason: {finding.exception_reason}"
 
 
 def _rule_id_parts(rule_id: str) -> tuple[str, str | None]:
@@ -512,6 +602,15 @@ def _violations_from_validation_report(
             rule_id = violation.get("ruleName") or ""
             rule_info = violation.get("description") or ""
             rule_level = _normalize_rule_level(violation.get("severity", ""))
+            # Decided once per violation rather than per construct: every construct under one
+            # violation shares the description, so the state cannot differ between them.
+            compliance = _compliance_for_violation(rule_info)
+            if compliance == NOT_EVALUATED:
+                ASH_LOGGER.warning(
+                    f"cdk-nag rule '{rule_id}' from pack '{pack_name}' could not be "
+                    f"evaluated against this template, so it reports NOTHING about the "
+                    f"template's compliance with it: {rule_info}"
+                )
             # One violation can cite several constructs; each becomes its own finding so the
             # SARIF result points at a single resource, as it did under 2.x.
             for construct in violation.get("violatingConstructs", []) or []:
@@ -522,10 +621,7 @@ def _violations_from_validation_report(
                     _NagFinding(
                         rule_id=rule_id,
                         resource_id=construct_path,
-                        # The validation report carries violations only. "Non-Compliant" is
-                        # therefore the sole possible value, and include_compliant_checks has
-                        # nothing to include -- see the note in the docstring.
-                        compliance="Non-Compliant",
+                        compliance=compliance,
                         exception_reason="N/A",
                         rule_level=rule_level,
                         rule_info=rule_info,
@@ -871,7 +967,7 @@ def run_cdk_nag_against_cfn_template(
                         kind=kind,
                         message=Message(
                             root=Message1(
-                                text=f"{line.rule_info}\n\nException Reason: {line.exception_reason}"
+                                text=_result_message_text(line, cfn_file_rel_path)
                             )
                         ),
                         analysisTarget=ArtifactLocation(

--- a/automated_security_helper/utils/cdk_nag_wrapper.py
+++ b/automated_security_helper/utils/cdk_nag_wrapper.py
@@ -100,9 +100,17 @@ class _NagFinding:
     ``resource_id``, ``compliance``, ``exception_reason``, ``rule_level``, ``rule_info``) so
     the SARIF construction below is untouched by the v3 migration. ``NagReportLine`` itself is
     not used because v3 no longer ships the file-report schema it belonged to.
+
+    ``pack`` is the one field with no 2.x counterpart, and it exists because v3's report is not
+    cdk-nag's. See :func:`_violations_from_validation_report`: the file is CDK's shared
+    policy-validation report, every registered plugin writes into it, and from aws-cdk-lib
+    2.262.0 the CDK registers one of its own. So the plugin that produced a finding is no longer
+    implied by the file it came out of, and carrying it here is what lets it stay attributable
+    after the caller flattens the per-pack mapping into a single result list.
     """
 
     __slots__ = (
+        "pack",
         "rule_id",
         "resource_id",
         "compliance",
@@ -119,6 +127,7 @@ class _NagFinding:
         exception_reason: str,
         rule_level: str,
         rule_info: str,
+        pack: str = "",
     ) -> None:
         self.rule_id = rule_id
         self.resource_id = resource_id
@@ -126,6 +135,7 @@ class _NagFinding:
         self.exception_reason = exception_reason
         self.rule_level = rule_level
         self.rule_info = rule_info
+        self.pack = pack
 
     def as_dict(self) -> Dict[str, str]:
         """The raw finding record, attached to the SARIF result's property bag.
@@ -134,6 +144,7 @@ class _NagFinding:
         ``result.properties.model_extra["cdk_nag_finding"]`` and indexes it by these keys.
         """
         return {
+            "pack": self.pack,
             "rule_id": self.rule_id,
             "resource_id": self.resource_id,
             "compliance": self.compliance,
@@ -518,6 +529,14 @@ def _violations_from_validation_report(
                         exception_reason="N/A",
                         rule_level=rule_level,
                         rule_info=rule_info,
+                        # The plugin that produced this finding, kept per-row rather than
+                        # relying on the mapping key. The caller iterates
+                        # ``results.items()``, binds the key to a loop variable and extends
+                        # one flat list with the values, so the key does not survive into
+                        # SARIF -- and after aws-cdk-lib 2.262.0 the key is the only thing
+                        # that distinguishes a cdk-nag rule from a CloudFormation Validate
+                        # one.
+                        pack=pack_name,
                     )
                 )
 

--- a/deploy/cdk-constructs/test/ash-scan-step.test.ts
+++ b/deploy/cdk-constructs/test/ash-scan-step.test.ts
@@ -291,15 +291,31 @@ describe('install modes', () => {
   });
 
   test('PIP pins the given git ref', () => {
+    // A commit, not a release tag, and the choice is load bearing twice over.
+    //
+    // This test only proves anything if the ref differs from the default one
+    // above, so naming the packaged version would make it pass whether or not
+    // `version` ever reached the buildspec. And a release tag here is
+    // indistinguishable, to anything reading the file as text, from an install
+    // command a user pastes: the tree-wide pin walk in
+    // tests/unit/test_agent_plugin_ash_version.py matches
+    // `automated-security-helper.git@v<semver>` wherever it appears and cannot
+    // tell a jest assertion from a real one, so a tag here either goes stale at
+    // the next release or costs that guard an exemption covering the whole
+    // file -- including the two live `@v3.7.0` pins it should keep watching.
+    // A commit is unambiguous, and it covers the third ref kind `version`
+    // documents; the default above already covers the tag case.
+    const commit = '0123456789abcdef0123456789abcdef01234567';
+
     const { template } = synthesizeWithStep({
       installMode: ASHInstallMode.PIP,
-      version: 'v3.6.0',
+      version: commit,
     });
 
     template.hasResourceProperties('AWS::CodeBuild::Project', {
       Source: Match.objectLike({
         BuildSpec: Match.stringLikeRegexp(
-          'git\\+https://github.com/awslabs/automated-security-helper.git@v3.6.0',
+          `git\\+https://github.com/awslabs/automated-security-helper.git@${commit}`,
         ),
       }),
     });

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -129,6 +129,25 @@ def foreign_plugin_template(tmp_path: Path) -> Path:
     return path
 
 
+# The two shapes ASH's own repository feeds cdk-nag today. Both are read by the YAML/JSON
+# loader, and neither can survive it: an unknown tag has no constructor, and JSON with comments
+# is not a flow mapping.
+UNPARSEABLE_TARGETS = {
+    "mkdocs.yml": (
+        "site_name: Fixture\n"
+        "markdown_extensions:\n"
+        "  - pymdownx.emoji:\n"
+        "      emoji_index: !!python/name:material.extensions.emoji.twemoji\n"
+    ),
+    "tsconfig.json": (
+        "{\n"
+        "  // a comment makes this not plain JSON\n"
+        '  "compilerOptions": {"strict": true}\n'
+        "}\n"
+    ),
+}
+
+
 @pytest.fixture()
 def unevaluatable_template(tmp_path: Path) -> Path:
     path = tmp_path / "unevaluatable.template.json"
@@ -449,3 +468,96 @@ class TestRuleThatCouldNotBeEvaluated:
             f"notifications name {sorted(notified_rules)} but the notApplicable results are "
             f"{sorted(unevaluated_rules)}"
         )
+
+
+class TestTargetThatCouldNotBeParsed:
+    """A file cdk-nag cannot parse must stay OUT of the findings channel.
+
+    WHY THIS EXISTS WITHOUT A FIX BESIDE IT
+    ---------------------------------------
+    ASH's own CI feeds cdk-nag files that are not CloudFormation at all -- ``mkdocs.yml`` and
+    ``deploy/cdk/tsconfig.json`` -- and the scan logs two parse failures next to a non-zero exit
+    citing "1 actionable findings". The obvious reading is that the two failures became the
+    finding. They did not: that run's summary table attributes the single actionable finding to
+    detect-secrets, at CRITICAL, with cdk-nag itself on ``Action 0 / PASSED``. Two unrelated
+    facts, printed near each other.
+
+    So there is nothing to fix here, and that is exactly why the property is worth pinning. It
+    is currently correct and nothing asserted it, which is the state a regression arrives in.
+    A future change that turned a target-level parse failure into a synthetic finding would
+    inflate the count and fail builds on repositories whose only problem is that a YAML file is
+    not a template.
+
+    WHAT THIS ASSERTS, AND WHAT IT REFUSES TO ASSERT
+    -----------------------------------------------
+    The count and the channel, never the wording. A test that watched the log message would pass
+    while the miscount survived, because the message is emitted before the finding would be
+    constructed. So: the number of results, the absence of any result attributed to the
+    unparseable files, and the presence of both failures in ``exitCodeDescription`` -- the error
+    channel the scanner actually reports them through.
+
+    WHAT IS DELIBERATELY NOT ASSERTED AS CORRECT
+    --------------------------------------------
+    ``executionSuccessful`` is True and ``exitCode`` is 0 on this run even though a third of the
+    targets were never evaluated, because ``determine_status`` only reports ERROR once
+    ``targets_failed >= targets_attempted``. Partial coverage loss being invisible in the
+    rolled-up status is a real and separate defect from the three this module covers; it is not
+    fixed here and this test does not pretend the value is right, it only records what it is.
+    """
+
+    def test_an_unparseable_target_is_an_error_not_a_finding(
+        self, test_plugin_context, non_compliant_template: Path
+    ):
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        # A real template alongside them, so the scan has something it CAN evaluate. Without it
+        # every target fails, the scanner reports ERROR, and the test would be measuring the
+        # total-failure path instead of the partial one.
+        (source_dir / "template.json").write_text(non_compliant_template.read_text())
+        for name, body in UNPARSEABLE_TARGETS.items():
+            (source_dir / name).write_text(body)
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+        assert report is not False, "scanner refused to run"
+
+        assert scanner.targets_attempted == 3, (
+            f"expected all three files in the scan set, got {scanner.targets_attempted}"
+        )
+        assert scanner.targets_failed == len(UNPARSEABLE_TARGETS), (
+            f"expected {len(UNPARSEABLE_TARGETS)} parse failures, got {scanner.targets_failed}"
+        )
+
+        run = report.runs[0]
+        results = run.results or []
+        assert results, (
+            "the real template produced no findings, so this fixture is not exercising the "
+            "partial-failure path"
+        )
+        # The channel assertion. Named per file so a failure says which one leaked.
+        for name in UNPARSEABLE_TARGETS:
+            leaked = [
+                r.ruleId
+                for r in results
+                if name in str(getattr(r.analysisTarget, "uri", "") or "")
+            ]
+            assert not leaked, (
+                f"{name} could not be parsed yet produced findings {leaked}"
+            )
+
+        # And the error channel does carry them, which is the positive artifact: "not a finding"
+        # on its own would also be satisfied by the failure vanishing entirely.
+        description = run.invocations[0].exitCodeDescription or ""
+        for name in UNPARSEABLE_TARGETS:
+            assert name in description, (
+                f"{name} failed to parse but is absent from exitCodeDescription, so the "
+                f"failure is recorded nowhere a consumer can see it"
+            )

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -59,6 +59,42 @@ def non_compliant_template(tmp_path: Path) -> Path:
     return path
 
 
+# A template that trips the CDK's OWN validation plugin as well as a nag pack. From
+# aws-cdk-lib 2.262.0 the CDK registers CloudFormationValidatePlugin unconditionally, so its
+# findings arrive in the same validation-report.json as cdk-nag's -- and a placeholder KMS key
+# identifier is the cheapest way to make it produce one (rule F3017). The bucket is also
+# non-compliant for AwsSolutions, which is load-bearing: both packs must appear in one report
+# or the test cannot show the two being told apart.
+FOREIGN_PLUGIN_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Fixture that trips both a nag pack and the CDK's own validation plugin",
+    "Resources": {
+        "PlaceholderKeyBucket": {
+            "Type": "AWS::S3::Bucket",
+            "Properties": {
+                "BucketName": "ash-cdk-nag-foreign-plugin-fixture",
+                "BucketEncryption": {
+                    "ServerSideEncryptionConfiguration": [
+                        {
+                            "ServerSideEncryptionByDefault": {
+                                "SSEAlgorithm": "aws:kms",
+                                "KMSMasterKeyID": "my-kms-key",
+                            }
+                        }
+                    ]
+                },
+            },
+        }
+    },
+}
+
+@pytest.fixture()
+def foreign_plugin_template(tmp_path: Path) -> Path:
+    path = tmp_path / "foreign_plugin.template.json"
+    path.write_text(json.dumps(FOREIGN_PLUGIN_TEMPLATE, indent=2))
+    return path
+
+
 class TestRealNagPack:
     def test_pack_constructs_against_installed_cdk_nag(self):
         """The wrapper's own construction call must work on the installed major.
@@ -143,4 +179,120 @@ class TestRealNagPack:
         assert response is None, (
             "wrapper returned a populated response for a non-CloudFormation input; an "
             "empty-but-successful result is what makes a total failure look clean"
+        )
+
+
+class TestReportAttribution:
+    """Which tool produced a finding, measured against the real report rather than a fixture.
+
+    ``validation-report.json`` belongs to CDK, not to cdk-nag: it is the shared policy-validation
+    report, every registered ``IPolicyValidationPlugin`` writes into it, and from aws-cdk-lib
+    2.262.0 the CDK registers ``CloudFormationValidatePlugin`` on every app whether or not the
+    caller asked for it. So "the report came out of a cdk-nag run" stopped implying "cdk-nag
+    produced these rules", and the equivalent unit tests in
+    ``tests/unit/utils/test_cdk_nag_report_fidelity.py`` assert against a hand-written report
+    that could drift away from what the installed libraries actually emit. This class is what
+    stops that drift.
+    """
+
+    def test_a_cdk_plugin_that_is_not_a_nag_pack_is_named_as_its_own_pack(
+        self, foreign_plugin_template: Path, tmp_path: Path
+    ):
+        """The CDK's built-in plugin must be attributed to itself, not to cdk-nag.
+
+        The pack assertion is on the finding record. The per-pack mapping key is also correct
+        and is not sufficient on its own: the scanner binds that key to a loop variable, logs
+        it, and extends one flat result list, so it does not reach SARIF.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            run_cdk_nag_against_cfn_template,
+        )
+
+        response = run_cdk_nag_against_cfn_template(
+            template_path=foreign_plugin_template,
+            nag_packs=["AwsSolutionsChecks"],
+            outdir=tmp_path / "cdk-out-foreign",
+        )
+
+        assert response is not None and response.failure is None
+        packs = set(response.results)
+        assert "CloudFormation Validate" in packs, (
+            "the CDK's own validation plugin did not report; this fixture no longer "
+            f"exercises the defect. Packs present: {sorted(packs)}"
+        )
+        assert "AwsSolutions" in packs, (
+            f"the nag pack did not report, so nothing is being told apart. Packs: {sorted(packs)}"
+        )
+
+        for pack_name, findings in response.results.items():
+            assert findings, f"pack {pack_name!r} reported no findings"
+            for finding in findings:
+                record = (finding.properties.model_extra or {})["cdk_nag_finding"]
+                assert record["pack"] == pack_name, (
+                    f"{finding.ruleId} came from {pack_name!r} but records its pack as "
+                    f"{record['pack']!r}"
+                )
+
+        # The rule that made this defect visible in the first place, named so the fixture
+        # cannot quietly stop producing it.
+        foreign_rule_ids = {
+            f.ruleId for f in response.results["CloudFormation Validate"]
+        }
+        assert "F3017" in foreign_rule_ids, (
+            f"expected the placeholder-KMS-key rule F3017, got {sorted(foreign_rule_ids)}"
+        )
+
+    def test_the_scanner_documents_a_foreign_rule_against_the_right_guide(
+        self, test_plugin_context, foreign_plugin_template: Path
+    ):
+        """The rule descriptor a consumer reads, built by the real scanner.
+
+        ``helpUri`` was cdk-nag's RULES.md for every rule in the report, including the CDK's
+        own. Following it for ``F3017`` reaches a page that neither documents the rule nor
+        describes how to acknowledge it. The exact destination is named rather than "not the
+        cdk-nag URL", which would also be satisfied by an empty value.
+
+        This is the only test in this class that goes through ``CdkNagScanner.scan`` rather than
+        the wrapper, and it is what covers the reporting half: the rule descriptor is assembled
+        by the scanner, from a per-pack mapping it has already flattened.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "foreign_plugin.template.json").write_text(
+            foreign_plugin_template.read_text()
+        )
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+        assert report is not False, "scanner refused to run"
+
+        rules = {r.id: r for r in report.runs[0].tool.driver.rules or []}
+        assert "F3017" in rules, (
+            f"F3017 produced no rule descriptor; got {sorted(rules)}"
+        )
+
+        foreign = rules["F3017"]
+        assert foreign.properties.model_extra["pack"] == "CloudFormation Validate"
+        assert "pack::CloudFormation Validate" in foreign.properties.tags
+        assert (
+            str(foreign.helpUri)
+            == "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+        )
+
+        # The control: a genuine cdk-nag rule from the same scan keeps pointing at cdk-nag.
+        nag_rule_ids = [rid for rid in rules if rid.startswith("AwsSolutions-")]
+        assert nag_rule_ids, f"no cdk-nag rule in the same report; got {sorted(rules)}"
+        nag_rule = rules[nag_rule_ids[0]]
+        assert nag_rule.properties.model_extra["pack"] == "AwsSolutions"
+        assert str(nag_rule.helpUri).startswith(
+            "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#"
         )

--- a/tests/integration/scanners/test_cdk_nag_real_pack.py
+++ b/tests/integration/scanners/test_cdk_nag_real_pack.py
@@ -88,10 +88,51 @@ FOREIGN_PLUGIN_TEMPLATE = {
     },
 }
 
+# A template on which a nag rule RAISES rather than returning a verdict.
+#
+# cdk-nag rules read primitive properties through NagRules.resolveIfPrimitive, which throws
+# "the rule could not be validated" when the value resolves to a non-primitive -- which is what
+# a Ref to a CloudFormation Parameter resolves to. applyRule catches that and records it through
+# the same addViolation a real violation uses, so the report cannot be told apart structurally.
+#
+# Two resources rather than one because two different rules have to be exercised: EC2Volume's
+# Encrypted trips AwsSolutions-EC26 and the security group description trips AwsSolutions-EC27.
+# Measured against cdk-nag 3.0.2, both come back at severity "error".
+UNEVALUATABLE_TEMPLATE = {
+    "AWSTemplateFormatVersion": "2010-09-09",
+    "Description": "Fixture whose primitive properties resolve to intrinsic functions",
+    "Parameters": {
+        "SgDescription": {"Type": "String", "Default": "fixture security group"},
+        "VolumeEncrypted": {"Type": "String", "Default": "true"},
+    },
+    "Resources": {
+        "IntrinsicSecurityGroup": {
+            "Type": "AWS::EC2::SecurityGroup",
+            "Properties": {"GroupDescription": {"Ref": "SgDescription"}},
+        },
+        "IntrinsicVolume": {
+            "Type": "AWS::EC2::Volume",
+            "Properties": {
+                "AvailabilityZone": "us-east-1a",
+                "Size": 8,
+                "Encrypted": {"Ref": "VolumeEncrypted"},
+            },
+        },
+    },
+}
+
+
 @pytest.fixture()
 def foreign_plugin_template(tmp_path: Path) -> Path:
     path = tmp_path / "foreign_plugin.template.json"
     path.write_text(json.dumps(FOREIGN_PLUGIN_TEMPLATE, indent=2))
+    return path
+
+
+@pytest.fixture()
+def unevaluatable_template(tmp_path: Path) -> Path:
+    path = tmp_path / "unevaluatable.template.json"
+    path.write_text(json.dumps(UNEVALUATABLE_TEMPLATE, indent=2))
     return path
 
 
@@ -295,4 +336,116 @@ class TestReportAttribution:
         assert nag_rule.properties.model_extra["pack"] == "AwsSolutions"
         assert str(nag_rule.helpUri).startswith(
             "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#"
+        )
+
+
+class TestRuleThatCouldNotBeEvaluated:
+    def test_an_unevaluated_rule_is_not_reported_as_a_violation(
+        self, unevaluatable_template: Path, tmp_path: Path
+    ):
+        """A rule that raised must render as notApplicable with no severity.
+
+        cdk-nag reports a rule that threw through the same ``addViolation`` as a real finding,
+        at whatever severity the rule declared -- ``"error"`` for these two, which ASH's ladder
+        reads as CRITICAL. So before this change a template referencing a parameter produced
+        critical security findings for rules that never ran.
+
+        Both directions are asserted from one report: the unevaluated rules must be
+        ``notApplicable``/``none``, and a genuine violation from the same run must still be
+        ``fail``/``error``.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            run_cdk_nag_against_cfn_template,
+        )
+
+        response = run_cdk_nag_against_cfn_template(
+            template_path=unevaluatable_template,
+            nag_packs=["AwsSolutionsChecks"],
+            outdir=tmp_path / "cdk-out-unevaluatable",
+        )
+
+        assert response is not None and response.failure is None
+
+        unevaluated = [
+            finding
+            for findings in response.results.values()
+            for finding in findings
+            if (finding.properties.model_extra or {})["cdk_nag_finding"]["compliance"]
+            == NOT_EVALUATED
+        ]
+        assert unevaluated, (
+            "no rule reported as un-evaluated, so this fixture no longer reproduces the "
+            "defect. cdk-nag raises out of NagRules.resolveIfPrimitive when a primitive "
+            "property resolves to an intrinsic; check that the parameter Refs survived."
+        )
+
+        for finding in unevaluated:
+            assert finding.kind == Kind.notApplicable, (
+                f"{finding.ruleId} could not be evaluated but rendered kind={finding.kind}"
+            )
+            assert finding.level == Level.none, (
+                f"{finding.ruleId} could not be evaluated but carries level={finding.level}"
+            )
+            # The message is what most report surfaces show, so the fact has to be legible
+            # there too rather than only in the machine-readable kind.
+            assert "NOT evaluated" in finding.message.root.text
+
+    def test_the_scanner_reports_an_unevaluated_rule_as_a_run_level_condition(
+        self, test_plugin_context, unevaluatable_template: Path
+    ):
+        """End to end through the real scanner, asserting the SARIF invocation.
+
+        This is the only test here that exercises ``CdkNagScanner.scan`` rather than the
+        wrapper, and it is what covers the reporting half of the fix: the rule descriptor's
+        pack and help pointer, and the ``toolExecutionNotifications`` entry.
+
+        SARIF's own definitions are why the notification exists at all --
+        ``toolExecutionNotifications`` is "A list of runtime conditions detected by the tool
+        during the analysis" and ``notification.associatedRule`` is "A reference used to locate
+        the rule descriptor associated with this notification". A rule that raised mid-scan is
+        a runtime condition, and a coverage hole is a property of the run rather than of one
+        result.
+        """
+        _require_cdk_nag()
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            CdkNagScanner,
+            CdkNagScannerConfig,
+        )
+
+        source_dir = Path(test_plugin_context.source_dir)
+        source_dir.mkdir(parents=True, exist_ok=True)
+        (source_dir / "unevaluatable.template.json").write_text(
+            unevaluatable_template.read_text()
+        )
+
+        scanner = CdkNagScanner(
+            context=test_plugin_context, config=CdkNagScannerConfig()
+        )
+        report = scanner.scan(target=source_dir, target_type="source")
+
+        assert report is not False, "scanner refused to run"
+        run = report.runs[0]
+
+        notifications = run.invocations[0].toolExecutionNotifications or []
+        notified_rules = {
+            n.associatedRule.root.id for n in notifications if n.associatedRule
+        }
+        assert notified_rules, (
+            "the scan produced no toolExecutionNotifications, so a rule that did not run "
+            "leaves no trace at the run level"
+        )
+
+        # Every notified rule must correspond to a notApplicable result, and vice versa: the
+        # two channels are two views of one fact and must not disagree.
+        from automated_security_helper.schemas.sarif_schema_model import Kind
+
+        unevaluated_rules = {
+            r.ruleId for r in (run.results or []) if r.kind == Kind.notApplicable
+        }
+        assert notified_rules == unevaluated_rules, (
+            f"notifications name {sorted(notified_rules)} but the notApplicable results are "
+            f"{sorted(unevaluated_rules)}"
         )

--- a/tests/unit/cli/test_merge.py
+++ b/tests/unit/cli/test_merge.py
@@ -1407,6 +1407,65 @@ class TestShardContributionIsRefused:
         with pytest.raises(ShardCoverageError, match=r"completed none"):
             merge_shard_results(as_loaded(shards), require_scanner_completion=True)
 
+    def test_a_shard_that_lost_only_some_targets_is_still_merged(self):
+        """Partial coverage loss must NOT be read as "this shard completed nothing".
+
+        Two checks both mean "incomplete" and are not the same question:
+
+        * ``_completed`` / ``_verify_shard_contributions`` ask whether a shard's
+          scanner ran **at all**. A scanner that read 8 of its 10 targets ran, so
+          the shard contributed and the merge must proceed.
+        * ``incomplete_scanners`` asks whether everything the scanner was given
+          was evaluated. It answers no here, and that is what the opt-in exit-code
+          gate acts on.
+
+        What each assertion is worth, stated honestly because the two differ:
+
+        The merge-proceeds half is a regression guard whose protection is
+        currently *structural* rather than behavioural. ``_completed`` inspects a
+        ``ScannerTargetStatusInfo`` from ``scanner_results``, and that model
+        declares no target counters at all, so it cannot see coverage even if
+        someone wired it to try. Verified by mutation: reimplementing
+        ``_completed`` to consult ``_partial_coverage`` does not change this
+        test's result, because the value it would consult is never there. So this
+        assertion documents a boundary and would catch a future change that put
+        the counters onto that model, but no one-line mistake today can violate
+        it. It is not the reason to trust the boundary; the reason is that
+        partial coverage does not change the status, which
+        ``test_partial_coverage_loss_still_reports_passed`` pins directly.
+
+        The gate-still-sees-it half is falsifiable and is what earns this test its
+        place. It is the only coverage this repository has that the target counters
+        survive a **merge** -- they live in ``additional_reports``, which the merge
+        recombines from n shards -- and reach the exit-code gate on the merged
+        product. Verified by mutation: removing the coverage arm from
+        ``incomplete_scanners`` fails it. It doubles as the control against a
+        fixture with no partial coverage in it, which would make the first half a
+        test of nothing.
+        """
+        shards = build_shards(3)
+        owned = list(read_shard_assignment(shards[1]).assigned_scanners)
+        assert owned, "fixture must give shard 1 scanners to lose targets on"
+        for scanner in owned:
+            # Lost some, not all: determine_status leaves the status alone, which
+            # is precisely the state that used to be invisible to both checks.
+            shards[1].additional_reports[scanner]["source"]["targets_attempted"] = 10
+            shards[1].additional_reports[scanner]["source"]["targets_failed"] = 4
+
+        merged = merge_shard_results(as_loaded(shards), require_scanner_completion=True)
+
+        from automated_security_helper.interactions.run_ash_scan import (
+            incomplete_scanners,
+        )
+
+        listed = dict(incomplete_scanners(merged))
+        for scanner in owned:
+            assert scanner in listed, (
+                f"{scanner} lost 4 of 10 targets, so the fixture is genuinely "
+                f"partial and this test is not vacuous; the exit-code gate has to "
+                f"see it even though shard verification correctly did not"
+            )
+
     def test_a_scanner_absent_from_its_owners_results_is_refused(self):
         # The case a status-based check structurally cannot see: the owning shard
         # recorded no entry at all, so there is no status to inspect. Reproduced

--- a/tests/unit/cli/test_merge.py
+++ b/tests/unit/cli/test_merge.py
@@ -1421,18 +1421,17 @@ class TestShardContributionIsRefused:
 
         What each assertion is worth, stated honestly because the two differ:
 
-        The merge-proceeds half is a regression guard whose protection is
-        currently *structural* rather than behavioural. ``_completed`` inspects a
-        ``ScannerTargetStatusInfo`` from ``scanner_results``, and that model
-        declares no target counters at all, so it cannot see coverage even if
-        someone wired it to try. Verified by mutation: reimplementing
-        ``_completed`` to consult ``_partial_coverage`` does not change this
-        test's result, because the value it would consult is never there. So this
-        assertion documents a boundary and would catch a future change that put
-        the counters onto that model, but no one-line mistake today can violate
-        it. It is not the reason to trust the boundary; the reason is that
-        partial coverage does not change the status, which
-        ``test_partial_coverage_loss_still_reports_passed`` pins directly.
+        The merge-proceeds half is a regression guard, and an earlier version of
+        this docstring undersold it on a false premise. It said the protection was
+        *structural* because ``ScannerTargetStatusInfo`` declares no target
+        counters. The model sets ``extra="allow"``, so counters written into
+        ``scanner_results`` land in ``model_extra`` and ``getattr(entry,
+        "targets_failed", 0)`` returns 4 rather than the default -- measured, not
+        reasoned. Nothing structural stops ``_completed`` from reading coverage.
+        What stops it is that it reads the status and only the status, which is a
+        behavior, and ``test_partial_coverage_still_counts_as_having_run`` in
+        ``tests/unit/interactions/test_fail_on_partial_target_coverage.py`` holds
+        that behavior against a mutation that consults the counters.
 
         The gate-still-sees-it half is falsifiable and is what earns this test its
         place. It is the only coverage this repository has that the target counters

--- a/tests/unit/core/test_partial_target_coverage_visibility.py
+++ b/tests/unit/core/test_partial_target_coverage_visibility.py
@@ -35,9 +35,16 @@ even in principle. That is the half of the defect that is purely additive to fix
 
 Whether a partially-covered scan should FAIL is a separate question with a real blast radius --
 at a 40% rate on this repository, "ERROR on any failed target" would turn a routine condition
-into a permanent red -- so the status and the exit code are deliberately unchanged here. The
-tests below assert that they are unchanged, so that a later change to them is a visible decision
-rather than a side effect.
+into a permanent red -- so PARTIAL loss moves neither the status nor the exit code, and the tests
+below assert that, so a later change to it is a visible decision rather than a side effect.
+
+Read that as scoped to partial loss, not as a claim about the change this file belongs to. A
+sibling commit ORs ``any_target_errored`` into the ``error`` flag, so a tree that lost ALL of its
+targets -- which ``determine_status`` does report as ERROR -- now reaches the rolled-up status
+where it previously could not. That is a status change, it has no opt-in, and
+``tests/unit/core/test_scanner_status_across_targets.py`` owns it. The two are consistent because
+they concern different conditions: 4 of 10 lost is not a status, 10 of 10 lost on some tree always
+was one and simply could not be seen.
 
 ASSERTIONS ARE ON COUNTS AND CHANNELS, NEVER ON WORDING
 -------------------------------------------------------

--- a/tests/unit/core/test_partial_target_coverage_visibility.py
+++ b/tests/unit/core/test_partial_target_coverage_visibility.py
@@ -1,0 +1,354 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""How much of a scanner's input it actually evaluated has to reach the output.
+
+WHAT WAS MEASURED
+-----------------
+A scanner reports per-target counters -- ``targets_attempted`` and ``targets_failed`` -- and
+``ScanResultsContainer.determine_status`` only returns ERROR once ``targets_failed >=
+targets_attempted``. So total coverage loss is loud and partial coverage loss is silent. Measured
+end to end with the real cdk-nag scanner over four trees of three targets each, with the findings
+gate off so the exit code reflects coverage alone:
+
+    failing   determine_status   executionSuccessful   exit   summary status
+    0/3       PASSED             True                  0      PASSED
+    1/3       PASSED             True                  0      PASSED
+    2/3       PASSED             True                  0      PASSED
+    3/3       ERROR              False                 0      ERROR
+
+The cliff is exactly at "all failed", and 1/3 and 2/3 are indistinguishable from 0/3 in every
+status channel. ``scanner_evaluated_nothing`` does not cover this: it keys on
+``targets_attempted <= 0``, and here three targets were attempted every time.
+
+On ASH's own repository cdk-nag attempts 10 targets and fails 4 -- a 40% loss reported as a clean
+scan. Two of those four are genuine CloudFormation templates that went unscanned; the other two
+are a ``mkdocs.yml`` and a ``tsconfig.json`` that were never templates. The signal is hidden among
+the noise, which is the reason the counts have to be legible rather than merely present.
+
+WHY THIS FIXES VISIBILITY AND NOT THE VERDICT
+---------------------------------------------
+``ScannerMetrics`` is the single model the summary table and every reporter read, and it had no
+field for either counter. So the counters existed in ``ash_aggregated_results.json`` and in the
+scanner's own SARIF and could not reach the table, ``ash.flat.json``, or any human-facing report
+even in principle. That is the half of the defect that is purely additive to fix.
+
+Whether a partially-covered scan should FAIL is a separate question with a real blast radius --
+at a 40% rate on this repository, "ERROR on any failed target" would turn a routine condition
+into a permanent red -- so the status and the exit code are deliberately unchanged here. The
+tests below assert that they are unchanged, so that a later change to them is a visible decision
+rather than a side effect.
+
+ASSERTIONS ARE ON COUNTS AND CHANNELS, NEVER ON WORDING
+-------------------------------------------------------
+A test that checked the output mentions unevaluated targets would pass on a cosmetic change while
+the numbers stayed wrong. So the counts are asserted through ``coverage_shortfalls``, which
+returns structured tuples, and the rendering is asserted only for presence-versus-absence -- the
+channel. Each status assertion names the status it requires rather than "not PASSED", which any
+wrong status would also satisfy, and every case has a matching negative control.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _model(reports: dict):
+    """An AshAggregatedResults stand-in carrying the serialized per-target reports.
+
+    ``ScanResultProcessor`` dumps each container with ``exclude_unset=True``, so a scanner that
+    does not track targets has no counter keys at all rather than zeroes. That distinction is the
+    subject of one of the tests below, so the fixture has to be able to express it.
+
+    ``sarif.runs`` is empty, which keeps every severity count at zero. Without that the findings
+    gate would decide the status and the coverage assertions would be measuring the wrong thing.
+    """
+    model = MagicMock()
+    model.sarif = MagicMock()
+    model.sarif.runs = []
+    model.scanner_results = {}
+    model.ash_config = MagicMock()
+    model.ash_config.global_settings.severity_threshold = "MEDIUM"
+    model.ash_config.get_plugin_config.return_value = None
+    model.additional_reports = reports
+    return model
+
+
+def _report(status: str, attempted=None, failed=None, name="cdk-nag") -> dict:
+    report = {"scanner_name": name, "status": status, "duration": 1.0}
+    if attempted is not None:
+        report["targets_attempted"] = attempted
+    if failed is not None:
+        report["targets_failed"] = failed
+    return report
+
+
+PARTIAL = {
+    "cdk-nag": {
+        # Two of three source targets could not be evaluated; the converted tree was clean.
+        "source": _report("PASSED", attempted=3, failed=2),
+        "converted": _report("PASSED", attempted=1, failed=0),
+    }
+}
+
+
+class TestTargetCountsReachTheMetrics:
+    def test_counts_are_summed_across_every_target_report(self):
+        """Both targets contribute, because a scanner gets two and either can lose coverage.
+
+        Exact totals are asserted rather than "greater than zero": summing only the source report
+        would give (3, 2) and reading only the converted one (1, 0), and both would satisfy a
+        loose assertion while dropping half the input.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        metrics = {
+            m.scanner_name: m for m in get_unified_scanner_metrics(_model(PARTIAL))
+        }
+
+        assert metrics["cdk-nag"].targets_attempted == 4
+        assert metrics["cdk-nag"].targets_failed == 2
+
+    def test_a_scanner_that_does_not_track_targets_makes_no_claim(self):
+        """None, not zero. The distinction is load-bearing.
+
+        ``targets_attempted`` is tri-state in the container for a documented reason: absent means
+        "this scanner does not track targets", and 0 means "it tracked and attempted none". bandit,
+        checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag and npm-audit are all in
+        the first state. Collapsing them to 0 would report every one of them as having evaluated
+        nothing.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["bandit"].targets_attempted is None
+        assert metrics["bandit"].targets_failed == 0
+
+    def test_the_counts_are_serialized_with_the_rest_of_the_metrics(self):
+        """``ash.flat.json`` is a verbatim dump of these rows, so presence here is user-visible.
+
+        Asserted on the dump rather than on the attributes, because a field excluded from
+        serialization would satisfy the attribute assertions above and still never reach a file.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        dumped = get_unified_scanner_metrics(_model(PARTIAL))[0].model_dump()
+
+        assert dumped["targets_attempted"] == 4
+        assert dumped["targets_failed"] == 2
+
+
+class TestTheCountsReachTheMachineReadableReports:
+    """``ReportContentEmitter.get_scanner_results()`` is a hand-built dict, not a model dump.
+
+    Worth its own test because assuming otherwise was wrong. Adding the fields to
+    ``ScannerMetrics`` made them serializable but did NOT put them in ``ash.flat.json``: that
+    reporter goes through this emitter, which enumerates its keys explicitly, so a new field on
+    the model reaches the file only if it is listed here too. Measured before the fix --
+    ``targets_attempted`` was absent from a real ``ash.flat.json`` even with the model field
+    populated.
+    """
+
+    def test_the_emitted_scanner_row_carries_both_counts(self):
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
+            ReportContentEmitter,
+        )
+
+        emitter = ReportContentEmitter(_model(PARTIAL))
+        rows = {r["scanner_name"]: r for r in emitter.get_scanner_results()}
+
+        assert rows["cdk-nag"]["targets_attempted"] == 4
+        assert rows["cdk-nag"]["targets_failed"] == 2
+
+    def test_a_non_tracking_scanner_emits_null_rather_than_zero(self):
+        """null and 0 are different claims, and a consumer has to be able to tell them apart."""
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.report_content_emitter import (
+            ReportContentEmitter,
+        )
+
+        emitter = ReportContentEmitter(
+            _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        )
+        rows = {r["scanner_name"]: r for r in emitter.get_scanner_results()}
+
+        assert rows["bandit"]["targets_attempted"] is None
+        assert rows["bandit"]["targets_failed"] == 0
+
+
+class TestCoverageShortfallsAreEnumerated:
+    def test_a_scanner_that_lost_targets_is_reported_with_its_counts(self):
+        """The structured channel the renderer formats, asserted as data rather than as prose."""
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        assert coverage_shortfalls(_model(PARTIAL)) == [("cdk-nag", 4, 2)]
+
+    def test_a_scanner_that_lost_nothing_is_absent(self):
+        """The negative control that stops the fix from warning about every scan."""
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+        assert coverage_shortfalls(_model(clean)) == []
+
+    def test_a_non_tracking_scanner_is_absent(self):
+        """No claim is not a shortfall.
+
+        Without this, a fix reading the absent counters as zeroes would list every non-tracking
+        scanner as having lost coverage.
+        """
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        model = _model({"bandit": {"source": _report("PASSED", name="bandit")}})
+        assert coverage_shortfalls(model) == []
+
+    def test_a_total_loss_is_reported_too(self):
+        """The all-failed case is a shortfall as well, not only the partial one.
+
+        Its status already says ERROR, but the count of what went unevaluated is exactly as
+        absent from the table there as it is in the partial case.
+        """
+        from automated_security_helper.core.unified_metrics import coverage_shortfalls
+
+        total = {"cdk-nag": {"source": _report("ERROR", attempted=3, failed=3)}}
+        assert coverage_shortfalls(_model(total)) == [("cdk-nag", 3, 3)]
+
+
+class TestTheVerdictIsDeliberatelyUnchanged:
+    @pytest.mark.parametrize("failed", [1, 2])
+    def test_partial_coverage_loss_still_reports_passed(self, failed: int):
+        """Named as PASSED, not as "not ERROR".
+
+        This change makes the loss legible and does not turn it into a failure, because at the
+        measured 40% rate on this repository that would make a routine condition a permanent red.
+        Asserting the exact status means a later decision to fail on partial coverage has to
+        change this test, which is where such a decision should be visible.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model(
+            {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=failed)}}
+        )
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["cdk-nag"].status == "PASSED"
+        assert metrics["cdk-nag"].passed is True
+
+    def test_total_coverage_loss_still_reports_error(self):
+        """The existing cliff is preserved, so the fix cannot flatten it either."""
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model({"cdk-nag": {"source": _report("ERROR", attempted=3, failed=3)}})
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert metrics["cdk-nag"].status == "ERROR"
+        assert metrics["cdk-nag"].passed is False
+
+
+class TestTheShortfallReachesTheMarkdownSummary:
+    """``ash.summary.md`` is the artifact a human pastes into a pull request.
+
+    Presence, absence, and the counts -- but not the sentence around them. The scanner table in
+    that report keeps its fixed ten-column shape, which is asserted elsewhere and parsed
+    positionally, so the shortfall is appended after it rather than added to it.
+    """
+
+    def _render(self, reports: dict, test_plugin_context, compact: bool = False) -> str:
+        """Constructed with ``context=`` because the reporter is a pydantic model whose
+        ``AshAggregatedResults`` annotation is a TYPE_CHECKING forward reference; without a
+        context it is not fully defined and instantiation raises. Every existing reporter test
+        uses the same form.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.reporters.markdown_reporter import (
+            MarkdownReporter,
+        )
+
+        reporter = MarkdownReporter(context=test_plugin_context)
+        reporter.report(_model(reports))  # resolves self.config from defaults
+        reporter.config.options.compact = compact
+        return reporter.report(_model(reports))
+
+    def test_a_shortfall_is_listed_with_its_counts(self, test_plugin_context):
+        out = self._render(PARTIAL, test_plugin_context)
+
+        assert "cdk-nag" in out
+        # 2 of 4 evaluated, 2 failed -- the arithmetic, not the phrasing.
+        assert "2 of 4" in out
+        assert "2 could not be evaluated" in out
+
+    def test_nothing_is_listed_when_no_coverage_was_lost(self, test_plugin_context):
+        """The negative control. Without it, a section emitted unconditionally would pass above."""
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+
+        assert "Incomplete coverage" not in self._render(clean, test_plugin_context)
+
+    def test_compact_mode_still_reports_it(self, test_plugin_context):
+        """Compact mode drops noise; a coverage gap is signal.
+
+        Asserted because compact is the rendering most likely to be pasted into a pull request,
+        so suppressing the notice there would remove it from the place it matters most.
+        """
+        out = self._render(PARTIAL, test_plugin_context, compact=True)
+
+        assert "2 of 4" in out
+
+    def test_the_scanner_table_keeps_its_column_count(self, test_plugin_context):
+        """The shortfall must not have been implemented as an extra column after all.
+
+        Counts the pipes in the header row. A test asserting only that the shortfall appears
+        would pass either way, and a twelfth column would silently break every positional
+        consumer of this table.
+        """
+        out = self._render(PARTIAL, test_plugin_context)
+        header = [line for line in out.splitlines() if line.startswith("| Scanner")]
+        assert header, f"no scanner table header found in:\n{out[:600]}"
+        assert header[0].count("|") == 11, (
+            f"the ten-column scanner table changed shape: {header[0]}"
+        )
+
+
+class TestTheShortfallReachesTheConsole:
+    """Presence versus absence only -- the channel, not the wording.
+
+    The counts are already pinned by ``TestCoverageShortfallsAreEnumerated`` against structured
+    output. Asserting the rendered sentence here as well would be asserting prose, which is what
+    passes on a cosmetic change while a miscount survives.
+    """
+
+    def _render(self, model) -> str:
+        from io import StringIO
+
+        from rich.console import Console
+
+        from automated_security_helper.core.metrics_table import (
+            print_coverage_shortfalls,
+        )
+
+        buffer = StringIO()
+        print_coverage_shortfalls(
+            model, Console(file=buffer, width=200, color_system=None)
+        )
+        return buffer.getvalue()
+
+    def test_a_shortfall_is_printed_and_names_the_scanner_and_both_counts(self):
+        out = self._render(_model(PARTIAL))
+
+        assert out.strip(), "a scanner lost coverage and the console said nothing"
+        assert "cdk-nag" in out
+        # The numbers, so a renderer that printed a bare warning without them fails here.
+        assert "4" in out and "2" in out
+
+    def test_nothing_is_printed_when_no_coverage_was_lost(self):
+        clean = {"cdk-nag": {"source": _report("PASSED", attempted=3, failed=0)}}
+
+        assert self._render(_model(clean)) == ""

--- a/tests/unit/core/test_scanner_status_across_targets.py
+++ b/tests/unit/core/test_scanner_status_across_targets.py
@@ -1,0 +1,204 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""An ERROR on any scanned target has to reach the rolled-up scanner status.
+
+WHY THIS FILE EXISTS
+--------------------
+``ScanPhase`` hands each scanner one task carrying two targets -- the source tree and the
+converted tree -- and ``ScanResultProcessor`` writes one serialized container per target under
+``additional_reports[scanner][target_type]``. The rolled-up status a human reads comes from
+``get_unified_scanner_metrics``, whose loudest branch is ``stats["error"]``, and that flag is
+produced by ``get_scanner_status_info``.
+
+``get_scanner_status_info`` read the ``"source"`` report and only the ``"source"`` report. So a
+scanner that passed on the source tree and errored on the converted tree rolled up to PASSED:
+the ERROR container was written, serialized, and never consulted. An ERROR means no rule was
+evaluated on that target, so this is the silent-pass shape the surrounding code was written
+against, arriving through the target dimension instead of through the severity counts.
+
+WHAT WAS ALREADY HANDLED, AND WHY THAT WAS NOT ENOUGH
+-----------------------------------------------------
+Two adjacent guards already existed and neither one covers this:
+
+* ``ScanResultsContainer.determine_status`` returns ERROR when a tracking scanner failed every
+  target it attempted. It did its job here -- the converted container really does carry
+  ``status="ERROR"``. The loss is downstream of it.
+* ``scanner_evaluated_nothing`` reads across EVERY target report, and documents why: only one
+  of the two targets may have been empty. It is the correct quantifier applied to the wrong
+  fact, and the asymmetry between the two functions is exactly where the defect lived.
+
+ASSERTIONS ARE ON THE PRESENCE OF ERROR, NOT ON THE ABSENCE OF PASSED
+--------------------------------------------------------------------
+"The status is no longer PASSED" would also be satisfied by FAILED, SKIPPED or MISSING, and by
+a scanner disappearing from the metrics list altogether. Each test below names the status it
+requires.
+
+WHAT IS DELIBERATELY NOT CHANGED
+--------------------------------
+``excluded`` and ``dependencies_missing`` are still read off the single scanner-level report.
+Both are facts about configuration rather than about a target: a scanner is switched off, or
+its tool is absent, for the whole run. Widening those to "any target" would let one target with
+an unrecognized status -- which ``_status_info_from_report`` maps to ``excluded=True`` for
+backward compatibility -- mark the whole scanner as operator-excluded.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _model_with_target_statuses(source_status: str, converted_status: str):
+    """An AshAggregatedResults stand-in carrying one serialized container per target.
+
+    The report shape is the one ``ScanResultProcessor`` actually writes: it dumps the
+    container with ``exclude_unset=True``, so only fields a scanner assigned are present.
+    That is why ``excluded`` is absent here rather than set to False -- its absence is what
+    makes ``_status_info_from_report`` trust the field.
+
+    ``sarif.runs`` is empty so every severity count is zero. That keeps the ``actionable > 0``
+    branch out of the way, which matters: it is checked before the did-not-run branches, and a
+    fixture that accidentally carried findings would return FAILED and pass a test that is
+    supposed to be about ERROR.
+    """
+    model = MagicMock()
+    model.sarif = MagicMock()
+    model.sarif.runs = []
+    model.scanner_results = {}
+    # Real values, not bare MagicMock attributes. ``ScannerMetrics.threshold`` is typed as a
+    # str and ``get_scanner_threshold_info`` reads it straight off the config, so an
+    # auto-created mock attribute reaches pydantic and raises a validation error before any
+    # status is computed -- a failure that looks like the defect but is the fixture.
+    model.ash_config = MagicMock()
+    model.ash_config.global_settings.severity_threshold = "MEDIUM"
+    model.ash_config.get_plugin_config.return_value = None
+    model.additional_reports = {
+        "cdk-nag": {
+            "source": {
+                "scanner_name": "cdk-nag",
+                "status": source_status,
+                "targets_attempted": 2,
+                "targets_failed": 0,
+                "duration": 1.5,
+            },
+            "converted": {
+                "scanner_name": "cdk-nag",
+                "status": converted_status,
+                "targets_attempted": 1,
+                "targets_failed": 1,
+                "duration": 0.5,
+            },
+        }
+    }
+    return model
+
+
+class TestErrorOnAnyTargetReachesTheRollup:
+    def test_status_info_reports_error_when_only_the_converted_target_errored(self):
+        """The measured shape: source PASSED, converted ERROR.
+
+        This is the narrowest statement of the defect. ``get_scanner_status_info`` returns the
+        ``error`` flag that every rolled-up status ultimately keys on, so if it is False here
+        nothing downstream can recover the fact.
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        excluded, dependencies_missing, error = (
+            ScannerStatisticsCalculator.get_scanner_status_info(model, "cdk-nag")
+        )
+
+        assert error is True, (
+            "an ERROR on the converted target did not set the error flag; the container was "
+            "written and never read"
+        )
+        # Named explicitly so a future change that produces error=True by routing through the
+        # excluded/missing branches instead fails here rather than passing quietly.
+        assert excluded is False
+        assert dependencies_missing is False
+
+    def test_status_info_reports_error_when_only_the_source_target_errored(self):
+        """The mirror case, so the fix cannot be a source-versus-converted swap.
+
+        Reading only ``"converted"`` would satisfy the test above and break this one. Both
+        directions are asserted because "any target" is the property being fixed, not "the
+        other target".
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("ERROR", "PASSED")
+
+        _, _, error = ScannerStatisticsCalculator.get_scanner_status_info(
+            model, "cdk-nag"
+        )
+
+        assert error is True, "an ERROR on the source target did not set the error flag"
+
+    def test_get_scanner_status_returns_error_for_a_converted_target_error(self):
+        """The string status, which is the other public route to the same fact.
+
+        ``get_scanner_status`` and ``get_unified_scanner_metrics`` are two functions answering
+        "what is this scanner's status", and the module's own comments require they not
+        disagree. Asserting both means a fix applied to one of them cannot leave the other
+        reporting PASSED.
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        assert (
+            ScannerStatisticsCalculator.get_scanner_status(model, "cdk-nag") == "ERROR"
+        )
+
+    def test_unified_metrics_rolls_a_converted_target_error_up_to_error(self):
+        """The status a human reads off the summary table, and the ``passed`` flag with it.
+
+        ``ScannerMetrics.passed`` is True for PASSED, SKIPPED and MISSING, so a row that
+        rolled up wrong renders green and is also serialized into ``ash.flat.json`` as
+        ``passed: true``. Both are asserted: the status is what the table shows, and
+        ``passed`` is what a machine consumer gates on.
+        """
+        from automated_security_helper.core.unified_metrics import (
+            get_unified_scanner_metrics,
+        )
+
+        model = _model_with_target_statuses("PASSED", "ERROR")
+
+        metrics = {m.scanner_name: m for m in get_unified_scanner_metrics(model)}
+
+        assert "cdk-nag" in metrics, (
+            "the scanner vanished from the metrics list entirely"
+        )
+        assert metrics["cdk-nag"].status == "ERROR"
+        assert metrics["cdk-nag"].passed is False
+
+    @pytest.mark.parametrize("converted_status", ["PASSED", "FAILED", "SKIPPED"])
+    def test_a_non_error_converted_target_does_not_invent_an_error(
+        self, converted_status: str
+    ):
+        """The negative control, without which the fix could be ``error = True``.
+
+        A test suite that only checks ERROR-is-visible is satisfied by a function that always
+        reports an error. FAILED and SKIPPED are included alongside PASSED because both are
+        verdicts a target legitimately reaches, and neither means "nothing was evaluated".
+        """
+        from automated_security_helper.core.scanner_statistics_calculator import (
+            ScannerStatisticsCalculator,
+        )
+
+        model = _model_with_target_statuses("PASSED", converted_status)
+
+        _, _, error = ScannerStatisticsCalculator.get_scanner_status_info(
+            model, "cdk-nag"
+        )
+
+        assert error is False, (
+            f"a converted target reporting {converted_status} was read as an error"
+        )

--- a/tests/unit/core/test_scanner_status_across_targets.py
+++ b/tests/unit/core/test_scanner_status_across_targets.py
@@ -11,11 +11,25 @@ converted tree -- and ``ScanResultProcessor`` writes one serialized container pe
 ``get_unified_scanner_metrics``, whose loudest branch is ``stats["error"]``, and that flag is
 produced by ``get_scanner_status_info``.
 
-``get_scanner_status_info`` read the ``"source"`` report and only the ``"source"`` report. So a
-scanner that passed on the source tree and errored on the converted tree rolled up to PASSED:
-the ERROR container was written, serialized, and never consulted. An ERROR means no rule was
-evaluated on that target, so this is the silent-pass shape the surrounding code was written
-against, arriving through the target dimension instead of through the severity counts.
+``get_scanner_status_info`` never consulted a per-target ERROR at all. Its branches are, in
+order: the scanner-level ``"None"`` report, else the ``scanner_results`` entry, else the
+``"source"`` report. In a real run ``scanner_results`` carries the scanner, so that middle branch
+wins and reads only ``excluded`` and ``dependencies_satisfied`` -- ``error`` stays False and even
+the ``"source"`` fallback is unreachable. So a scanner that passed on the source tree and errored
+on the converted tree rolled up to PASSED: the ERROR container was written, serialized, and read
+by nothing. An ERROR means no rule was evaluated on that target, so this is the silent-pass shape
+the surrounding code was written against, arriving through the target dimension instead of through
+the severity counts.
+
+THIS IS A STATUS CHANGE, AND IT IS NOT OPTED IN
+-----------------------------------------------
+Worth stating plainly here because sibling files say partial coverage does NOT move a status, and
+both are true of different conditions. ``error`` is the FIRST branch in both
+``get_scanner_status`` and ``get_unified_scanner_metrics``, so for an affected scanner the summary
+table, every report format and ``ash.flat.json``'s ``passed`` all change, on every scan, with no
+flag. The CHANGELOG carries it as a breaking change. Measured on this repository nothing changes,
+because cdk-nag's only target report is the source tree and it carries PASSED -- a repository is
+affected only where some tree lost every target it attempted.
 
 WHAT WAS ALREADY HANDLED, AND WHY THAT WAS NOT ENOUGH
 -----------------------------------------------------

--- a/tests/unit/interactions/test_fail_on_partial_target_coverage.py
+++ b/tests/unit/interactions/test_fail_on_partial_target_coverage.py
@@ -357,6 +357,39 @@ class TestTriStateSurvivesTheGate:
         )
         assert _listed([row]) == []
 
+    @pytest.mark.parametrize("bad_failed", [None, "4", 4.0, True])
+    def test_a_valid_attempt_count_with_an_unusable_failure_count(self, bad_failed):
+        """Each counter is guarded independently, and this is the second guard.
+
+        Added because it was missing: the branch that rejects an unusable
+        ``targets_failed`` was the one uncovered line in the new code after the
+        first full-suite run. Every other case in this class is rejected on the
+        ATTEMPT count and returns before the failure count is ever examined, so
+        the second guard was dead as far as the tests were concerned -- present,
+        plausible, and never executed.
+
+        The state is reachable rather than theoretical: a producer that writes an
+        attempt count and then a malformed failure count -- null, a string, a
+        float, a bool -- lands exactly here. ``4.0`` is included because a float
+        is not an ``int`` and would otherwise flow into the comparison; ``True``
+        because bool is an ``int`` subclass and must be rejected on this counter
+        for the same reason it is on the other one.
+
+        A shortfall needs both numbers to be trustworthy, so an unusable failure
+        count yields no claim rather than a guess.
+        """
+        row = SimpleNamespace(
+            scanner_name="cdk-nag",
+            status=ScannerStatus.PASSED.value,
+            targets_attempted=10,
+            targets_failed=bad_failed,
+        )
+
+        assert _listed([row]) == [], (
+            f"targets_failed={bad_failed!r} is not a usable count, so there is no "
+            f"honest shortfall to report"
+        )
+
 
 class TestTotalLossKeepsItsOldReport:
     """ERROR and MISSING have to read exactly as they did, message included."""

--- a/tests/unit/interactions/test_fail_on_partial_target_coverage.py
+++ b/tests/unit/interactions/test_fail_on_partial_target_coverage.py
@@ -696,12 +696,9 @@ class TestTheGateReadsTheRealRollup:
         along the way fails here, which the injected-row version of this control cannot
         detect -- it never runs ``target_counts`` at all.
         """
-        assert (
-            incomplete_scanners(
-                _rollup_model({"bandit": {"source": _target_report("PASSED", name="bandit")}})
-            )
-            == []
-        )
+        reports = {"bandit": {"source": _target_report("PASSED", name="bandit")}}
+
+        assert incomplete_scanners(_rollup_model(reports)) == []
 
     def test_the_default_exit_code_is_unchanged_through_the_real_rollup(self, tmp_path):
         """The blast-radius guard, measured end to end rather than on injected rows.

--- a/tests/unit/interactions/test_fail_on_partial_target_coverage.py
+++ b/tests/unit/interactions/test_fail_on_partial_target_coverage.py
@@ -17,19 +17,37 @@ turned the gate on to be told when coverage was lost was told only about total
 loss, which is the rarer case.
 
 Measured on this repository before the change: cdk-nag attempts 10 targets and
-fails 4, reports PASSED, and ``--fail-on-incomplete-scanners`` exited 0. Two of
-those four are real CloudFormation templates that went unscanned.
+fails 4, its per-target container reports PASSED, and
+``--fail-on-incomplete-scanners`` exited 0. Two of those four are real
+CloudFormation templates that went unscanned.
 
 What is deliberately NOT changed
 --------------------------------
-* No new ``ScannerStatus`` member. The status a scanner reports is unchanged, and
-  ``test_partial_coverage_does_not_change_the_status`` pins that.
+* No new ``ScannerStatus`` member. Partial coverage is expressed in this gate's
+  own output and not by promoting a status, so ``cli.merge._completed`` keeps
+  answering the narrower did-it-run-at-all question that shard refusal depends on.
+  ``test_partial_coverage_still_counts_as_having_run`` pins that, and pins it
+  falsifiably: it measures that the counters DO reach the entry -- the model sets
+  ``extra="allow"`` -- so ``_completed`` ignoring them is a behavior a mutation can
+  break rather than a structural impossibility.
 * No new config key. This is the existing opt-in flag learning about a case it
   was always meant to cover.
 * The default path. ``TestDefaultPathIsUntouched`` asserts that a partial-coverage
   run without the flag exits exactly as it did before -- because this change does
   move existing opt-in users from 0 to 1, and the blast radius has to stay
   confined to people who asked for the gate.
+
+What IS changed elsewhere, so this file is not read as a claim about the whole PR
+--------------------------------------------------------------------------------
+A sibling commit ORs ``any_target_errored`` into the ``error`` flag, so a target
+tree that lost ALL its targets -- which ``determine_status`` does report as ERROR
+-- now reaches the ROLLED-UP status. That is a status change with no opt-in, and
+it is not what this file is about; ``tests/unit/core/
+test_scanner_status_across_targets.py`` owns it. The distinction that makes both
+true at once: partial loss on a tree never became a status, total loss on a tree
+always was one and simply could not be seen. ``TestTheGateReadsTheRealRollup``
+below is where the two meet, and it is the only class here that does not patch
+``get_unified_scanner_metrics``.
 
 The tri-state is the subtle part
 --------------------------------
@@ -249,24 +267,80 @@ class TestDefaultPathIsUntouched:
 
         assert code == 0
 
-    def test_partial_coverage_does_not_change_the_status(self):
-        """The gate reads the status; it does not rewrite it.
+    def test_partial_coverage_still_counts_as_having_run(self):
+        """``cli.merge._completed`` asks a narrower question and must keep asking it.
 
-        Were the fix implemented by promoting a partial-coverage scanner to
-        ERROR, every reporter and the summary table would start calling a scan
-        that ran an error, and ``_completed`` in ``cli.merge`` would begin
-        refusing shards that had merely lost a target. The status stays PASSED
-        and only the gate's own verdict changes.
+        This replaces a test that could not fail. Its predecessor built a
+        ``ScannerMetrics`` with ``status=PASSED`` handed in and then asserted the
+        status was PASSED, which pins only that ``incomplete_scanners`` does not
+        mutate its argument -- something nobody proposed and no production code
+        does. It exercised none of the two behaviors it claimed to protect.
+
+        The behavior worth protecting is the one below. Two checks both mean
+        "incomplete" and answer different questions:
+
+        * ``_completed`` asks whether a scanner ran **at all**, and
+          ``_verify_shard_contributions`` refuses a merge outright where a shard
+          completed none of the scanners it owned. A scanner that read 6 of 10
+          targets ran.
+        * ``incomplete_scanners`` asks whether everything the scanner was given was
+          evaluated. It answers no, and that is what the opt-in exit-code gate acts
+          on.
+
+        Why this is falsifiable, which an earlier note in ``tests/unit/cli/
+        test_merge.py`` denied. That note said ``ScannerTargetStatusInfo``
+        "declares no target counters at all, so it cannot see coverage even if
+        someone wired it to try", making the boundary structural. The model sets
+        ``extra="allow"``: counters written into ``scanner_results`` land in
+        ``model_extra``, and the assertion below measures that ``getattr`` finds
+        them. So ``_completed`` CAN read coverage, it simply does not, and
+        reimplementing it to consult these counters fails this test.
+
+        The counters are asserted present before the verdict is. Without that, a
+        model that silently dropped the extras would make the ``_completed``
+        assertion pass for the wrong reason -- there would be no coverage to
+        ignore.
         """
-        metric = _metric(
-            "cdk-nag",
-            ScannerStatus.PASSED.value,
+        from automated_security_helper.cli.merge import _completed
+        from automated_security_helper.models.asharp_model import (
+            ScannerTargetStatusInfo,
+        )
+
+        entry = ScannerTargetStatusInfo(
+            status=ScannerStatus.PASSED,
             targets_attempted=10,
             targets_failed=4,
         )
 
-        assert metric.status == ScannerStatus.PASSED.value
-        assert metric.passed is True
+        assert getattr(entry, "targets_failed", None) == 4, (
+            "the counters must reach the entry, or _completed has nothing to "
+            "ignore and this test cannot fail"
+        )
+        assert _completed(entry) is True, (
+            "a scanner that evaluated 6 of its 10 targets ran; reading its "
+            "coverage here would make _verify_shard_contributions refuse healthy "
+            "shards, failing the merge far from the code that caused it"
+        )
+
+    def test_a_scanner_that_evaluated_nothing_still_does_not_count_as_having_run(self):
+        """The negative control for the assertion above.
+
+        Without it, ``_completed`` could be ``return True`` and the test above
+        would pass. ERROR is the status a target reaches when it lost everything,
+        and that one really does mean the scanner did not run.
+        """
+        from automated_security_helper.cli.merge import _completed
+        from automated_security_helper.models.asharp_model import (
+            ScannerTargetStatusInfo,
+        )
+
+        entry = ScannerTargetStatusInfo(
+            status=ScannerStatus.ERROR,
+            targets_attempted=10,
+            targets_failed=10,
+        )
+
+        assert _completed(entry) is False
 
 
 class TestTriStateSurvivesTheGate:
@@ -489,3 +563,165 @@ def _listed(metrics):
     """``incomplete_scanners`` over *metrics*."""
     with patch(f"{_MODULE}.get_unified_scanner_metrics", return_value=metrics):
         return incomplete_scanners(MagicMock())
+
+
+def _rollup_model(reports: dict):
+    """A results stand-in carrying serialized per-target reports and nothing derived.
+
+    Everything above this line injects ``ScannerMetrics`` rows by patching
+    ``get_unified_scanner_metrics``, which is the right shape for pinning the gate's
+    own logic and the wrong shape for pinning that the gate and the rollup agree. The
+    class below uses this instead: only ``additional_reports`` is populated, and the
+    counters and the status are both DERIVED by the production code under test.
+
+    ``scanner_results`` is left empty and ``sarif.runs`` is empty so no severity count
+    can decide the status -- otherwise a fixture that accidentally carried findings
+    would return FAILED and an assertion about ERROR would be measuring the findings
+    gate.
+    """
+    model = MagicMock()
+    model.sarif = MagicMock()
+    model.sarif.runs = []
+    model.scanner_results = {}
+    model.ash_config = MagicMock()
+    model.ash_config.global_settings.severity_threshold = "MEDIUM"
+    model.ash_config.get_plugin_config.return_value = None
+    model.additional_reports = reports
+    return model
+
+
+def _target_report(status: str, attempted=None, failed=None, name="cdk-nag") -> dict:
+    """One serialized ``ScanResultsContainer``, as ``ScanResultProcessor`` writes it.
+
+    Dumped with ``exclude_unset=True`` in production, so a scanner that does not track
+    targets has no counter keys at all rather than zeroes. Omitting them here rather
+    than passing None is what makes the non-tracking control a real control.
+    """
+    report = {"scanner_name": name, "status": status, "duration": 1.0}
+    if attempted is not None:
+        report["targets_attempted"] = attempted
+    if failed is not None:
+        report["targets_failed"] = failed
+    return report
+
+
+class TestTheGateReadsTheRealRollup:
+    """End to end from serialized per-target reports to the gate's verdict, unpatched.
+
+    Every other test in this module patches ``get_unified_scanner_metrics`` and hands
+    the gate rows it built itself. That leaves the seam where this change's two halves
+    meet completely uncovered: one half writes ``targets_attempted``/``targets_failed``
+    into ``ScannerMetrics`` from ``additional_reports``, the other reads them here, and
+    nothing drove the first into the second. A rename of either serialized key, or a
+    rollup that stopped summing across targets, would leave every injected-row test
+    green.
+
+    So these assert on ``incomplete_scanners`` with NO patch of the metrics getter.
+    ``target_counts``, ``get_scanner_status_info``, ``any_target_errored`` and
+    ``get_unified_scanner_metrics`` all run for real.
+    """
+
+    def test_partial_coverage_travels_from_the_serialized_reports_to_the_gate(self):
+        """The measured shape, derived rather than injected.
+
+        10 attempted and 4 failed on the source tree, which is what a real cdk-nag run
+        on this repository writes. The status stays PASSED because
+        ``determine_status`` only reports ERROR on total loss, so the counts are the
+        only thing that can carry the fact -- and they now arrive through the rollup.
+        """
+        listed = dict(
+            incomplete_scanners(
+                _rollup_model(
+                    {"cdk-nag": {"source": _target_report("PASSED", 10, 4)}}
+                )
+            )
+        )
+
+        assert "cdk-nag" in listed, (
+            "the counters did not survive the trip from additional_reports through "
+            "get_unified_scanner_metrics to the gate"
+        )
+        assert listed["cdk-nag"] == "PASSED (4 of 10 targets unevaluated)"
+
+    def test_a_total_loss_on_one_tree_arrives_as_error_carrying_its_counts(self):
+        """Both halves of this change, in one assertion, through the real rollup.
+
+        Source 2 attempted 0 failed, converted 1 attempted 1 failed. Two things have
+        to happen and neither is injected:
+
+        * ``any_target_errored`` has to see the converted tree's ERROR and roll the
+          scanner up to ERROR. Reading only ``"source"`` gives PASSED.
+        * the routing has to report the SUMMED counts -- 1 of 3 -- rather than the bare
+          status, because 1 of 3 is a partial shortfall. Selecting the bare-status arm
+          on status alone printed ``cdk-nag: ERROR`` and dropped them, which is exactly
+          the case the counts exist for: ERROR alone reads as "the tool is missing".
+        """
+        listed = dict(
+            incomplete_scanners(
+                _rollup_model(
+                    {
+                        "cdk-nag": {
+                            "source": _target_report("PASSED", 2, 0),
+                            "converted": _target_report("ERROR", 1, 1),
+                        }
+                    }
+                )
+            )
+        )
+
+        assert listed["cdk-nag"] == "ERROR (1 of 3 targets unevaluated)", (
+            f"expected the rolled-up ERROR to carry the summed counts; got "
+            f"{listed.get('cdk-nag')!r}"
+        )
+
+    def test_total_loss_on_every_tree_still_reports_the_bare_status(self):
+        """The precedence control, so the arm above cannot be "always append counts".
+
+        Everything attempted was lost, so the status already says nothing was
+        evaluated and a parenthetical would only repeat it.
+        """
+        listed = dict(
+            incomplete_scanners(
+                _rollup_model({"cdk-nag": {"source": _target_report("ERROR", 4, 4)}})
+            )
+        )
+
+        assert listed["cdk-nag"] == "ERROR"
+
+    def test_a_non_tracking_scanner_is_absent_from_the_real_rollup(self):
+        """The tri-state control at the seam, not just at the gate.
+
+        The nine scanners that report no counters must derive ``targets_attempted`` as
+        None through ``target_counts`` and be absent. Collapsing absence to 0 anywhere
+        along the way fails here, which the injected-row version of this control cannot
+        detect -- it never runs ``target_counts`` at all.
+        """
+        assert (
+            incomplete_scanners(
+                _rollup_model({"bandit": {"source": _target_report("PASSED", name="bandit")}})
+            )
+            == []
+        )
+
+    def test_the_default_exit_code_is_unchanged_through_the_real_rollup(self, tmp_path):
+        """The blast-radius guard, measured end to end rather than on injected rows.
+
+        ``_compute_exit_code`` reaches ``incomplete_scanners`` only once
+        ``_resolve_fail_on_incomplete_scanners`` returns true, so a partial-coverage run
+        that did not ask for the gate exits exactly as it did before. Asserted with the
+        real rollup so that a future change routing coverage into the default path is
+        caught here and not in somebody's pipeline.
+        """
+        model = _rollup_model({"cdk-nag": {"source": _target_report("PASSED", 10, 4)}})
+
+        assert dict(incomplete_scanners(model)), (
+            "the fixture must be genuinely partial or this asserts nothing"
+        )
+
+        opts = _opts(tmp_path, fail_on_findings=False)
+        assert _compute_exit_code(model, opts) == 0
+
+        opted_in = _opts(
+            tmp_path, fail_on_findings=False, fail_on_incomplete_scanners=True
+        )
+        assert _compute_exit_code(model, opted_in) == 1

--- a/tests/unit/interactions/test_fail_on_partial_target_coverage.py
+++ b/tests/unit/interactions/test_fail_on_partial_target_coverage.py
@@ -1,0 +1,458 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""``--fail-on-incomplete-scanners`` has to see a scanner that lost only *some* of its input.
+
+Why these tests exist
+---------------------
+The completeness gate selected on status alone::
+
+    _INCOMPLETE_SCANNER_STATUSES = {ERROR, MISSING}
+
+and ``ScanResultsContainer.determine_status`` returns ERROR only once
+``targets_failed >= targets_attempted``. Those two facts compose into a hole: a
+scanner that failed on *some* of its targets keeps whatever status the severity
+gate gives it -- normally PASSED -- so the gate never saw it. An operator who
+turned the gate on to be told when coverage was lost was told only about total
+loss, which is the rarer case.
+
+Measured on this repository before the change: cdk-nag attempts 10 targets and
+fails 4, reports PASSED, and ``--fail-on-incomplete-scanners`` exited 0. Two of
+those four are real CloudFormation templates that went unscanned.
+
+What is deliberately NOT changed
+--------------------------------
+* No new ``ScannerStatus`` member. The status a scanner reports is unchanged, and
+  ``test_partial_coverage_does_not_change_the_status`` pins that.
+* No new config key. This is the existing opt-in flag learning about a case it
+  was always meant to cover.
+* The default path. ``TestDefaultPathIsUntouched`` asserts that a partial-coverage
+  run without the flag exits exactly as it did before -- because this change does
+  move existing opt-in users from 0 to 1, and the blast radius has to stay
+  confined to people who asked for the gate.
+
+The tri-state is the subtle part
+--------------------------------
+``targets_attempted`` is ``None`` for the nine scanners that do not track
+per-target outcomes at all. ``None`` is "makes no claim", ``0`` is the claim
+"tracked, attempted none". Collapsing ``None`` to ``0`` would make every
+non-tracking scanner look like it evaluated nothing;
+``TestTriStateSurvivesTheGate`` pins all three values, because the gate is the
+consumer most likely to get this wrong -- it is the one that turns the number
+into a nonzero exit code.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from automated_security_helper.core.enums import ScannerStatus
+from automated_security_helper.core.unified_metrics import ScannerMetrics
+from automated_security_helper.interactions.run_ash_scan import (
+    ScanOptions,
+    _compute_exit_code,
+    incomplete_scanners,
+)
+
+_MODULE = "automated_security_helper.interactions.run_ash_scan"
+
+
+def _metric(
+    scanner_name: str,
+    status: str = ScannerStatus.PASSED.value,
+    *,
+    targets_attempted: int | None = None,
+    targets_failed: int = 0,
+    actionable: int = 0,
+) -> ScannerMetrics:
+    """A real ``ScannerMetrics``, not a MagicMock.
+
+    The sibling module's ``_metric`` helper builds MagicMocks on purpose -- it
+    pins status strings the calculator would never derive. That will not do here:
+    every attribute of a MagicMock is present and truthy, so a MagicMock cannot
+    express "this scanner reported no target counts", which is exactly the state
+    these tests have to distinguish from "reported zero".
+    """
+    return ScannerMetrics(
+        scanner_name=scanner_name,
+        status=status,
+        actionable=actionable,
+        targets_attempted=targets_attempted,
+        targets_failed=targets_failed,
+    )
+
+
+def _opts(tmp_path, **kwargs) -> ScanOptions:
+    return ScanOptions(
+        source_dir=tmp_path / "src",
+        output_dir=tmp_path / "out",
+        **kwargs,
+    )
+
+
+def _exit_code(tmp_path, metrics, **opt_kwargs) -> int:
+    """``_compute_exit_code`` over *metrics*, with findings-gating off.
+
+    ``fail_on_findings=False`` so the returned code reflects coverage alone. That
+    also exercises the ordering that matters: the completeness gate is checked
+    before the findings early-return, so a run with findings-gating off still
+    learns that its coverage was partial.
+    """
+    results = MagicMock()
+    results.sarif = None
+    opts = _opts(tmp_path, fail_on_findings=False, **opt_kwargs)
+    with patch(f"{_MODULE}.get_unified_scanner_metrics", return_value=metrics):
+        return _compute_exit_code(results, opts)
+
+
+class TestPartialCoverageTripsTheGate:
+    """The defect in its smallest form: some targets lost, status still PASSED."""
+
+    def test_partial_target_loss_exits_one_under_the_flag(self, tmp_path):
+        """4 of 10 targets unevaluated is not a clean scan.
+
+        This is the case measured on this repository. Before the change the
+        status was PASSED, PASSED is not in ``_INCOMPLETE_SCANNER_STATUSES``, and
+        the gate returned 0.
+        """
+        code = _exit_code(
+            tmp_path,
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                )
+            ],
+            fail_on_incomplete_scanners=True,
+        )
+
+        assert code == 1, (
+            "a scanner that could not evaluate 4 of its 10 targets has not "
+            "completed; exit 0 is indistinguishable from having scanned all 10"
+        )
+
+    def test_a_single_lost_target_is_enough(self, tmp_path):
+        """No tolerance threshold. One unevaluated target is unevaluated input.
+
+        A percentage floor was considered and rejected: it would need a number
+        nobody can justify, and "1 of 200 templates went unscanned" is still a
+        template nobody looked at.
+        """
+        code = _exit_code(
+            tmp_path,
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=200,
+                    targets_failed=1,
+                )
+            ],
+            fail_on_incomplete_scanners=True,
+        )
+
+        assert code == 1
+
+    def test_the_message_names_the_scanner_and_both_counts(self):
+        """An operator has to be able to tell this from a missing tool.
+
+        The pre-existing message for ERROR/MISSING reads "did not run", which is
+        false here -- the scanner ran and reported PASSED. The status string in
+        the pair therefore has to carry the counts, or the report tells the
+        operator to install a tool that is already installed.
+
+        No ``tmp_path``: this asserts on the pairs the gate returns, which is
+        where the numbers are data. That the counts also survive into a real
+        ``ash.flat.json`` is a different claim with a different failure mode --
+        ``ReportContentEmitter.get_scanner_results()`` enumerates its keys by
+        hand -- and it is pinned separately in
+        ``tests/unit/core/test_partial_target_coverage_visibility.py``.
+        """
+        listed = _listed(
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                )
+            ]
+        )
+
+        assert len(listed) == 1
+        name, status = listed[0]
+        assert name == "cdk-nag"
+        assert "4" in status and "10" in status, (
+            f"the operator needs both counts to judge severity; got {status!r}"
+        )
+
+    def test_full_coverage_stays_at_exit_zero(self, tmp_path):
+        """The control. Ten of ten evaluated is a complete scan."""
+        code = _exit_code(
+            tmp_path,
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=0,
+                )
+            ],
+            fail_on_incomplete_scanners=True,
+        )
+
+        assert code == 0
+
+
+class TestDefaultPathIsUntouched:
+    """This change moves existing opt-in users from 0 to 1. It must move nobody else."""
+
+    def test_partial_coverage_without_the_flag_exits_zero(self, tmp_path):
+        """Same input as the tripping case, flag absent, exit 0.
+
+        The gate is opt-in and stays opt-in. A repository whose cdk-nag loses 4
+        of 10 targets keeps exiting 0 unless it asked to be told.
+        """
+        code = _exit_code(
+            tmp_path,
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                )
+            ],
+        )
+
+        assert code == 0
+
+    def test_flag_explicitly_false_exits_zero(self, tmp_path):
+        """``--no-fail-on-incomplete-scanners`` is honoured, not merely the default."""
+        code = _exit_code(
+            tmp_path,
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                )
+            ],
+            fail_on_incomplete_scanners=False,
+        )
+
+        assert code == 0
+
+    def test_partial_coverage_does_not_change_the_status(self):
+        """The gate reads the status; it does not rewrite it.
+
+        Were the fix implemented by promoting a partial-coverage scanner to
+        ERROR, every reporter and the summary table would start calling a scan
+        that ran an error, and ``_completed`` in ``cli.merge`` would begin
+        refusing shards that had merely lost a target. The status stays PASSED
+        and only the gate's own verdict changes.
+        """
+        metric = _metric(
+            "cdk-nag",
+            ScannerStatus.PASSED.value,
+            targets_attempted=10,
+            targets_failed=4,
+        )
+
+        assert metric.status == ScannerStatus.PASSED.value
+        assert metric.passed is True
+
+
+class TestTriStateSurvivesTheGate:
+    """``None`` / ``0`` / positive must stay three distinct answers here."""
+
+    def test_none_attempted_is_not_a_shortfall(self):
+        """The nine non-tracking scanners must not all become failures.
+
+        bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag
+        and npm-audit report no target counts at all. Reading ``None`` as
+        "attempted 0, so everything was lost" would fail every scan on every
+        repository the moment the flag was turned on.
+        """
+        assert _listed([_metric("bandit", targets_attempted=None)]) == []
+
+    def test_none_attempted_with_a_nonzero_failure_count_is_not_a_shortfall(self):
+        """A failure count without an attempt count is a producer bug, not a verdict.
+
+        There is no honest denominator to report, so the gate declines to invent
+        one rather than emitting "3 of None".
+        """
+        assert (
+            _listed([_metric("bandit", targets_attempted=None, targets_failed=3)]) == []
+        )
+
+    def test_zero_attempted_and_zero_failed_is_not_a_shortfall(self):
+        """ "Tracked, attempted none, lost none" -- nothing was lost.
+
+        ``determine_status`` already routes attempted-zero to SKIPPED, which the
+        gate deliberately tolerates; this asserts the coverage arm does not
+        second-guess it.
+        """
+        assert (
+            _listed([_metric("cdk-nag", targets_attempted=0, targets_failed=0)]) == []
+        )
+
+    def test_a_positive_failure_count_with_a_known_denominator_is_a_shortfall(self):
+        """The one arrangement that is genuinely lost coverage."""
+        listed = _listed([_metric("cdk-nag", targets_attempted=10, targets_failed=4)])
+
+        assert len(listed) == 1
+        assert listed[0][0] == "cdk-nag"
+
+    def test_non_integer_counters_are_not_read_as_counts(self):
+        """A MagicMock metric must not trip the gate.
+
+        Not hypothetical: the sibling test module's ``_metric`` builds MagicMocks,
+        whose every attribute is present and truthy. Without this guard,
+        ``test_helper_lists_only_incomplete_scanners_with_statuses`` -- which
+        asserts that a PASSED bandit is absent from the list -- would start
+        seeing bandit as a partial-coverage failure. The same guard is what
+        ``unified_metrics.target_counts`` already applies to the serialized
+        counters, for the same reason.
+        """
+        mock_metric = MagicMock()
+        mock_metric.scanner_name = "bandit"
+        mock_metric.status = ScannerStatus.PASSED.value
+
+        assert _listed([mock_metric]) == [], (
+            "a metric whose counters are not integers makes no coverage claim"
+        )
+
+    def test_a_boolean_counter_is_not_read_as_one_or_zero(self):
+        """``True`` is an ``int`` subclass. Reading it as 1 would invent a target.
+
+        Deliberately NOT built through ``ScannerMetrics``. An earlier version of
+        this test was, and it failed for the wrong reason: pydantic coerces
+        ``True`` to a genuine ``int`` 1 on an ``int | None`` field, so a bool
+        never survives the model boundary and the assertion was describing a
+        state the model cannot hold.
+
+        The guard is reachable, though, because ``incomplete_scanners`` reads its
+        rows off whatever ``get_unified_scanner_metrics`` returns and reaches the
+        counters by ``getattr``. A plain object exercises that path. This is the
+        same hazard ``unified_metrics.target_counts`` guards against for real --
+        it reads the counters out of ``additional_reports``, which is parsed JSON,
+        where a ``true`` arrives as an actual ``bool``.
+        """
+        row = SimpleNamespace(
+            scanner_name="cdk-nag",
+            status=ScannerStatus.PASSED.value,
+            targets_attempted=True,
+            targets_failed=True,
+        )
+
+        assert isinstance(row.targets_attempted, bool), (
+            "the point of this test is a real bool reaching the gate"
+        )
+        assert _listed([row]) == []
+
+
+class TestTotalLossKeepsItsOldReport:
+    """ERROR and MISSING have to read exactly as they did, message included."""
+
+    @pytest.mark.parametrize(
+        "status", [ScannerStatus.ERROR.value, ScannerStatus.MISSING.value]
+    )
+    def test_status_based_incompleteness_reports_the_bare_status(self, status):
+        """No counts appended. These scanners were already covered by the gate.
+
+        Total loss also satisfies the coverage condition -- ``targets_failed >=
+        targets_attempted`` implies ``targets_failed > 0`` -- so without an
+        explicit precedence the ERROR row would gain a parenthetical and every
+        existing assertion on the message would break.
+        """
+        listed = _listed(
+            [_metric("cdk-nag", status, targets_attempted=10, targets_failed=10)]
+        )
+
+        assert listed == [("cdk-nag", status)]
+
+    def test_a_scanner_is_never_listed_twice(self):
+        """One scanner, one row, whichever arm selected it."""
+        listed = _listed(
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.ERROR.value,
+                    targets_attempted=10,
+                    targets_failed=10,
+                )
+            ]
+        )
+
+        assert len(listed) == 1
+
+    def test_skipped_with_no_counts_still_never_trips_the_gate(self):
+        """SKIPPED is how sharding excludes another shard's scanners.
+
+        Guarded in the sibling module for the status arm; repeated here because
+        the coverage arm is a second, independent route to the same list, and a
+        SKIPPED shard sibling reaching it would fail every shard of every
+        sharded scan.
+        """
+        assert _listed([_metric("semgrep", ScannerStatus.SKIPPED.value)]) == []
+
+
+class TestOrderingAndMixedRuns:
+    """A real run has several scanners in several states."""
+
+    def test_both_arms_appear_in_scanner_name_order(self):
+        """The list order is asserted because operators read it as a list."""
+        listed = _listed(
+            [
+                _metric("bandit", ScannerStatus.PASSED.value),
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.PASSED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                ),
+                _metric("grype", ScannerStatus.MISSING.value),
+                _metric("semgrep", ScannerStatus.SKIPPED.value),
+            ]
+        )
+
+        assert [name for name, _ in listed] == ["cdk-nag", "grype"]
+
+    def test_a_failed_scanner_with_partial_coverage_is_still_a_shortfall(self):
+        """FAILED means "ran and found problems", which does not mean "saw everything".
+
+        A scanner can report findings from the targets it managed to read and
+        still have lost others. The findings gate would fail this run anyway, but
+        not for this reason, and an operator clearing the listed findings would
+        believe the scan then clean.
+        """
+        listed = _listed(
+            [
+                _metric(
+                    "cdk-nag",
+                    ScannerStatus.FAILED.value,
+                    targets_attempted=10,
+                    targets_failed=4,
+                    actionable=3,
+                )
+            ]
+        )
+
+        assert len(listed) == 1
+        assert listed[0][0] == "cdk-nag"
+
+    def test_no_results_is_still_empty(self):
+        assert incomplete_scanners(None) == []
+
+
+def _listed(metrics):
+    """``incomplete_scanners`` over *metrics*."""
+    with patch(f"{_MODULE}.get_unified_scanner_metrics", return_value=metrics):
+        return incomplete_scanners(MagicMock())

--- a/tests/unit/plugin_modules/ash_builtin/reporters/test_github_ghas_reporter.py
+++ b/tests/unit/plugin_modules/ash_builtin/reporters/test_github_ghas_reporter.py
@@ -206,6 +206,80 @@ class TestReportStructure:
         assert emitted == rule_ids, "result order and membership must be preserved"
 
 
+class TestInvocationsDoNotReachGitHub:
+    """Error-level tool notifications must not be uploaded to Code Scanning.
+
+    cdk-nag's scanner now writes one ``toolExecutionNotifications`` entry per rule that raised
+    instead of returning a verdict, at ``level: error``, and those survive into the aggregated
+    ``ash.sarif`` -- measured on this repository, 11 of them where there were previously none.
+    ``github/codeql-action/upload-sarif`` renders an error-level notification as an analysis
+    error, so if they reached this report every ASH scan of a CDK repository would report
+    failures in Code Scanning that are not findings.
+
+    They do not, and this pins why rather than trusting it. ``report()`` reads ``model.sarif``
+    to harvest rules and results and then assembles a FRESH run dict carrying only
+    ``tool.driver`` and ``results``. It does not copy the run, so there is nowhere for an
+    invocation to arrive from. Measured against a real scan: ``ash.ghas.sarif`` has no
+    ``invocations`` key while ``ash.sarif`` alongside it has eleven notifications.
+
+    The guard is worth having because the containment is incidental. Nothing in ``report()``
+    names invocations or explains that omitting them is load-bearing, so a future refactor that
+    started from the source run and pruned it -- a natural way to write this -- would begin
+    uploading them with no test objecting. ASH's own workflow uploads ``ash.ghas.sarif``, so this
+    report is the boundary.
+    """
+
+    def test_error_level_tool_notifications_are_not_forwarded(self, reporter):
+        from automated_security_helper.schemas.sarif_schema_model import (
+            Invocation,
+            Message1,
+            Notification,
+            ReportingDescriptorReference,
+            ReportingDescriptorReference3,
+        )
+
+        run = Run(
+            tool=Tool(driver=ToolComponent(name="ASH", rules=[_rule("R1")])),
+            results=[_result("R1")],
+            invocations=[
+                Invocation(
+                    executionSuccessful=True,
+                    toolExecutionNotifications=[
+                        Notification(
+                            level=Level.error,
+                            message=Message(
+                                root=Message1(
+                                    text="Rule AwsSolutions-IAM5 could not be evaluated"
+                                )
+                            ),
+                            associatedRule=ReportingDescriptorReference(
+                                root=ReportingDescriptorReference3(
+                                    id="AwsSolutions-IAM5"
+                                )
+                            ),
+                        )
+                    ],
+                )
+            ],
+        )
+
+        model = _model(run)
+        assert model.sarif.runs[0].invocations[0].toolExecutionNotifications, (
+            "the input must actually carry an error notification, or this test passes "
+            "against a reporter that forwards everything"
+        )
+
+        doc = json.loads(reporter.report(model))
+
+        assert "invocations" not in doc["runs"][0], (
+            "an error-level tool notification reached the report uploaded to GitHub Code "
+            "Scanning, where it renders as an analysis error rather than a finding"
+        )
+        # The findings themselves still have to arrive, so the assertion above cannot be
+        # satisfied by a reporter that emitted nothing at all.
+        assert [r["ruleId"] for r in doc["runs"][0]["results"]] == ["R1"]
+
+
 class TestEmptyAndErrorPaths:
     def test_no_sarif_returns_empty_report(self, reporter):
         model = AshAggregatedResults()

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -43,7 +43,13 @@ from automated_security_helper.schemas.sarif_schema_model import (
 )
 
 
-def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
+def _result(
+    rule_id: str,
+    pack: str,
+    rule_level: str = "Error",
+    message_text: str | None = None,
+    message_markdown: str | None = None,
+) -> Result:
     """A Result shaped the way the wrapper emits one.
 
     ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
@@ -54,10 +60,27 @@ def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
     included. Those two matter: the wrapper already writes them onto every result, so a
     descriptor that forwards the result's tags AND appends its own emits each twice. A fixture
     that omitted them would leave the duplication tests unable to fail.
+
+    ``message_text`` and ``message_markdown`` are overridable because the message is a
+    per-occurrence value and the default is not. The default derives from ``rule_id`` alone,
+    which is what every caller below wants -- but it makes two results for one rule share a
+    message by construction, so a test that varies nothing else cannot observe the message
+    reaching the descriptor. ``TestRuleTagsAreRuleScoped`` passes both explicitly for that
+    reason. ``markdown`` is separate from ``text`` because they are two fields, and a fix that
+    stops forwarding one can leave the other forwarding.
     """
     return Result(
         ruleId=rule_id,
-        message=Message(root=Message1(text=f"{rule_id} description text")),
+        message=Message(
+            root=Message1(
+                text=(
+                    message_text
+                    if message_text is not None
+                    else f"{rule_id} description text"
+                ),
+                markdown=message_markdown,
+            )
+        ),
         properties=PropertyBag(
             cdk_nag_finding={
                 "pack": pack,
@@ -264,20 +287,56 @@ class TestRuleTagsAreRuleScoped:
         assert "AWS::IAM::Policy" not in descriptor.properties.tags
 
     def test_two_results_for_one_rule_yield_byte_identical_descriptors(self):
-        """Identical input, identical bytes -- whichever occurrence the aggregation yields first.
+        """No per-occurrence CHANNEL reaches the descriptor -- message, markdown or tags.
 
-        This is the stability half, and it is the one that could not be expressed at all while
-        the tags were inherited: the two results below differ ONLY in their per-occurrence tags,
-        so under forwarding the two descriptors differed and the emitted SARIF depended on
-        result order. Compared as serialized JSON rather than field by field, so a
-        per-occurrence value reaching any part of the descriptor fails here, not just one the
-        assertion happened to name.
+        What this pins, precisely: two results that agree on every rule-scoped fact (id, pack,
+        rule level, rule description) and disagree on all three per-occurrence channels must
+        produce the same descriptor bytes. ``scan()`` keys a ``rule_map`` by ``ruleId`` and
+        ``continue``s on a repeat, so exactly one of them becomes the descriptor and which one
+        is an aggregation order rather than a fact.
+
+        The scenario is real, not hypothetical. One cdk-nag rule that raises during validation
+        of two templates produces two results under one ``ruleId``, and
+        ``utils.cdk_nag_wrapper._result_message_text`` opens that message with the template's
+        own path -- so the message differs between them while the rule does not. Forwarding it
+        put one template's name in the definition of a rule that failed on both.
+
+        AN EARLIER VERSION OF THIS TEST COULD NOT FAIL, which is why the channels are now
+        passed explicitly. It varied ``properties.tags`` and nothing else, and took its message
+        from ``_result``'s default of ``f"{rule_id} description text"`` -- a function of
+        ``rule_id`` alone. Both results therefore shared a message BY CONSTRUCTION, and
+        ``model_dump_json()`` compared equal whether or not the message reached the descriptor.
+        Its docstring claimed "a per-occurrence value reaching any part of the descriptor fails
+        here"; only the tag half of that was ever true.
+
+        The three guard assertions below are the reason it cannot regress to that state. Each
+        one fails loudly if the fixture stops differing in that channel, so a future edit that
+        re-derives a channel from ``rule_id`` breaks the guard instead of quietly making the
+        comparison vacuous.
+
+        Compared as serialized JSON rather than field by field, so a channel reaching a field no
+        assertion happens to name still fails here.
         """
         from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
             _reporting_descriptor_for,
         )
 
-        first = _result("AwsSolutions-IAM5", "AwsSolutions")
+        # Both results are the same rule, not evaluated against two different templates. Only
+        # the template path differs -- the rule-scoped tail is identical, exactly as the
+        # wrapper builds it.
+        unevaluated = (
+            "so this result says nothing about whether the template complies with it."
+            "\n\nRule threw an error during validation."
+        )
+        first = _result(
+            "AwsSolutions-IAM5",
+            "AwsSolutions",
+            message_text=(
+                "'infra/alpha.template.json' was NOT evaluated for rule "
+                f"AwsSolutions-IAM5, {unevaluated}"
+            ),
+            message_markdown="`infra/alpha.template.json` was NOT evaluated.",
+        )
         first.properties.tags = [
             "aws",
             "cdk",
@@ -289,7 +348,15 @@ class TestRuleTagsAreRuleScoped:
             "tool_name::cdk-nag",
             "tool_type::IAC",
         ]
-        second = _result("AwsSolutions-IAM5", "AwsSolutions")
+        second = _result(
+            "AwsSolutions-IAM5",
+            "AwsSolutions",
+            message_text=(
+                "'infra/beta.template.json' was NOT evaluated for rule "
+                f"AwsSolutions-IAM5, {unevaluated}"
+            ),
+            message_markdown="`infra/beta.template.json` was NOT evaluated.",
+        )
         second.properties.tags = [
             "aws",
             "cdk",
@@ -302,9 +369,23 @@ class TestRuleTagsAreRuleScoped:
             "tool_type::IAC",
         ]
 
+        assert first.message.root.text != second.message.root.text, (
+            "the two occurrences must carry different message text or this test cannot "
+            "detect the message reaching the descriptor"
+        )
+        assert first.message.root.markdown != second.message.root.markdown, (
+            "the two occurrences must carry different message markdown or this test cannot "
+            "detect the markdown reaching the descriptor"
+        )
         assert first.properties.tags != second.properties.tags, (
             "the two occurrences must differ or this test cannot detect order dependence"
         )
+        # The rule-scoped facts must AGREE, or a descriptor difference would be legitimate and
+        # the comparison below would be asserting the wrong thing.
+        assert (
+            first.properties.model_extra["cdk_nag_finding"]
+            == second.properties.model_extra["cdk_nag_finding"]
+        ), "the two occurrences must agree on the rule-scoped facts"
 
         one = _reporting_descriptor_for(first, tool_name="cdk-nag", tool_type="IAC")
         two = _reporting_descriptor_for(second, tool_name="cdk-nag", tool_type="IAC")
@@ -313,6 +394,84 @@ class TestRuleTagsAreRuleScoped:
             "the rule descriptor depends on which occurrence was seen first, so two runs over "
             "identical input can emit different SARIF"
         )
+
+    def test_two_unevaluated_results_for_one_rule_yield_identical_descriptors(self):
+        """The case a ``rule_info``-based fix passes while still being order-dependent.
+
+        The test above varies the message, which is necessary and not sufficient. Deriving the
+        descriptions from ``finding_props["rule_info"]`` instead of from the message fixes that
+        one and leaves this one broken, so the two tests together discriminate between the
+        candidate fixes rather than only between broken and fixed.
+
+        WHY ``rule_info`` IS NOT RULE-SCOPED HERE. It is ``violation.description`` from
+        ``validation-report.json`` verbatim, and cdk-nag 3.0.2's ``addViolation`` builds that
+        field two ways. For an evaluated rule it is ``f"{params.info} {params.explanation}"``,
+        and those are static literals -- 463 of each in the bundled ``package/lib``, none
+        interpolated. For a rule that RAISED it is
+        ``f"Rule threw an error during validation. {errorMessage}"``, where ``errorMessage`` is
+        the rule's own exception text, included rather than elided because
+        ``_build_nag_pack`` passes ``verbose=True``. Every interpolating throw site reachable
+        from ``applyRule``'s catch embeds template-derived data: ``nag-rules.js:50`` the
+        resolved parameter value, ``LambdaLatestVersion.js:24``/``:48`` the resource runtime,
+        ``LexBotAliasEncryptedConversationLogs.js:57`` a resource logical id.
+
+        The two fixtures below are that shape: one rule, two templates, two different resolved
+        parameter values in the exception text. The descriptions come from
+        ``nag-rules.js``'s wording, doubled "to to" included, because that is what the real
+        report contains -- ``tests/unit/utils/test_cdk_nag_unevaluated_rule.py`` carries the
+        same string.
+
+        The descriptor must therefore use NEITHER the message nor ``rule_info`` on this path.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+        from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+        def _unevaluated(template: str, resolved: str) -> Result:
+            result = _result(
+                "AwsSolutions-EC26",
+                "AwsSolutions",
+                message_text=(
+                    f"'{template}' was NOT evaluated for rule AwsSolutions-EC26, so this "
+                    "result says nothing about whether the template complies with it."
+                ),
+            )
+            finding = result.properties.model_extra["cdk_nag_finding"]
+            finding["compliance"] = NOT_EVALUATED
+            finding["rule_info"] = (
+                "Rule threw an error during validation. The parameter resolved to to a "
+                f'non-primitive value "{resolved}", therefore the rule could not be validated.'
+            )
+            return result
+
+        first = _unevaluated("infra/alpha.template.json", '{"Ref":"VolumeEncrypted"}')
+        second = _unevaluated("infra/beta.template.json", '{"Ref":"KmsKeyArn"}')
+
+        assert (
+            first.properties.model_extra["cdk_nag_finding"]["rule_info"]
+            != second.properties.model_extra["cdk_nag_finding"]["rule_info"]
+        ), (
+            "the two occurrences must carry different rule_info or this test cannot tell a "
+            "rule_info-based fix apart from a rule-scoped one"
+        )
+
+        one = _reporting_descriptor_for(first, tool_name="cdk-nag", tool_type="IAC")
+        two = _reporting_descriptor_for(second, tool_name="cdk-nag", tool_type="IAC")
+
+        assert one.model_dump_json() == two.model_dump_json(), (
+            "the descriptor of a rule that threw depends on which template it threw on first, "
+            "so cdk-nag's exception text -- which carries resolved template values and, for "
+            "the Lex rule, a resource logical id -- reached the rule's definition"
+        )
+
+        # Named explicitly as well as compared, because the comparison above passes if BOTH
+        # descriptors carry the same wrong thing, and a future edit could make it so.
+        emitted = one.model_dump_json()
+        for leaked in ("VolumeEncrypted", "KmsKeyArn", "alpha.template.json"):
+            assert leaked not in emitted, (
+                f"{leaked!r} is a per-occurrence value and must not appear in a rule descriptor"
+            )
 
     def test_the_tool_type_tag_uses_the_enum_value_not_its_repr(self):
         """``ScannerToolType`` is a str mixin, and ``Enum.__str__`` still wins.

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -19,6 +19,15 @@ carried neither fact correctly:
   every finding that has ever been scanned, so the pack the wrapper had been writing onto each
   result never reached the rule.
 
+The tags repair went wrong once before it went right, and that is what
+``TestRuleTagsAreRuleScoped`` guards. Forwarding ``result.properties.tags`` wholesale put the
+pack on the rule and also put the FIRST matching resource's logical id and ``AWS::*::*`` type
+there, because the wrapper builds that list per occurrence while the descriptor is built once per
+``ruleId``. Measured on this repository: ``HIPAA.Security-IAMNoInlinePolicy`` fires on 35 results
+and its descriptor carried ``ConfigKeyAccessB463082D`` and ``AWS::IAM::Policy``. Which resource
+won was an ordering, not a fact, so identical input could produce different bytes. The tags are
+now constructed from rule-scoped facts, and the per-occurrence values stay on the results.
+
 These tests drive ``_reporting_descriptor_for`` directly. It was inline in ``scan()`` until this
 change, where reaching it meant running a full CDK synthesis -- which is why an always-empty
 ``tags`` read survived in it.
@@ -40,6 +49,11 @@ def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
     ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
     not declare it; ``tags`` is a declared field. The descriptor builder reads both, so the
     fixture has to populate both or it would be testing a shape the wrapper never produces.
+
+    ``tags`` reproduces the wrapper's list verbatim, ``tool_name::``/``tool_type::`` entries
+    included. Those two matter: the wrapper already writes them onto every result, so a
+    descriptor that forwards the result's tags AND appends its own emits each twice. A fixture
+    that omitted them would leave the duplication tests unable to fail.
     """
     return Result(
         ruleId=rule_id,
@@ -54,7 +68,16 @@ def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
                 "rule_level": rule_level,
                 "rule_info": f"{rule_id} rule info",
             },
-            tags=["aws", "cdk", "cdk-nag", pack, rule_id, "ProbeResource"],
+            tags=[
+                "aws",
+                "cdk",
+                "cdk-nag",
+                pack,
+                rule_id,
+                "ProbeResource",
+                "tool_name::cdk-nag",
+                "tool_type::IAC",
+            ],
         ),
     )
 
@@ -80,12 +103,13 @@ class TestRuleDescriptorNamesItsPack:
         assert descriptor.properties.model_extra["pack"] == "CloudFormation Validate"
         assert "pack::CloudFormation Validate" in descriptor.properties.tags
 
-    def test_the_findings_own_tags_are_forwarded_onto_the_rule(self):
+    def test_the_rule_scoped_tags_reach_the_rule(self):
         """The always-empty lookup, stated as the tags that must now be present.
 
-        Asserted as a subset rather than an exact list so that adding a tag later does not
-        break this, but every tag the result carried is named -- the previous code forwarded
-        none of them and no test noticed.
+        Asserted as a subset rather than an exact list so that adding a rule-scoped tag later
+        does not break this. Every one of these names the rule, the pack or the tool -- none of
+        them names a resource, which is the whole distinction
+        ``TestRuleTagsAreRuleScoped`` exists to hold.
         """
         from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
             _reporting_descriptor_for,
@@ -103,7 +127,9 @@ class TestRuleDescriptorNamesItsPack:
             "cdk-nag",
             "AwsSolutions",
             "AwsSolutions-S1",
-            "ProbeResource",
+            "pack::AwsSolutions",
+            "tool_name::cdk-nag",
+            "tool_type::IAC",
         }.issubset(set(descriptor.properties.tags))
 
     def test_a_cdk_nag_rule_still_points_at_cdk_nags_rule_documentation(self):
@@ -180,6 +206,164 @@ class TestRuleDescriptorNamesItsPack:
         # difference between "cdk-nag" and "we do not know".
         assert descriptor.properties.model_extra["pack"] == ""
         assert "pack::unknown" in descriptor.properties.tags
+
+
+class TestRuleTagsAreRuleScoped:
+    """A rule descriptor describes a rule. It must carry nothing about one occurrence of it.
+
+    ``scan()`` keys a ``rule_map`` by ``ruleId`` and ``continue``s on a repeat, so exactly one
+    of a rule's N results becomes its descriptor. Anything per-occurrence that reaches the
+    descriptor is therefore both wrong -- it describes one resource as though it described the
+    rule -- and unstable, since "the first result" is an ordering.
+    """
+
+    def test_a_resource_logical_id_never_reaches_the_rule_descriptor(self):
+        """The leak in its narrowest form.
+
+        ``ProbeResource`` is on the result's own tag list, exactly as the wrapper puts a real
+        resource's logical id there. It must not appear on the rule. Asserted on the resource id
+        specifically rather than on the list length, because a length assertion passes for the
+        wrong reason as soon as any tag is added or removed.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        result = _result("AwsSolutions-S1", "AwsSolutions")
+        assert "ProbeResource" in result.properties.tags, (
+            "the fixture must carry a per-occurrence tag or this test proves nothing"
+        )
+
+        descriptor = _reporting_descriptor_for(
+            result, tool_name="cdk-nag", tool_type="IAC"
+        )
+
+        assert "ProbeResource" not in descriptor.properties.tags, (
+            "the resource this rule happened to fire on first was stamped into the rule's "
+            "own definition"
+        )
+
+    def test_a_resource_type_never_reaches_the_rule_descriptor(self):
+        """The second per-occurrence value, asserted separately.
+
+        The wrapper writes ``cfn_resource.Type`` beside the logical id. Both are per-occurrence
+        and a filter could plausibly catch one and miss the other, so neither is covered by a
+        test of the other.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        result = _result("AwsSolutions-S1", "AwsSolutions")
+        result.properties.tags.append("AWS::IAM::Policy")
+
+        descriptor = _reporting_descriptor_for(
+            result, tool_name="cdk-nag", tool_type="IAC"
+        )
+
+        assert "AWS::IAM::Policy" not in descriptor.properties.tags
+
+    def test_two_results_for_one_rule_yield_byte_identical_descriptors(self):
+        """Identical input, identical bytes -- whichever occurrence the aggregation yields first.
+
+        This is the stability half, and it is the one that could not be expressed at all while
+        the tags were inherited: the two results below differ ONLY in their per-occurrence tags,
+        so under forwarding the two descriptors differed and the emitted SARIF depended on
+        result order. Compared as serialized JSON rather than field by field, so a
+        per-occurrence value reaching any part of the descriptor fails here, not just one the
+        assertion happened to name.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        first = _result("AwsSolutions-IAM5", "AwsSolutions")
+        first.properties.tags = [
+            "aws",
+            "cdk",
+            "cdk-nag",
+            "AwsSolutions",
+            "AwsSolutions-IAM5",
+            "ConfigKeyAccessB463082D",
+            "AWS::IAM::Policy",
+            "tool_name::cdk-nag",
+            "tool_type::IAC",
+        ]
+        second = _result("AwsSolutions-IAM5", "AwsSolutions")
+        second.properties.tags = [
+            "aws",
+            "cdk",
+            "cdk-nag",
+            "AwsSolutions",
+            "AwsSolutions-IAM5",
+            "TaskExecutionRole250D2532",
+            "AWS::IAM::Role",
+            "tool_name::cdk-nag",
+            "tool_type::IAC",
+        ]
+
+        assert first.properties.tags != second.properties.tags, (
+            "the two occurrences must differ or this test cannot detect order dependence"
+        )
+
+        one = _reporting_descriptor_for(first, tool_name="cdk-nag", tool_type="IAC")
+        two = _reporting_descriptor_for(second, tool_name="cdk-nag", tool_type="IAC")
+
+        assert one.model_dump_json() == two.model_dump_json(), (
+            "the rule descriptor depends on which occurrence was seen first, so two runs over "
+            "identical input can emit different SARIF"
+        )
+
+    def test_the_tool_type_tag_uses_the_enum_value_not_its_repr(self):
+        """``ScannerToolType`` is a str mixin, and ``Enum.__str__`` still wins.
+
+        ``scan()`` passes ``self.tool_type``, a ``ScannerToolType`` member, so interpolating it
+        renders ``tool_type::ScannerToolType.IAC`` while the wrapper writes the literal
+        ``tool_type::IAC`` onto every result. Measured on this repository, forwarding put both
+        spellings in one list. The descriptor has to agree with the results.
+        """
+        from automated_security_helper.core.enums import ScannerToolType
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        assert str(ScannerToolType.IAC) != ScannerToolType.IAC.value, (
+            "if the enum ever renders as its value this test is no longer about anything"
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions"),
+            tool_name="cdk-nag",
+            tool_type=ScannerToolType.IAC,
+        )
+
+        type_tags = [
+            tag for tag in descriptor.properties.tags if tag.startswith("tool_type::")
+        ]
+        assert type_tags == ["tool_type::IAC"], (
+            f"expected exactly one tool_type tag spelled as the literal; got {type_tags}"
+        )
+
+    def test_the_tool_name_tag_appears_exactly_once(self):
+        """Forwarding duplicated it, because the wrapper already writes it onto the result."""
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert (
+            sum(
+                1
+                for tag in descriptor.properties.tags
+                if tag.startswith("tool_name::")
+            )
+            == 1
+        )
 
 
 class TestPackOwnershipIsDerivedNotListed:

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -320,10 +320,17 @@ class TestRuleTagsAreRuleScoped:
         from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
             _reporting_descriptor_for,
         )
+        from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
 
         # Both results are the same rule, not evaluated against two different templates. Only
         # the template path differs -- the rule-scoped tail is identical, exactly as the
         # wrapper builds it.
+        #
+        # ``compliance`` is set to match the message rather than left at the fixture's
+        # "Non-Compliant" default. Production cannot pair a "was NOT evaluated" message with
+        # that default, because ``_compliance_for_violation`` derives NOT_EVALUATED from the
+        # same description the message is built from -- so leaving it would have driven the
+        # rule_info branch while this docstring described the not-evaluated one.
         unevaluated = (
             "so this result says nothing about whether the template complies with it."
             "\n\nRule threw an error during validation."
@@ -337,6 +344,7 @@ class TestRuleTagsAreRuleScoped:
             ),
             message_markdown="`infra/alpha.template.json` was NOT evaluated.",
         )
+        first.properties.model_extra["cdk_nag_finding"]["compliance"] = NOT_EVALUATED
         first.properties.tags = [
             "aws",
             "cdk",
@@ -357,6 +365,7 @@ class TestRuleTagsAreRuleScoped:
             ),
             message_markdown="`infra/beta.template.json` was NOT evaluated.",
         )
+        second.properties.model_extra["cdk_nag_finding"]["compliance"] = NOT_EVALUATED
         second.properties.tags = [
             "aws",
             "cdk",

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -1,0 +1,212 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""The SARIF rule descriptor has to name the plugin that owns the rule.
+
+``validation-report.json`` is CDK's shared policy-validation report. Registering any cdk-nag
+pack on an app whose aws-cdk-lib is 2.262.0 or newer also gets the CDK's own
+``CloudFormationValidatePlugin``, whose ``PLUGIN_NAME`` is ``"CloudFormation Validate"``, so a
+single scan produces rules from two different tools. The wrapper keys them apart; the scanner
+flattens them into one result list and then builds one ``ReportingDescriptor`` per rule id.
+
+That descriptor is where a consumer looks up what a rule is and where it is documented, and it
+carried neither fact correctly:
+
+* ``helpUri`` was cdk-nag's RULES.md for every rule. Following it for ``F3017`` lands on a page
+  that does not mention ``F3017`` and does not describe the mechanism that governs it.
+* ``tags`` was built from ``finding_props.get("tags", [])``, and ``finding_props`` is
+  ``_NagFinding.as_dict()``, which has no ``tags`` key. The lookup returned its default on
+  every finding that has ever been scanned, so the pack the wrapper had been writing onto each
+  result never reached the rule.
+
+These tests drive ``_reporting_descriptor_for`` directly. It was inline in ``scan()`` until this
+change, where reaching it meant running a full CDK synthesis -- which is why an always-empty
+``tags`` read survived in it.
+"""
+
+import pytest
+
+from automated_security_helper.schemas.sarif_schema_model import (
+    Message,
+    Message1,
+    PropertyBag,
+    Result,
+)
+
+
+def _result(rule_id: str, pack: str, rule_level: str = "Error") -> Result:
+    """A Result shaped the way the wrapper emits one.
+
+    ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
+    not declare it; ``tags`` is a declared field. The descriptor builder reads both, so the
+    fixture has to populate both or it would be testing a shape the wrapper never produces.
+    """
+    return Result(
+        ruleId=rule_id,
+        message=Message(root=Message1(text=f"{rule_id} description text")),
+        properties=PropertyBag(
+            cdk_nag_finding={
+                "pack": pack,
+                "rule_id": rule_id,
+                "resource_id": "ProbeResource",
+                "compliance": "Non-Compliant",
+                "exception_reason": "N/A",
+                "rule_level": rule_level,
+                "rule_info": f"{rule_id} rule info",
+            },
+            tags=["aws", "cdk", "cdk-nag", pack, rule_id, "ProbeResource"],
+        ),
+    )
+
+
+class TestRuleDescriptorNamesItsPack:
+    def test_the_pack_is_a_labelled_property_on_the_rule(self):
+        """A named field, not a positional entry in a nine-element tag list.
+
+        The pack is in ``tags`` as well, and that is not sufficient on its own: beside it sit
+        the rule id, the resource logical id and the resource type, and nothing tells a
+        consumer which string is which.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("F3017", "CloudFormation Validate", rule_level="Warning"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert descriptor.properties.model_extra["pack"] == "CloudFormation Validate"
+        assert "pack::CloudFormation Validate" in descriptor.properties.tags
+
+    def test_the_findings_own_tags_are_forwarded_onto_the_rule(self):
+        """The always-empty lookup, stated as the tags that must now be present.
+
+        Asserted as a subset rather than an exact list so that adding a tag later does not
+        break this, but every tag the result carried is named -- the previous code forwarded
+        none of them and no test noticed.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert {
+            "aws",
+            "cdk",
+            "cdk-nag",
+            "AwsSolutions",
+            "AwsSolutions-S1",
+            "ProbeResource",
+        }.issubset(set(descriptor.properties.tags))
+
+    def test_a_cdk_nag_rule_still_points_at_cdk_nags_rule_documentation(self):
+        """The behaviour that was already right, pinned so the fix cannot break it.
+
+        The anchor is derived from the rule level, which is the pre-existing convention. Naming
+        the whole URL means a change to either half fails here.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("AwsSolutions-S1", "AwsSolutions", rule_level="Error"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        # str(), because ReportingDescriptor.helpUri is typed as a pydantic AnyUrl and
+        # comparing the model object with a string is always False.
+        assert (
+            str(descriptor.helpUri)
+            == "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#errors"
+        )
+
+    def test_a_cloudformation_validate_rule_points_at_the_cdk_validation_guide(self):
+        """The destination that documents the plugin AND how to acknowledge its findings.
+
+        Named as an exact URL rather than "not the cdk-nag one", because "not X" is satisfied
+        by an empty string, by None, and by any wrong page.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        descriptor = _reporting_descriptor_for(
+            _result("F3017", "CloudFormation Validate", rule_level="Warning"),
+            tool_name="cdk-nag",
+            tool_type="IAC",
+        )
+
+        assert (
+            str(descriptor.helpUri)
+            == "https://docs.aws.amazon.com/cdk/v2/guide/policy-validation-synthesis.html"
+        )
+
+    def test_a_finding_with_no_recorded_pack_keeps_its_previous_destination(self):
+        """Only findings positively known to be foreign are redirected.
+
+        An absent pack is not evidence of a foreign producer. Inside this scanner's own report
+        the likeliest producer is cdk-nag, so treating "no pack recorded" as "not cdk-nag" would
+        send genuine cdk-nag rules away from their own documentation -- the same misattribution
+        in the opposite direction, introduced by the fix for it.
+
+        The generic ``#rules`` anchor is what a missing ``rule_level`` degrades to, and it
+        claims nothing about a specific rule.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _reporting_descriptor_for,
+        )
+
+        bare = _result("AwsSolutions-S9", pack="")
+        bare.properties.model_extra["cdk_nag_finding"].pop("rule_level")
+
+        descriptor = _reporting_descriptor_for(
+            bare, tool_name="cdk-nag", tool_type="IAC"
+        )
+
+        assert (
+            str(descriptor.helpUri)
+            == "https://github.com/cdklabs/cdk-nag/blob/main/RULES.md#rules"
+        )
+        # The pack is reported as unknown rather than invented, so a reader can tell the
+        # difference between "cdk-nag" and "we do not know".
+        assert descriptor.properties.model_extra["pack"] == ""
+        assert "pack::unknown" in descriptor.properties.tags
+
+
+class TestPackOwnershipIsDerivedNotListed:
+    @pytest.mark.parametrize(
+        ("rule_id", "pack", "owned"),
+        [
+            # cdk-nag mints every rule id as f"{packName}-{ruleSuffix}".
+            ("AwsSolutions-S1", "AwsSolutions", True),
+            ("AwsSolutions-IAM5[Resource::*]", "AwsSolutions", True),
+            ("HIPAASecurity-S1", "HIPAASecurity", True),
+            # A pack cdk-nag has not shipped yet must still be recognised, which is the whole
+            # reason ownership is derived from the id rather than from a list of names.
+            ("SomeFuturePack-XYZ1", "SomeFuturePack", True),
+            # The CDK's own plugin does not prefix its rule ids with its plugin name.
+            ("F3017", "CloudFormation Validate", False),
+            ("W3010", "CloudFormation Validate", False),
+            # A pack that is merely a prefix of another pack's name must not claim its rules.
+            ("AwsSolutionsExtra-S1", "AwsSolutions", False),
+            # No pack recorded at all -- nothing can be claimed.
+            ("AwsSolutions-S1", "", False),
+        ],
+    )
+    def test_ownership_follows_cdk_nags_rule_id_construction(
+        self, rule_id: str, pack: str, owned: bool
+    ):
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _rule_is_from_pack,
+        )
+
+        assert _rule_is_from_pack(rule_id, pack) is owned

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_sarif_attribution.py
@@ -356,14 +356,10 @@ class TestRuleTagsAreRuleScoped:
             tool_type="IAC",
         )
 
-        assert (
-            sum(
-                1
-                for tag in descriptor.properties.tags
-                if tag.startswith("tool_name::")
-            )
-            == 1
-        )
+        name_tags = [
+            tag for tag in descriptor.properties.tags if tag.startswith("tool_name::")
+        ]
+        assert name_tags == ["tool_name::cdk-nag"]
 
 
 class TestPackOwnershipIsDerivedNotListed:

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_scanner_behavior.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_scanner_behavior.py
@@ -62,19 +62,28 @@ def nag_result(
     text="The S3 Bucket has server access logs disabled.",
     rule_level="Error",
     tags=None,
+    pack="AwsSolutions",
 ):
-    """A Result shaped the way cdk_nag_wrapper emits one."""
+    """A Result shaped the way cdk_nag_wrapper emits one.
+
+    ``pack`` is part of that shape. The wrapper records which plugin produced each finding,
+    because ``validation-report.json`` is CDK's shared policy-validation report and from
+    aws-cdk-lib 2.262.0 the CDK's own ``CloudFormationValidatePlugin`` writes into it alongside
+    the nag packs. Leaving it out of this helper would make every test here describe a finding
+    the wrapper cannot emit, and the help-pointer tests below turn on it.
+    """
     return Result(
         ruleId=rule_id,
         level=Level.error,
         message=Message(root=Message1(text=text)),
         properties=PropertyBag(
             cdk_nag_finding={
+                "pack": pack,
                 "rule_id": rule_id,
                 "rule_level": rule_level,
                 "rule_info": text,
             },
-            tags=["aws", "cdk", "cdk-nag", rule_id] + (tags or []),
+            tags=["aws", "cdk", "cdk-nag", pack, rule_id] + (tags or []),
         ),
     )
 
@@ -634,25 +643,28 @@ def test_rule_carries_the_finding_text_and_tool_tags(
     )
 
 
-def test_rule_tags_do_not_include_the_findings_own_tags(
+def test_rule_tags_include_the_findings_own_tags(
     scanner, cdk_available, wrapper_double, template_in_work_dir
 ):
-    """Rule tags come out as only the two tool tags.
+    """Rule tags carry the finding's tags plus the pack and the two tool tags.
 
-    The rule builder reads tags from ``cdk_nag_finding``, but cdk_nag_wrapper
-    puts the finding's tags on ``properties.tags`` and its cdk_nag_finding dict
-    holds only rule_id/resource_id/compliance/exception_reason/rule_level/
-    rule_info. So ``finding_props.get("tags", [])`` is always empty in
-    production and the resource/pack/type tags never reach the rule. The
-    fixture here mirrors the wrapper's real dict shape so the assertion
-    reflects what ships.
+    This test used to assert the opposite, and the behaviour it described was a
+    defect rather than a decision: the rule builder read
+    ``finding_props.get("tags", [])`` out of ``cdk_nag_finding``, which is
+    ``_NagFinding.as_dict()`` and has no ``tags`` key at all. The lookup
+    returned its default on every finding ever scanned, so the resource, type
+    and pack tags the wrapper puts on ``properties.tags`` never reached the
+    rule -- the one place a consumer looks up what a rule is and who owns it.
+
+    The builder now reads the result's own property bag. Every tag is named
+    below rather than counted, because a count passes for the wrong reason as
+    soon as the tag list changes shape, and it was a count that let the empty
+    read look deliberate.
     """
     finding = nag_result(rule_id="AwsSolutions-S1")
     assert "tags" not in finding.properties.model_extra["cdk_nag_finding"], (
-        "fixture must match the wrapper's cdk_nag_finding shape"
-    )
-    assert "AwsSolutions-S1" in finding.properties.tags, (
-        "the finding does carry tags -- just not where the rule builder looks"
+        "fixture must match the wrapper's cdk_nag_finding shape: the tags live "
+        "on properties.tags, not inside the finding record"
     )
     wrapper_double.return_value = CdkNagWrapperResponse(
         results={"AwsSolutions": [finding]}
@@ -661,7 +673,12 @@ def test_rule_tags_do_not_include_the_findings_own_tags(
     report = scanner.scan(target=scanner.context.work_dir, target_type="converted")
 
     tags = report.runs[0].tool.driver.rules[0].properties.tags
-    assert len(tags) == 2, f"expected only the two tool tags, got {tags}"
+    assert {"aws", "cdk", "cdk-nag", "AwsSolutions", "AwsSolutions-S1"}.issubset(
+        set(tags)
+    ), f"the finding's own tags did not reach the rule; got {tags}"
+    assert "pack::AwsSolutions" in tags, (
+        f"the originating pack is not labelled on the rule; got {tags}"
+    )
     assert any(t.startswith("tool_name::") for t in tags)
     assert any(t.startswith("tool_type::") for t in tags)
 

--- a/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_unevaluated_notification.py
+++ b/tests/unit/plugin_modules/ash_builtin/test_cdk_nag_unevaluated_notification.py
@@ -1,0 +1,150 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A rule that did not run has to be visible as a condition of the RUN, not just a result.
+
+WHY A RESULT IS NOT ENOUGH
+--------------------------
+Marking the individual finding ``kind=notApplicable`` with ``level=none`` is correct and is
+covered by ``tests/unit/utils/test_cdk_nag_unevaluated_rule.py``. It is also easy to miss: that
+result sits in the same array as the findings, at the lowest severity there is, and report
+surfaces routinely sort or filter by severity. The fact an operator needs is coarser -- "part of
+this scan did not run" -- and it belongs where facts about the run live.
+
+SARIF already defines that place, in its own words. ``invocation.toolExecutionNotifications`` is
+"A list of runtime conditions detected by the tool during the analysis", and
+``notification.associatedRule`` is "A reference used to locate the rule descriptor associated
+with this notification". A rule raising mid-evaluation is a runtime condition detected during
+the analysis, and the rule it happened to is the thing to associate it with. So the
+representation is SARIF's rather than a bespoke property bag key.
+
+``tests/integration/scanners/test_cdk_nag_real_pack.py`` asserts the same thing end to end
+through ``CdkNagScanner.scan`` against real cdk-nag; these tests pin the helper's behaviour on
+inputs a live run is awkward to produce on demand, such as one rule raising on several resources.
+"""
+
+from automated_security_helper.schemas.sarif_schema_model import (
+    Kind,
+    Level,
+    Message,
+    Message1,
+    PropertyBag,
+    Result,
+)
+from automated_security_helper.utils.cdk_nag_wrapper import NOT_EVALUATED
+
+
+def _result(rule_id: str, compliance: str, resource: str = "ProbeResource") -> Result:
+    """A Result shaped the way the wrapper emits one.
+
+    ``cdk_nag_finding`` lands in ``model_extra`` because ``PropertyBag`` allows extras and does
+    not declare it. The helper reads ``compliance`` out of that bag rather than off ``kind``,
+    which is deliberate on its part -- the bag is the wrapper's own record and cannot be changed
+    by a later reporting step.
+    """
+    return Result(
+        ruleId=rule_id,
+        kind=Kind.notApplicable if compliance == NOT_EVALUATED else Kind.fail,
+        level=Level.none if compliance == NOT_EVALUATED else Level.error,
+        message=Message(root=Message1(text=f"{rule_id} message")),
+        properties=PropertyBag(
+            cdk_nag_finding={
+                "pack": "AwsSolutions",
+                "rule_id": rule_id,
+                "resource_id": resource,
+                "compliance": compliance,
+                "exception_reason": "N/A",
+                "rule_level": "Error",
+                "rule_info": f"{rule_id} could not be validated.",
+            },
+            tags=["aws", "cdk", "cdk-nag", "AwsSolutions", rule_id, resource],
+        ),
+    )
+
+
+class TestUnevaluatedRuleNotifications:
+    def test_an_unevaluated_rule_produces_a_notification_naming_that_rule(self):
+        """The positive artifact: a notification whose ``associatedRule`` is the rule id.
+
+        The rule id is asserted rather than just the notification count, because a notification
+        that does not say which rule went unevaluated tells an operator nothing actionable.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [
+                _result("AwsSolutions-EC26", NOT_EVALUATED),
+                _result("AwsSolutions-S1", "Non-Compliant"),
+            ]
+        )
+
+        assert [n.associatedRule.root.id for n in notifications] == [
+            "AwsSolutions-EC26"
+        ]
+        assert "could not be evaluated" in notifications[0].message.root.text
+        assert "AwsSolutions" in notifications[0].message.root.text
+
+    def test_the_notification_is_reported_at_error_level(self):
+        """``error``, overriding the field's ``warning`` default.
+
+        For a security scanner a rule that silently did not run is the more serious of the two
+        things it can report -- a violation at least tells you what to fix. Asserted because
+        ``Notification.level`` defaults to ``warning``, so getting this right requires passing it
+        and a regression here would be invisible.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [_result("AwsSolutions-EC26", NOT_EVALUATED)]
+        )
+
+        assert notifications[0].level == Level.error
+
+    def test_one_rule_raising_on_several_resources_is_reported_once(self):
+        """Deduplicated by rule id.
+
+        A rule that cannot resolve a property raises for every construct sharing that shape, and
+        the run-level statement is about the rule. The per-resource detail is already carried by
+        the results. Two distinct rules must still produce two notifications, which is what stops
+        the deduplication from collapsing everything to one.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        notifications = _unevaluated_rule_notifications(
+            [
+                _result("AwsSolutions-EC26", NOT_EVALUATED, resource="VolumeA"),
+                _result("AwsSolutions-EC26", NOT_EVALUATED, resource="VolumeB"),
+                _result("AwsSolutions-EC27", NOT_EVALUATED, resource="SecurityGroup"),
+            ]
+        )
+
+        assert sorted(n.associatedRule.root.id for n in notifications) == [
+            "AwsSolutions-EC26",
+            "AwsSolutions-EC27",
+        ]
+
+    def test_a_scan_with_no_unevaluated_rule_produces_no_notifications(self):
+        """The negative control.
+
+        ``toolExecutionNotifications`` is written unconditionally into the invocation, so this is
+        what keeps an ordinary clean scan from claiming a coverage gap it does not have.
+        """
+        from automated_security_helper.plugin_modules.ash_builtin.scanners.cdk_nag_scanner import (
+            _unevaluated_rule_notifications,
+        )
+
+        assert (
+            _unevaluated_rule_notifications(
+                [
+                    _result("AwsSolutions-S1", "Non-Compliant"),
+                    _result("AwsSolutions-S10", "Non-Compliant"),
+                ]
+            )
+            == []
+        )

--- a/tests/unit/utils/test_cdk_nag_pack_attribution.py
+++ b/tests/unit/utils/test_cdk_nag_pack_attribution.py
@@ -1,0 +1,124 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A finding has to name the plugin that produced it, not the tool that ran the scan.
+
+``validation-report.json`` is CDK's policy-validation report, not cdk-nag's. Every plugin
+registered on the app writes into the same ``pluginReports`` array, and from aws-cdk-lib 2.262.0
+the CDK registers one of its own unconditionally: ``CloudFormationValidatePlugin``, whose
+``PLUGIN_NAME`` is the literal string ``"CloudFormation Validate"`` and whose rules are
+``@aws/cloudformation-validate`` ids such as ``F3017`` and ``W3010``. A measured run against a
+template carrying a placeholder KMS key identifier returns both ``"AwsSolutions"`` and
+``"CloudFormation Validate"`` in one report.
+
+The pack name reached ``properties.tags`` as an unlabelled positional entry and reached nothing
+else. So a consumer asking "what produced F3017, and where is it documented" got the answer
+"cdk-nag" -- which is wrong, and is why the rule's help pointer aimed at cdk-nag's RULES.md, a
+document that does not mention F3017 and does not describe the mechanism that governs it.
+
+These tests drive ``_violations_from_validation_report`` against a written report rather than
+through a synthesis, because translating the report is that function's whole job and the report
+is its only input. The fixture is a trimmed copy of a report produced by the installed
+aws-cdk-lib 2.267.0 and cdk-nag 3.0.2; ``TestReportAttribution`` in
+``tests/integration/scanners/test_cdk_nag_real_pack.py`` asserts the same properties against a
+live synthesis, so the fixture cannot drift into fiction without something going red.
+"""
+
+import json
+from pathlib import Path
+
+
+def _write_report(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "validation-report.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# A two-plugin report, which is the ordinary case rather than an edge case: registering any nag
+# pack on an app whose CDK is >= 2.262.0 produces one.
+TWO_PLUGIN_REPORT = {
+    "version": "2.1.0",
+    "title": "Validation Report",
+    "pluginReports": [
+        {
+            "pluginName": "AwsSolutions",
+            "violations": [
+                {
+                    "ruleName": "AwsSolutions-S1",
+                    "description": "The S3 Bucket has server access logs disabled.",
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                }
+            ],
+        },
+        {
+            "pluginName": "CloudFormation Validate",
+            "violations": [
+                {
+                    "ruleName": "F3017",
+                    "description": (
+                        "BucketEncryption.ServerSideEncryptionConfiguration.0."
+                        "ServerSideEncryptionByDefault.KMSMasterKeyID: 'my-kms-key' "
+                        "is not a valid KMS key identifier"
+                    ),
+                    "severity": "warning",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                }
+            ],
+        },
+    ],
+}
+
+
+class TestOriginatingPackIsCarriedOnTheFinding:
+    def test_each_finding_records_the_plugin_that_produced_it(self, tmp_path: Path):
+        """The pack travels on the finding record, not only as a dict key.
+
+        The per-pack mapping this function returns is consumed by a loop in the scanner that
+        binds the key to a variable, logs it, and extends one flat list -- so the key is gone by
+        the time SARIF is assembled. Putting the pack on the finding is what survives that.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        per_pack, failure = _violations_from_validation_report(
+            _write_report(tmp_path, TWO_PLUGIN_REPORT)
+        )
+
+        assert failure is None
+        assert set(per_pack) == {"AwsSolutions", "CloudFormation Validate"}
+
+        for pack_name, findings in per_pack.items():
+            assert findings, f"pack {pack_name!r} produced no findings"
+            for finding in findings:
+                assert finding.pack == pack_name, (
+                    f"finding {finding.rule_id} landed under pack {pack_name!r} but records "
+                    f"its pack as {finding.pack!r}"
+                )
+
+    def test_the_pack_survives_into_the_serialized_finding_record(self, tmp_path: Path):
+        """``as_dict()`` is the property bag the scanner reads back out of SARIF.
+
+        ``cdk_nag_finding`` is indexed by these exact keys downstream, so a pack that exists on
+        the object but not in this dict is a pack the reporting path still cannot see.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, TWO_PLUGIN_REPORT)
+        )
+
+        record = per_pack["CloudFormation Validate"][0].as_dict()
+        assert record["pack"] == "CloudFormation Validate"
+        assert record["rule_id"] == "F3017"
+
+        # The control: the nag pack's own finding must record its own pack, not the foreign one.
+        nag_record = per_pack["AwsSolutions"][0].as_dict()
+        assert nag_record["pack"] == "AwsSolutions"

--- a/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
+++ b/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
@@ -1,0 +1,308 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""A rule cdk-nag could not evaluate is a coverage gap, not a violation.
+
+THE MECHANISM
+-------------
+cdk-nag 3.0.2's ``applyRule`` wraps each rule in a try/catch and, on an exception, calls the
+same ``addViolation`` a real violation goes through -- passing the exception message as a third
+argument. ``addViolation`` turns that into a description prefixed "Rule threw an error during
+validation.", and leaves the severity as whatever the rule declared. Reached in practice
+whenever a rule calls ``NagRules.resolveIfPrimitive`` on a property that resolves to a
+non-primitive, which throws "therefore the rule could not be validated" -- a ``Ref`` to a
+CloudFormation Parameter is exactly that.
+
+So there is no structural marker in the report: the description prefix is the only thing that
+separates "this rule found a problem" from "this rule never ran". A rule that never ran arrived
+as ``severity: "error"``, which this module normalizes to ``"Error"``, which the SARIF mapping
+rendered ``level=error, kind=fail`` -- CRITICAL on ASH's severity ladder. Two rules that did not
+run were reported as two critical security findings, and the gap in coverage they represent was
+invisible.
+
+WHY notApplicable AND NOT open
+------------------------------
+SARIF 2.1.0 defines both, and the difference decides which one is a true statement. Quoting the
+OASIS Standard incorporating Approved Errata 01, section 3.27.9:
+
+  "notApplicable" : The rule specified by ruleId was not evaluated, because it does not apply
+  to the analysis target.
+
+  "open" : The specified rule was evaluated, and the tool concluded that there was insufficient
+  information to decide whether a problem exists.
+
+``open`` opens with "was evaluated", and its NOTE 1 scopes the value to proof-based tools that
+completed an analysis and could not prove either direction. cdk-nag's rule did not complete --
+it raised partway through -- so "was not evaluated" is the accurate half. Section 3.27.9's own
+example for ``notApplicable`` is a result whose message reads "<target> was not evaluated for
+rule <id> because <reason>", which is the shape this path now produces.
+
+``level`` follows rather than being chosen: section 3.27.10 defines ``"none"`` as "The concept of
+'severity' does not apply to this result because the kind property (3.27.9) has a value other
+than 'fail'". ASH's ladder maps ``none`` to INFO, so the count inflation stops as a consequence
+of getting the SARIF right rather than as a separate adjustment that could drift away from it.
+
+The live-synthesis counterpart is ``TestRuleThatCouldNotBeEvaluated`` in
+``tests/integration/scanners/test_cdk_nag_real_pack.py``, which makes real cdk-nag rules raise
+and asserts the same properties -- so the fixture below cannot drift away from what cdk-nag
+actually emits without something going red.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+def _write_report(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "validation-report.json"
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# cdk-nag's not-evaluated shape beside a genuine violation, in one report. Having both is
+# load-bearing: every assertion below names what must change AND what must not, so a change that
+# rewrites every finding cannot pass.
+UNEVALUATED_REPORT = {
+    "version": "2.1.0",
+    "title": "Validation Report",
+    "pluginReports": [
+        {
+            "pluginName": "AwsSolutions",
+            "violations": [
+                {
+                    "ruleName": "AwsSolutions-EC26",
+                    "description": (
+                        "Rule threw an error during validation. The parameter resolved "
+                        'to to a non-primitive value "{\\"Ref\\":\\"VolumeEncrypted\\"}", '
+                        "therefore the rule could not be validated."
+                    ),
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeVolume"}
+                    ],
+                },
+                {
+                    "ruleName": "AwsSolutions-S1",
+                    "description": "The S3 Bucket has server access logs disabled.",
+                    "severity": "error",
+                    "violatingConstructs": [
+                        {"constructPath": "ASHCDKNagScanner/tpl/ProbeBucket"}
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
+
+class TestARuleThatCouldNotBeEvaluatedIsNotAViolation:
+    def test_end_to_end_the_unevaluated_rule_does_not_render_as_a_critical_failure(
+        self, tmp_path: Path
+    ):
+        """The whole defect in one assertion, using only names that already existed.
+
+        Deliberately written without importing anything added by this change, so that its red
+        state on the unfixed tree is a behavioural difference rather than a missing symbol. It
+        composes the two functions exactly as ``run_cdk_nag_against_cfn_template`` does -- read
+        the report, then map each finding's compliance and level onto SARIF -- and checks what a
+        consumer of that SARIF sees.
+
+        On the unfixed tree this returns ``(Level.error, Kind.fail)``, which ASH's severity
+        ladder reads as CRITICAL. The pair is asserted rather than each field separately,
+        because section 3.27.10 makes them dependent: ``level`` is only meaningful once ``kind``
+        is known.
+        """
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _level_and_kind,
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+        rendered = {
+            finding.rule_id: _level_and_kind(
+                compliance=finding.compliance,
+                rule_level=finding.rule_level,
+                exception_reason=finding.exception_reason,
+            )
+            for finding in per_pack["AwsSolutions"]
+        }
+
+        assert rendered["AwsSolutions-EC26"] == (Level.none, Kind.notApplicable), (
+            "a rule cdk-nag could not evaluate rendered as an evaluated result; "
+            f"got {rendered['AwsSolutions-EC26']}"
+        )
+        # The rule that really did fire, from the same report, must be untouched.
+        assert rendered["AwsSolutions-S1"] == (Level.error, Kind.fail)
+
+    def test_the_unevaluated_rule_is_marked_as_its_own_compliance_state(
+        self, tmp_path: Path
+    ):
+        """ "Not-Evaluated" is a third state alongside Non-Compliant and Suppressed.
+
+        Asserted on the record rather than only on the rendered level, because the scanner reads
+        ``compliance`` back out of the property bag -- that is how the run-level notification
+        finds its rules -- and a reader of the raw report needs the same distinction the SARIF
+        carries.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _violations_from_validation_report,
+        )
+
+        per_pack, failure = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+
+        assert failure is None
+        by_rule = {f.rule_id: f for f in per_pack["AwsSolutions"]}
+
+        assert by_rule["AwsSolutions-EC26"].compliance == NOT_EVALUATED
+        assert by_rule["AwsSolutions-S1"].compliance == "Non-Compliant"
+
+    def test_the_message_says_the_rule_was_not_evaluated(self, tmp_path: Path):
+        """``kind`` is the machine-readable half; the message is the half people read.
+
+        Plenty of report surfaces render only the message, so a reader looking at one of those
+        would still see a rule that did not run described as a problem that was found. The
+        wording follows the example section 3.27.9 gives for ``notApplicable``.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _result_message_text,
+            _violations_from_validation_report,
+        )
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, UNEVALUATED_REPORT)
+        )
+        by_rule = {f.rule_id: f for f in per_pack["AwsSolutions"]}
+
+        unevaluated = _result_message_text(by_rule["AwsSolutions-EC26"], "tpl.yaml")
+        assert "'tpl.yaml' was NOT evaluated for rule AwsSolutions-EC26" in unevaluated
+
+        # A real finding's message is unchanged, including the historical Exception Reason line.
+        violation = _result_message_text(by_rule["AwsSolutions-S1"], "tpl.yaml")
+        assert violation == (
+            "The S3 Bucket has server access logs disabled.\n\nException Reason: N/A"
+        )
+
+    def test_an_unevaluated_rule_renders_as_notapplicable_with_no_severity(self):
+        """The mapping in isolation, so a failure points at the mapping and not the reader."""
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _level_and_kind,
+        )
+
+        level, kind = _level_and_kind(
+            compliance=NOT_EVALUATED, rule_level="Error", exception_reason="N/A"
+        )
+
+        assert kind == Kind.notApplicable
+        assert level == Level.none
+
+    def test_a_real_violation_still_renders_as_a_failure(self):
+        """The control that stops the fix from demoting every finding.
+
+        ``Error``/``Non-Compliant`` has to stay ``level=error, kind=fail``. Without this, a
+        one-line change returning ``notApplicable`` unconditionally would pass every other test
+        in this class while silencing the scanner completely.
+        """
+        from automated_security_helper.schemas.sarif_schema_model import Kind, Level
+        from automated_security_helper.utils.cdk_nag_wrapper import _level_and_kind
+
+        level, kind = _level_and_kind(
+            compliance="Non-Compliant", rule_level="Error", exception_reason="N/A"
+        )
+
+        assert kind == Kind.fail
+        assert level == Level.error
+
+    @pytest.mark.parametrize(
+        "description",
+        [
+            "Rule threw an error during validation. Something specific went wrong.",
+            # verbose=False is not what ASH passes today, but _build_nag_pack is the only thing
+            # making that true and the prefix is identical either way.
+            (
+                "Rule threw an error during validation. This is generally caused by a "
+                "parameter referencing an intrinsic function."
+            ),
+        ],
+    )
+    def test_the_marker_is_recognized_in_both_of_cdk_nags_message_forms(
+        self, tmp_path: Path, description: str
+    ):
+        """cdk-nag builds the description differently under verbose and non-verbose.
+
+        Only the prefix is shared, which is why detection keys on the prefix. Pinning the whole
+        string would work today and silently stop working the moment ``verbose`` changes -- and
+        the failure mode is the defect coming back, not a red test.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            NOT_EVALUATED,
+            _violations_from_validation_report,
+        )
+
+        report = {
+            "pluginReports": [
+                {
+                    "pluginName": "AwsSolutions",
+                    "violations": [
+                        {
+                            "ruleName": "AwsSolutions-EC26",
+                            "description": description,
+                            "severity": "error",
+                            "violatingConstructs": [{"constructPath": "s/t/R"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, report)
+        )
+
+        assert per_pack["AwsSolutions"][0].compliance == NOT_EVALUATED
+
+    def test_a_description_that_merely_mentions_an_error_is_still_a_violation(
+        self, tmp_path: Path
+    ):
+        """The prefix is anchored at the start, not searched for anywhere in the text.
+
+        A rule whose own explanation happens to contain the words "an error during validation"
+        must not be demoted. Without this, a substring search would look identical to the
+        anchored one on every fixture above while silently suppressing real findings.
+        """
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _violations_from_validation_report,
+        )
+
+        report = {
+            "pluginReports": [
+                {
+                    "pluginName": "AwsSolutions",
+                    "violations": [
+                        {
+                            "ruleName": "AwsSolutions-APIG1",
+                            "description": (
+                                "The API does not log. Without logs you cannot tell whether "
+                                "a Rule threw an error during validation."
+                            ),
+                            "severity": "error",
+                            "violatingConstructs": [{"constructPath": "s/t/R"}],
+                        }
+                    ],
+                }
+            ]
+        }
+
+        per_pack, _ = _violations_from_validation_report(
+            _write_report(tmp_path, report)
+        )
+
+        assert per_pack["AwsSolutions"][0].compliance == "Non-Compliant"

--- a/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
+++ b/tests/unit/utils/test_cdk_nag_unevaluated_rule.py
@@ -306,3 +306,74 @@ class TestARuleThatCouldNotBeEvaluatedIsNotAViolation:
         )
 
         assert per_pack["AwsSolutions"][0].compliance == "Non-Compliant"
+
+
+class TestTheMarkerStillMatchesTheInstalledCdkNag:
+    """One sentence in cdk-nag's source is load-bearing for three behaviours.
+
+    ``_compliance_for_violation`` decides ``NOT_EVALUATED`` from
+    ``description.startswith(_UNEVALUATED_DESCRIPTION_PREFIX)`` and from nothing else, because
+    ``addViolation`` records a rule that threw through the same call a real violation goes
+    through and leaves no structural marker to key on. Three things then hang off that decision:
+
+    * ``_level_and_kind`` renders the result ``none``/``notApplicable`` instead of a finding at
+      the rule's declared severity
+    * ``cdk_nag_scanner._rule_scoped_description`` discards the description, which is what keeps
+      cdk-nag's exception text -- resolved parameter values, and a resource logical id from the
+      Lex rule -- out of the SARIF rule descriptor
+    * the run-level ``toolExecutionNotifications`` entry exists at all
+
+    So if upstream rewords that sentence, a rule that never ran silently becomes a real finding
+    again AND per-occurrence text starts reaching the rule descriptor again. Neither failure
+    announces itself: the report stays well-formed and every other test here builds its own
+    fixture using our constant, so they would all keep passing against the new wording.
+
+    This test is the only thing standing between that and a silent regression. It reads the
+    cdk-nag distribution ASH actually installs rather than a fixture, so it fails on the version
+    bump that introduces the drift instead of on the scan that is misreported because of it.
+    """
+
+    def test_the_prefix_appears_verbatim_in_the_installed_distribution(self):
+        import tarfile
+
+        import cdk_nag
+
+        from automated_security_helper.utils.cdk_nag_wrapper import (
+            _UNEVALUATED_DESCRIPTION_PREFIX,
+        )
+
+        root = Path(cdk_nag.__file__).parent
+        tarballs = sorted(root.rglob("*.tgz"))
+        assert tarballs, (
+            f"no cdk-nag tarball under {root}; this test cannot fail as written, so the "
+            "marker is unpinned rather than confirmed"
+        )
+
+        sources = {}
+        for tarball in tarballs:
+            with tarfile.open(tarball) as archive:
+                for member in archive.getmembers():
+                    if member.name.endswith("lib/nag-pack.js"):
+                        handle = archive.extractfile(member)
+                        assert handle is not None
+                        sources[f"{tarball.name}:{member.name}"] = handle.read().decode(
+                            "utf-8", "replace"
+                        )
+
+        assert sources, (
+            f"no lib/nag-pack.js inside {[t.name for t in tarballs]}; the marker is unpinned"
+        )
+        # Positive control: the file we found must be the one that builds the description, or a
+        # missing prefix would be indistinguishable from having read the wrong file.
+        for name, text in sources.items():
+            assert "addViolation(ruleName" in text, (
+                f"{name} does not define addViolation, so it is not the file that builds the "
+                "description and this assertion would prove nothing"
+            )
+            assert _UNEVALUATED_DESCRIPTION_PREFIX in text, (
+                f"{name} no longer contains {_UNEVALUATED_DESCRIPTION_PREFIX!r}. cdk-nag has "
+                "reworded the one string ASH uses to recognise a rule that threw. Until "
+                "_UNEVALUATED_DESCRIPTION_PREFIX is updated, such a rule is reported as a real "
+                "finding at its declared severity, and its exception text -- which carries "
+                "template values -- reaches the SARIF rule descriptor."
+            )


### PR DESCRIPTION
Consolidates #555 and #557 and adds one behavior change on top. The three parts share a theme: **a scanner's report should tell the truth about what it actually scanned.** Each is a separate commit; the file sets of the two original PRs are disjoint, so this is a clean combine rather than a merge resolution.

## 1. cdk-nag attributed findings to the wrong thing, and reported unevaluated rules as critical

Three defects in how cdk-nag findings were reported, all of them in the SARIF the scanner produces.

**Pack attribution was lost at the rule descriptor.** The reporting descriptor read `finding_props.get("tags", [])`, and `_NagFinding.as_dict()` has no `tags` key. It therefore returned `[]` on *every finding ever scanned*, and `helpUri` pointed at cdk-nag's own `RULES.md` for every rule regardless of which pack raised it. A finding from AwsSolutions and a finding from HIPAA were indistinguishable in the report, and the help pointer led somewhere that does not document the rule.

**A rule that could not be evaluated was reported as a critical finding.** `CdkNagValidationFailure` no longer exists in v3. A rule that throws during validation now arrives through `applyRule`'s catch calling `addViolation`, distinguishable only by the message prefix `"Rule threw an error during validation."` Those were being emitted as `level=error, kind=fail` — CRITICAL on ASH's severity ladder — when what they mean is "this rule did not evaluate." They now report `kind=notApplicable` with `level=none`, which the SARIF spec requires once `kind != fail`. A genuine violation still reports `level=error, kind=fail`, and there is a test holding that line so the fix cannot quietly reclassify real findings.

**An error on any scanned target now reaches the scanner status,** instead of being lost when only one of a scanner's two targets failed.

Adds `NOT_EVALUATED`, `_violations_from_validation_report`, `_level_and_kind`, `_unevaluated_rule_notifications`, `_rule_is_from_pack`, and `_reporting_descriptor_for`.

## 2. A scan could not say how much of its input it evaluated

`ScannerMetrics` is the only model the summary table and every reporter read, and it had no field for either target counter. The counts existed on the container, in `ash_aggregated_results.json`, and in the scanner's own SARIF — with no route to any human-facing output even in principle.

Adds `targets_attempted`/`targets_failed` preserving a tri-state `None`, plus `coverage_shortfalls()`, surfaced through `metrics_table.py`, `report_content_emitter.py` and `markdown_reporter.py`.

Two things worth knowing before changing this code:

- **Adding the model field was not sufficient.** `ReportContentEmitter.get_scanner_results()` builds its dict by enumerating keys explicitly, so a new model field reaches `ash.flat.json` only if it is listed there too. Measured: `targets_attempted` was absent from a real `ash.flat.json` with the model field already populated. I swept the other consumers on this path for the same bug class — `_populate_summary_stats_from_unified_metrics` and `_populate_scanner_results_from_unified_metrics` are both hand-built enumerations, but their target models (`SummaryStats`, `ScannerTargetStatusInfo`) carry no target counters at all, so there was nothing for them to drop.
- **The shortfall is reported beside the summary table, not as a twelfth column.** `test_the_scanner_table_keeps_its_column_count` pins `len(table.columns) == 11` deliberately, because consumers parse that table positionally.

## 3. `--fail-on-incomplete-scanners` was blind to partial coverage loss

The new behavior change, and the reason the first two belong together.

The gate selected on scanner *status*:

```python
_INCOMPLETE_SCANNER_STATUSES = frozenset({ERROR, MISSING})
```

and `determine_status` returns `ERROR` only once `targets_failed >= targets_attempted`. Those two facts compose into a hole: a scanner that failed on *some* of its targets keeps whatever status the severity gate gives it, so the gate never saw it. The flag reported total coverage loss and stayed silent on partial loss — which is both the more common case and the one operators turn the flag on to catch.

### Behavior change

**This turns an existing exit 0 into an exit 1 for some users with no change to their own code.** It affects only runs that pass `--fail-on-incomplete-scanners` or set `fail_on_incomplete_scanners: true`. The default path is unchanged, and there is a test asserting that the same partial-coverage input still exits 0 without the flag. Recorded in `CHANGELOG.md` rather than left for people to discover.

Measured blast radius on this repository's own tree: **exactly one scanner is newly caught.** cdk-nag attempts 10 targets and cannot evaluate 4 of them (40%), so ASH's own scan flips to exit 1 under the flag. That is the intended behavior, not a regression.

Two of the four are real CloudFormation templates that went unscanned, and two are a target-selection bug:

| target | cause | genuinely a template? |
|---|---|---|
| `tests/.../test-yaml.template.json` | cdk-nag produced no validation report | **yes — unscanned** |
| `tests/.../cfn-and-python-test-yaml.template.json` | cdk-nag produced no validation report | **yes — unscanned** |
| `deploy/cdk/tsconfig.json` | `ScannerError: while scanning for the next token` | no, never a template |
| `mkdocs.yml` | `ConstructorError` on a `pymdownx.emoji.twemoji` tag | no, never a template |

So the 40% is not entirely spurious: half of it is real coverage loss. Fixing target selection is deliberately **out of scope here**.

### Deliberately not done

- **No new `ScannerStatus` member and no new config key.** This is the existing opt-in flag learning about a case it was always meant to cover. A partially-covered scanner still reports its own status, so no reporter, no summary table, and no consumer of the status enum reads differently.
- **No status-shaped expression of partial coverage,** and that is a caller constraint rather than taste. `cli/merge.py::_completed` keys on status against `_INCOMPLETE_SCANNER_STATUSES` to answer a narrower question — whether a shard's scanner ran *at all* — and `_verify_shard_contributions` refuses the merge outright where a shard completed none of the scanners it owned. A scanner that lost one target of ten did run, so a status for partial coverage would propagate into shard refusal and fail merges far from the cause. That is the concrete cost of adding a `ScannerStatus` member here, and the reason none was added.

  Worth stating precisely, because my first version of this reasoning overstated it and the code comment now records the correction. `_completed` inspects a `ScannerTargetStatusInfo`, which declares no target counters, so it cannot read coverage today by any route — the protection is structural, not merely conventional. Confirmed by mutation: reimplementing `_completed` to consult `_partial_coverage` changes nothing, because the value it would consult is never there. The boundary is trustworthy because the status does not change, which `test_partial_coverage_loss_still_reports_passed` pins directly, rather than because of the frozenset. `TestShardContributionIsRefused::test_a_shard_that_lost_only_some_targets_is_still_merged` pins it from the merge side, and that test's falsifiable half is the only coverage anywhere that the counters survive a merge — they live in `additional_reports`, which the merge recombines from n shards — and still reach the gate afterwards.
- **No tolerance threshold.** A percentage floor would need a number nobody can justify, and "1 of 200 templates went unscanned" is still a template nobody looked at.

### The tri-state is the subtle part

`targets_attempted` is `None` for the nine scanners that do not track per-target outcomes (bandit, checkov, semgrep, grype, syft, detect-secrets, opengrep, cfn-nag, npm-audit). `None` means "makes no claim"; `0` means "tracked, attempted none". Reading absence as "attempted 0, therefore lost everything" would fail every scan on every repository the moment the flag was turned on — the exact inverse of the defect being fixed. All three values are pinned end to end, and confirmed on a real `ash.flat.json`, where the nine non-tracking scanners serialize `null` rather than `0`.

Both counters are type-checked rather than trusted, matching what `unified_metrics.target_counts` already does to the serialized counters.

The operator-facing message said the scanners "did not run", which is false for the new case — the scanner ran and reported a status. Both the scan and merge messages now say the scanners did not evaluate everything they were given, and the guidance names the target-count case so nobody is sent to install a tool that is already installed.

## Verification

Against an `origin/main` baseline captured first, because main is currently red on one unrelated test.

- **Baseline (`origin/main`):** 1 failed, 6571 passed, 119 skipped, 3 xfailed. The failure is `test_agent_plugin_ash_version.py::TestInstallRefsTrackPackagedVersion::test_every_install_ref_names_the_packaged_version`, which another PR fixes.
- **This branch:** 1 failed, 6648 passed, 124 skipped, 3 xfailed — the same single inherited failure, **no new failures**. Confirmed on CI across Linux, Windows and macOS separately, each reporting exactly one failure and the same test, so a platform-specific new failure is not hiding behind a matching total.
- **The gate change was proven able to fail.** Run against the unmodified code first, the new tests failed 6 of 20, all six being the partial-coverage cases; the 14 controls (default path, tri-state negatives, total-loss message preservation) passed before and after. Whole file green after the change.
- **Coverage, per language, unblended:** Python 93.20% (gate is 80%). TypeScript, both trees: `deploy/cdk-constructs` 97.35% statements over 116 tests in 3 suites; `deploy/cdk` 94.36% statements over 355 tests in 13 suites. This change touches no TypeScript.
- **`ash config lint`** clean. **`ruff check`** byte-identical to the `origin/main` baseline on a per-rule statistics diff. The repo formatter was run on the changed files, and the three that remain unformatted are unformatted on main too.
- **Measured on a real artifact rather than the model in isolation:** a live cdk-nag scan of this repository, whose `ash.flat.json` carries `targets_attempted: 10` and `targets_failed: 4` for cdk-nag, and the exit code flipping 0 → 1 on those real results with and without the flag.

One coverage gap in the new code was found and closed rather than left: `_partial_coverage` guards its two counters independently, and every existing case was rejected on the *attempt* count and returned before the failure count was examined, leaving that second guard present, plausible, and never executed. It is now parametrized over the four shapes a malformed failure count takes.

